### PR TITLE
fix: feed intermediate camera frames to deck.gl during fly-to

### DIFF
--- a/frontend/src/components/StoryRenderer.tsx
+++ b/frontend/src/components/StoryRenderer.tsx
@@ -125,9 +125,10 @@ function ScrollytellingBlock({
   );
 
   const handleCameraChange = useCallback((c: CameraState) => {
-    if (isTransitioningRef.current) return;
     setCamera(c);
-    setTransitionDuration(undefined);
+    if (!isTransitioningRef.current) {
+      setTransitionDuration(undefined);
+    }
   }, []);
 
   const handleTransitionEnd = useCallback(() => {


### PR DESCRIPTION
## Summary

Fixes fly-to animations not playing in the scrollytelling reader.

**Root cause:** deck.gl's controlled mode requires `onViewStateChange` values to be fed back into `viewState` for transitions to animate frame-by-frame. The previous fix (`if (isTransitioningRef.current) return`) skipped ALL camera updates during transitions, starving deck.gl of intermediate frames — so the map just jumped to the final position.

**Fix:** Always update camera state (so deck.gl gets intermediate frames), but only clear `transitionDuration` when NOT transitioning:

```diff
- if (isTransitioningRef.current) return;
- setCamera(c);
- setTransitionDuration(undefined);
+ setCamera(c);
+ if (!isTransitioningRef.current) {
+   setTransitionDuration(undefined);
+ }
```

## Test plan

- [ ] Open a published story with multiple scrollytelling chapters at different map locations
- [ ] Scroll between chapters — map should smoothly fly between locations over ~2 seconds
- [ ] Verify the map is still non-interactive in reader mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera responsiveness during animated transitions by allowing camera updates to process continuously rather than being blocked during active animations. This provides smoother interaction with the storytelling interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->