### PR TITLE
fix: add vector view mode toggle for PMTiles vs GeoParquet

### DIFF
--- a/frontend/src/components/VectorSidebarControls.tsx
+++ b/frontend/src/components/VectorSidebarControls.tsx
@@ -1,0 +1,79 @@
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { transition } from "../lib/interactionStyles";
+
+type VectorRenderMode = "vector-tiles" | "geojson";
+
+interface VectorSidebarControlsProps {
+  renderMode: VectorRenderMode;
+  onRenderModeChange: (mode: VectorRenderMode) => void;
+  hasParquet: boolean;
+}
+
+export function VectorSidebarControls({
+  renderMode,
+  onRenderModeChange,
+  hasParquet,
+}: VectorSidebarControlsProps) {
+  return (
+    <Box mb={3}>
+      <Text
+        fontSize="11px"
+        color="brand.textSecondary"
+        fontWeight={600}
+        textTransform="uppercase"
+        letterSpacing="1px"
+        mb={3}
+      >
+        View Mode
+      </Text>
+      <Flex gap={2}>
+        <ModeButton
+          label="Vector Tiles"
+          active={renderMode === "vector-tiles"}
+          onClick={() => onRenderModeChange("vector-tiles")}
+        />
+        {hasParquet && (
+          <ModeButton
+            label="GeoParquet"
+            active={renderMode === "geojson"}
+            onClick={() => onRenderModeChange("geojson")}
+          />
+        )}
+      </Flex>
+    </Box>
+  );
+}
+
+function ModeButton({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Box
+      as="button"
+      flex={1}
+      py={1.5}
+      fontSize="12px"
+      fontWeight={500}
+      borderRadius="6px"
+      border="1px solid"
+      borderColor={active ? "brand.orange" : "brand.border"}
+      bg={active ? "brand.orange" : "white"}
+      color={active ? "white" : "brand.brown"}
+      cursor="pointer"
+      transition={transition(150)}
+      _hover={{
+        borderColor: "brand.orange",
+        color: active ? "white" : "brand.orange",
+      }}
+      onClick={onClick}
+    >
+      {label}
+    </Box>
+  );
+}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -8,6 +8,7 @@ import { ShareButton } from "../components/ShareButton";
 import { BugReportLink } from "../components/BugReportLink";
 import { SidePanel } from "../components/SidePanel";
 import { RasterSidebarControls } from "../components/RasterSidebarControls";
+import { VectorSidebarControls } from "../components/VectorSidebarControls";
 import { ExploreTab } from "../components/ExploreTab";
 import { ReportCard, getTileUrlPrefix } from "../components/ReportCard";
 import { UnifiedMap } from "../components/UnifiedMap";
@@ -502,12 +503,26 @@ export default function MapPage() {
                   onRenderModeChange={(mode) => setRenderMode(mode)}
                 />
               )}
-              {dataset.dataset_type === "vector" && dataset.parquet_url && (
-                <ExploreTab
-                  dataset={dataset}
-                  active={true}
-                  onTableChange={handleTableChange}
-                />
+              {dataset.dataset_type === "vector" && (
+                <>
+                  <VectorSidebarControls
+                    renderMode={
+                      renderMode === "geojson" ? "geojson" : "vector-tiles"
+                    }
+                    onRenderModeChange={(mode) => {
+                      setRenderMode(mode);
+                      if (mode === "vector-tiles") setArrowTable(null);
+                    }}
+                    hasParquet={!!dataset.parquet_url}
+                  />
+                  {renderMode === "geojson" && dataset.parquet_url && (
+                    <ExploreTab
+                      dataset={dataset}
+                      active={true}
+                      onTableChange={handleTableChange}
+                    />
+                  )}
+                </>
               )}
             </SidePanel>
           </Box>


### PR DESCRIPTION
## Summary
- Vector datasets only showed the GeoParquet Explore tab, with no way to switch back to PMTiles vector tile view
- Adds `VectorSidebarControls` component with toggle buttons ("Vector Tiles" / "GeoParquet") matching the raster controls style
- ExploreTab is now conditionally shown only when GeoParquet mode is selected

Closes #22

## Test plan
- [ ] Upload a GeoJSON or Shapefile and navigate to the map page
- [ ] Verify "Vector Tiles" and "GeoParquet" toggle buttons appear in the sidebar
- [ ] Confirm "Vector Tiles" is selected by default and renders PMTiles
- [ ] Switch to "GeoParquet" and verify the Explore tab appears with DuckDB/SQL interface
- [ ] Switch back to "Vector Tiles" and verify PMTiles rendering resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)