### PR TITLE
fix: extract CRS name from WKT instead of missing .name attribute

### DIFF
--- a/ingestion/src/services/pipeline.py
+++ b/ingestion/src/services/pipeline.py
@@ -140,7 +140,7 @@ def _extract_raster_geo_metadata(output_path: str) -> RasterGeoMetadata:
     with rasterio.open(output_path) as src:
         return RasterGeoMetadata(
             crs=str(src.crs) if src.crs else None,
-            crs_name=src.crs.name if src.crs else None,
+            crs_name=src.crs.to_wkt().split('"')[1] if src.crs else None,
             pixel_width=src.width,
             pixel_height=src.height,
             resolution=abs(src.res[0]) if src.res else None,


### PR DESCRIPTION
## Summary
- `rasterio.crs.CRS` doesn't have a `.name` attribute, causing raster uploads to crash during metadata extraction
- Fixed by parsing the human-readable CRS name from the WKT string (e.g., `"WGS 84"`, `"WGS 84 / UTM zone 18N"`)

Closes #33

## Test plan
- [x] Upload a GeoTIFF and verify it completes without error
- [x] Check that the dataset metadata includes a valid `crs_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)