### PR TITLE
fix: resolve map bounds zoom race condition on production

### DIFF
--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useCallback,
+} from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useWorkspace } from "../hooks/useWorkspace";
 import { Box, Flex, Text } from "@chakra-ui/react";
@@ -65,7 +72,8 @@ export default function MapPage() {
   const [basemap, setBasemap] = useState("streets");
   const mapContainerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  const boundsKey = item?.bounds?.join(",") ?? "";
+  useLayoutEffect(() => {
     if (item?.bounds) {
       const el = mapContainerRef.current;
       const size = el
@@ -73,7 +81,7 @@ export default function MapPage() {
         : undefined;
       setCamera(cameraFromBounds(item.bounds, size));
     }
-  }, [item?.bounds]);
+  }, [boundsKey]);
 
   // --- Report card ---
   const [reportCardOpen, setReportCardOpen] = useState(false);


### PR DESCRIPTION
## Summary
- Switch bounds zoom from `useEffect` to `useLayoutEffect` to eliminate race condition with DeckGL's async initialization that overwrites the camera on production
- Serialize bounds array to string key (`boundsKey`) for stable value-based dependency comparison instead of fragile array reference check

Closes #88

## Test plan
- [ ] Deploy to production and verify map auto-zooms to dataset bounds on load
- [ ] Verify no visual flash (camera set before first paint)
- [ ] Verify user pan/zoom still works after initial bounds zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced map camera positioning updates to ensure proper synchronization with changes to map bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->