### PR TITLE
fix: add cache-control headers to prevent stale assets after deploy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -94,8 +94,8 @@
 		@assets path /assets/*
 		header @assets Cache-Control "public, max-age=31536000, immutable"
 
-		@html path /index.html /
-		header @html Cache-Control "no-cache"
+		@notAssets not path /assets/*
+		header @notAssets Cache-Control "no-cache"
 
 		try_files {path} /index.html
 		file_server


### PR DESCRIPTION
## Summary

- Adds explicit `Cache-Control` headers to the Caddyfile for frontend static files
- `index.html` / `/` get `no-cache` so browsers always revalidate after deploys
- `/assets/*` get `immutable` + 1 year max-age since Vite hashes filenames on every build

## Root cause

After a redeploy, browsers served a cached `index.html` that referenced old hashed chunk filenames (e.g. `maplibre-gl-DfUZULZ4.js`) which no longer existed on disk, causing `Failed to fetch dynamically imported module` errors and broken basemaps.

Closes #100

## Test plan

- [ ] Deploy to production and verify `curl -I https://cngsandbox.org/` returns `Cache-Control: no-cache`
- [ ] Verify `curl -I https://cngsandbox.org/assets/index-*.js` returns `Cache-Control: public, max-age=31536000, immutable`
- [ ] Hard refresh the map page and confirm basemap loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted HTTP caching: static assets (images, scripts, styles) are now cached long-term for faster load times and reduced bandwidth; HTML and SPA fallback responses are served no-cache so users promptly receive the latest application updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->