### PR TITLE
fix: scrollytelling initialization and scroll context for overlay layout

### DIFF
--- a/frontend/src/components/StoryRenderer.tsx
+++ b/frontend/src/components/StoryRenderer.tsx
@@ -83,8 +83,8 @@ function ScrollytellingBlock({
           "[data-step]"
         ) as unknown as HTMLElement[],
         offset: 0.8,
-        container: scrollParent,
-      })
+        ...(scrollParent ? { container: scrollParent } : {}),
+      } as Parameters<typeof scroller.setup>[0])
       .onStepEnter(({ index }) => {
         setActiveIndex(index);
       });


### PR DESCRIPTION
## Summary

Fixes two bugs in the guided tour reader:

1. **Scrollytelling only shows first chapter on initial load** — The overlay layout used `position: absolute; overflowY: auto` creating a nested scroll container that scrollama couldn't observe. Steps are now in normal document flow using a sticky map + negative margin pattern.

2. **Fly-to animations not triggering** — Same root cause. Scrollama wasn't detecting step entries, so `activeIndex` never changed, so camera transitions never fired.

### What changed

- Map container: `position: sticky; top: 0; height: 100vh` (stays fixed in viewport while scrolling)
- Steps container: `position: relative; mt: -100vh` (overlaps the sticky map, in normal document flow)
- Scrollama setup: finds the nearest `overflowY: auto/scroll` ancestor and passes it as the `container` option

## Test plan

- [ ] Open a published story with multiple scrollytelling chapters
- [ ] Verify Chapter 1 is visible and the map renders on first load (no scroll needed)
- [ ] Scroll down — verify subsequent chapters appear and the map animates (fly-to) to their positions
- [ ] Verify overlay cards float left/right per chapter setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrollytelling to reliably detect and use custom scroll containers so scroll-triggered content activates correctly.
* **UI Improvements**
  * Map is now sticky while story steps scroll over it for smoother visual continuity and better layout performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->