### PR TITLE
fix: serialize Error objects in console capture (closes #21)

### DIFF
--- a/frontend/src/lib/consoleCapture.ts
+++ b/frontend/src/lib/consoleCapture.ts
@@ -23,6 +23,7 @@ export function initConsoleCapture(): () => void {
     const message = args
       .map((a) => {
         if (typeof a === "string") return a;
+        if (a instanceof Error) return a.stack ?? a.message;
         try { return JSON.stringify(a); } catch { return String(a); }
       })
       .join(" ");


### PR DESCRIPTION
## Bug Report
Fixes #21

## Root Cause
`consoleCapture.ts` uses `JSON.stringify()` to serialize console arguments for bug reports. Error objects have non-enumerable properties (`message`, `stack`), so `JSON.stringify(new Error("foo"))` produces `"{}"` — which is why bug reports #20 and #21 show empty error objects.

## Fix
Added an `instanceof Error` check before `JSON.stringify`, using `error.stack` (falls back to `error.message`) for meaningful output in captured logs.

## Auto-triaged
This PR was created automatically by the daily triage job.