### PR TITLE
fix: ensure fresh frontend assets on every deploy

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,7 +51,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no \
             -i ~/.ssh/deploy_key \
             "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}" \
-            "cd ${{ secrets.DEPLOY_PATH }} && git pull && docker compose --profile prod up -d --build"
+            "cd ${{ secrets.DEPLOY_PATH }} && git checkout main && git pull origin main && docker compose --profile prod up -d --build"
 
       - name: Verify deploy health
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,8 +184,8 @@ services:
     profiles:
       - prod
     volumes:
-      - frontend_dist:/app/dist
-    command: ["echo", "Build complete"]
+      - frontend_dist:/dist
+    command: ["sh", "-c", "rm -rf /dist/* && cp -a /app/dist/. /dist/"]
 
   caddy:
     build:


### PR DESCRIPTION
## Summary

- **Stale frontend fix**: The `frontend-build` container was mounting the `frontend_dist` volume at `/app/dist`, which shadowed the freshly built files from the Docker image. Now mounts at `/dist` and copies fresh assets on each start.
- **Deploy workflow fix**: The release-please deploy step ran `git pull` which fails if the VM isn't on `main`. Now explicitly runs `git checkout main` first.

## Test plan

- [ ] After merging, trigger a deploy and verify `https://cngsandbox.org` serves the latest frontend
- [ ] Verify the deploy workflow no longer fails when the VM is on a non-main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment workflow updated to explicitly check out and verify the main branch before pulling code changes during production updates, ensuring deployment consistency
  * Frontend build process refined to include automatic cleanup of previous build artifacts and proper placement of new build output in the production environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->