### PR TITLE
fix: add missing uri strip_prefix for COG tiler proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,15 @@ jobs:
       - name: Audit GitHub Actions
         run: zizmor --min-severity medium .github/
 
+  proxy-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Check Vite/Caddy proxy parity
+        run: bash scripts/check-proxy-parity.sh
+
   docker-build:
     runs-on: ubuntu-latest
     steps:

--- a/Caddyfile
+++ b/Caddyfile
@@ -51,6 +51,7 @@
 		basic_auth {
 			{$AUTH_USER} {$AUTH_PASSWORD_HASH}
 		}
+		uri strip_prefix /cog
 		reverse_proxy cog-tiler:80 {
 			header_down Cache-Control "no-store"
 		}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       },
       "/cog": {
         target: process.env.COG_TILER_PROXY_TARGET || "http://localhost:8084",
+        rewrite: (path: string) => path.replace(/^\/cog/, ""),
         configure: (proxy) => {
           proxy.on("proxyRes", (proxyRes) => {
             proxyRes.headers["cache-control"] = "no-store";

--- a/scripts/check-proxy-parity.sh
+++ b/scripts/check-proxy-parity.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Verify that Vite dev proxy and Caddyfile proxy routes stay in sync.
+#
+# For every proxy path that appears in BOTH vite.config.ts and Caddyfile,
+# check that prefix stripping is consistent: if one strips, both must strip.
+# The /api path is excluded because the backend expects the /api prefix.
+set -euo pipefail
+
+VITE_CONFIG="frontend/vite.config.ts"
+CADDYFILE="Caddyfile"
+ERRORS=0
+
+# Paths that intentionally keep their prefix
+SKIP_PATHS=("/api")
+
+is_skipped() {
+  local path="$1"
+  for skip in "${SKIP_PATHS[@]}"; do
+    [[ "$path" == "$skip" ]] && return 0
+  done
+  return 1
+}
+
+# --- Extract all Vite proxy paths ---
+mapfile -t vite_paths < <(grep -oP '^\s+"(/[^"]+)"' "$VITE_CONFIG" | grep -oP '/[^"]+')
+
+# --- Check each Vite path for rewrite ---
+declare -A vite_rewrites
+for path in "${vite_paths[@]}"; do
+  # Look for rewrite on lines near this path definition
+  if grep -A5 "\"$path\"" "$VITE_CONFIG" | grep -q 'rewrite:'; then
+    vite_rewrites[$path]=1
+  else
+    vite_rewrites[$path]=0
+  fi
+done
+
+# --- Extract Caddy handle paths and check for strip_prefix ---
+declare -A caddy_strips
+while IFS= read -r line; do
+  path=$(echo "$line" | grep -oP 'handle\s+(/[^\s/*]+)' | grep -oP '/\S+') || continue
+  # Check if the block following this handle has uri strip_prefix
+  if grep -A5 "handle ${path}/\*" "$CADDYFILE" | grep -q 'uri strip_prefix'; then
+    caddy_strips[$path]=1
+  else
+    caddy_strips[$path]=0
+  fi
+done < <(grep 'handle /.*\*' "$CADDYFILE")
+
+# --- Compare paths that exist in both ---
+for path in "${vite_paths[@]}"; do
+  is_skipped "$path" && continue
+  # Only check paths present in both configs
+  [[ -z "${caddy_strips[$path]+x}" ]] && continue
+
+  vite_strips=${vite_rewrites[$path]}
+  caddy_does=${caddy_strips[$path]}
+
+  if [[ "$vite_strips" -eq 1 && "$caddy_does" -eq 0 ]]; then
+    echo "ERROR: $path — Vite rewrites prefix but Caddyfile does not strip it"
+    ERRORS=$((ERRORS + 1))
+  elif [[ "$vite_strips" -eq 0 && "$caddy_does" -eq 1 ]]; then
+    echo "ERROR: $path — Caddyfile strips prefix but Vite does not rewrite it"
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+if [[ "$ERRORS" -gt 0 ]]; then
+  echo ""
+  echo "FAILED: $ERRORS proxy parity error(s) found."
+  echo "Every proxy that strips its prefix in vite.config.ts must also"
+  echo "have 'uri strip_prefix' in the Caddyfile, and vice versa."
+  exit 1
+fi
+
+echo "OK: Vite and Caddy proxy configurations are in sync."


### PR DESCRIPTION
## Summary

- Adds `uri strip_prefix /cog` to the Caddyfile so the COG tiler receives `/tiles/...` instead of `/cog/tiles/...`
- Adds matching `rewrite` to the Vite dev proxy for local dev parity
- Adds a new `proxy-parity` CI job that verifies Vite and Caddy proxy routes stay in sync

## Root cause

The `/cog` proxy in the Caddyfile was the only tiler proxy missing `uri strip_prefix`. Every other proxy (`/raster`, `/vector`, `/pmtiles`, `/storage`) strips its prefix before forwarding. The COG tiler (titiler) received `/cog/tiles/WebMercatorQuad/{z}/{x}/{y}` and returned 404 because that endpoint doesn't exist — it expects `/tiles/WebMercatorQuad/{z}/{x}/{y}`.

Closes #111

## Test plan

- [ ] Connect a COG URL and verify map tiles load without 404 console errors
- [ ] Verify `proxy-parity` CI job passes
- [ ] Temporarily remove `uri strip_prefix /cog` from Caddyfile and verify `proxy-parity` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved proxy path configuration alignment between development and production environments.

* **Tests**
  * Added automated validation to ensure consistent proxy behavior across development and production setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->