### PR TITLE
fix: use controller={true} with pointer-events for fly-to transitions

### DIFF
--- a/frontend/src/components/StoryRenderer.tsx
+++ b/frontend/src/components/StoryRenderer.tsx
@@ -125,10 +125,9 @@ function ScrollytellingBlock({
   );
 
   const handleCameraChange = useCallback((c: CameraState) => {
+    if (isTransitioningRef.current) return;
     setCamera(c);
-    if (!isTransitioningRef.current) {
-      setTransitionDuration(undefined);
-    }
+    setTransitionDuration(undefined);
   }, []);
 
   const handleTransitionEnd = useCallback(() => {

--- a/frontend/src/components/UnifiedMap.tsx
+++ b/frontend/src/components/UnifiedMap.tsx
@@ -85,24 +85,17 @@ export const UnifiedMap = forwardRef<any, UnifiedMapProps>(function UnifiedMap(
     : camera;
 
   return (
-    <Box position="relative" w="100%" h="100%">
+    <Box
+      position="relative"
+      w="100%"
+      h="100%"
+      pointerEvents={interactive ? "auto" : "none"}
+    >
       <DeckGL
         ref={ref}
         viewState={viewState}
         onViewStateChange={handleViewStateChange}
-        controller={
-          interactive
-            ? { dragRotate: true }
-            : {
-                dragPan: false,
-                dragRotate: false,
-                scrollZoom: false,
-                doubleClickZoom: false,
-                touchZoom: false,
-                touchRotate: false,
-                keyboard: false,
-              }
-        }
+        controller={interactive ? { dragRotate: true } : true}
         layers={layers}
         views={views}
         onHover={onHover}


### PR DESCRIPTION
## Summary

Third attempt at fixing fly-to animations. The previous two fixes each addressed part of the problem but not the whole thing.

**What was wrong:**

1. **PR #124** passed `controller={{ dragPan: false, dragRotate: false, ... }}` — an object with all options disabled. This doesn't fully activate deck.gl's internal transition engine the way `controller={true}` does.

2. **PR #125** fed intermediate animation frames back via `setCamera()`, which caused deck.gl to see "fly to where you already are" each frame — a no-op that prevented animation progress.

**What this fixes:**

1. **UnifiedMap**: `controller={true}` for non-interactive maps (fully activates deck.gl internals including transitions). User interaction blocked via `pointerEvents="none"` on the wrapper div instead.

2. **StoryRenderer**: Reverts `handleCameraChange` to early-return during transitions. In controlled mode with an active controller, deck.gl animates internally — intermediate frames don't need to be fed back.

## Test plan

- [ ] Open a published story with multiple scrollytelling chapters at different map locations
- [ ] Scroll between chapters — map should smoothly fly between locations over ~2 seconds
- [ ] Verify the map is non-interactive in reader mode (can't pan/zoom)
- [ ] Verify the editor map is still interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced camera transition handling to prevent conflicting updates during animated transitions.
  * Optimized interaction control implementation for improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->