### PR TITLE
fix: skip pixel fidelity check for reprojected GeoTIFFs

### DIFF
--- a/geo-conversions/geotiff-to-cog/scripts/validate.py
+++ b/geo-conversions/geotiff-to-cog/scripts/validate.py
@@ -410,12 +410,12 @@ def run_checks(input_path: str, output_path: str) -> list[CheckResult]:
         checks.extend([
             check_bounds_match(input_path, output_path),
             check_dimensions_match(input_path, output_path),
+            check_pixel_fidelity(input_path, output_path),
+            check_nodata_match(input_path, output_path),
         ])
 
     checks.extend([
         check_band_count(input_path, output_path),
-        check_pixel_fidelity(input_path, output_path),
-        check_nodata_match(input_path, output_path),
         check_overviews(output_path),
     ])
     return checks


### PR DESCRIPTION
## Summary

- Skip pixel fidelity and nodata comparison checks when input CRS differs from output (reprojected files have different grids, so direct pixel comparison is invalid)
- Fixes `IndexError: index 0 is out of bounds` crash when validating large reprojected GeoTIFFs (e.g. NLCD 160k x 105k → 203k x 95k)

## Test plan

- [x] GeoTIFF self-test passes (both passthrough and projected)
- [ ] Re-upload NLCD dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modified validation checks to apply specifically to EPSG:4326 coordinate reference systems. Pixel-level fidelity and NoData preservation checks now run only for this CRS type, with other coordinate reference systems skipping these integrity verifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->