### PR TITLE
fix: include pipeline error message in bug reports

### DIFF
--- a/frontend/src/components/BugReportModal.tsx
+++ b/frontend/src/components/BugReportModal.tsx
@@ -11,9 +11,10 @@ interface BugReportModalProps {
   storyId?: string;
   jobId?: string;
   datasetIds?: string[];
+  errorMessage?: string;
 }
 
-export function BugReportModal({ open, onClose, datasetId, storyId, jobId, datasetIds }: BugReportModalProps) {
+export function BugReportModal({ open, onClose, datasetId, storyId, jobId, datasetIds, errorMessage }: BugReportModalProps) {
   const [description, setDescription] = useState("");
   const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
   const [issueUrl, setIssueUrl] = useState<string | null>(null);
@@ -31,6 +32,7 @@ export function BugReportModal({ open, onClose, datasetId, storyId, jobId, datas
       story_id: storyId,
       job_id: jobId,
       dataset_ids: datasetIds,
+      error_message: errorMessage,
       console_logs: logs,
     };
     try {
@@ -111,6 +113,7 @@ export function BugReportModal({ open, onClose, datasetId, storyId, jobId, datas
               {datasetIds && datasetIds.length > 0 && (
                 <Text>Datasets: {datasetIds.join(", ")}</Text>
               )}
+              {errorMessage && <Text>Error: {errorMessage}</Text>}
               <Text>Page: {window.location.pathname}</Text>
               <Text>Console logs: {logs.length} entries</Text>
               {logs.length > 0 && (

--- a/frontend/src/lib/bugReport.ts
+++ b/frontend/src/lib/bugReport.ts
@@ -7,6 +7,7 @@ export interface BugReportPayload {
   story_id?: string;
   job_id?: string;
   dataset_ids?: string[];
+  error_message?: string;
   console_logs: LogEntry[];
 }
 

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -153,6 +153,7 @@ export default function UploadPage() {
         open={reportOpen}
         onClose={() => setReportOpen(false)}
         jobId={state.jobId ?? undefined}
+        errorMessage={state.error ?? undefined}
       />
     </Flex>
   );

--- a/ingestion/src/routes/bug_report.py
+++ b/ingestion/src/routes/bug_report.py
@@ -22,6 +22,7 @@ class BugReportRequest(BaseModel):
     story_id: str | None = None
     job_id: str | None = None
     dataset_ids: list[str] | None = None
+    error_message: str | None = None
     console_logs: list[LogEntry] = []
 
     @model_validator(mode="after")
@@ -54,6 +55,9 @@ def _build_issue_body(req: BugReportRequest) -> str:
     if req.job_id:
         lines.append(f"- **Job ID:** {req.job_id}")
     lines.append(f"- **Reported at:** {datetime.now(timezone.utc).isoformat()}")
+
+    if req.error_message:
+        lines.extend(["", "## Error", "", f"```\n{req.error_message}\n```"])
 
     if req.console_logs:
         log_text = "\n".join(f"[{e.timestamp}] {e.level.upper()}: {e.message}" for e in req.console_logs)


### PR DESCRIPTION
## Summary
- Adds `error_message` field to the bug report payload (frontend + backend)
- Threads `state.error` from the conversion job hook through BugReportModal into the GitHub issue
- Shows the error in the "What will be sent" preview so users can see what's being reported
- Backend renders it as a dedicated **Error** section in the issue body

This was originally the second commit on PR #29 but was pushed after merge. Re-submitted as a standalone PR.

## Test plan
- [ ] Trigger a conversion failure (e.g., unsupported file format)
- [ ] Click "Report" — verify the error message appears in the preview
- [ ] Submit — verify the GitHub issue includes an **Error** section with the pipeline error

🤖 Generated with [Claude Code](https://claude.com/claude-code)