### PR TITLE
fix: feed intermediate camera frames back to deck.gl during fly-to

### DIFF
--- a/frontend/src/components/StoryRenderer.tsx
+++ b/frontend/src/components/StoryRenderer.tsx
@@ -40,7 +40,6 @@ function ScrollytellingBlock({
     number | undefined
   >(undefined);
   const flyToRef = useRef(new FlyToInterpolator());
-  const isTransitioningRef = useRef(false);
   const stepsRef = useRef<HTMLDivElement>(null);
   const scrollerRef = useRef<ReturnType<typeof scrollama> | null>(null);
 
@@ -101,13 +100,7 @@ function ScrollytellingBlock({
 
     setBasemap(chapter.map_state.basemap);
 
-    if (chapter.transition === "fly-to") {
-      isTransitioningRef.current = true;
-      setTransitionDuration(2000);
-    } else {
-      isTransitioningRef.current = false;
-      setTransitionDuration(undefined);
-    }
+    setTransitionDuration(chapter.transition === "fly-to" ? 2000 : undefined);
 
     setCamera({
       longitude: chapter.map_state.center[0],
@@ -125,13 +118,7 @@ function ScrollytellingBlock({
   );
 
   const handleCameraChange = useCallback((c: CameraState) => {
-    if (isTransitioningRef.current) return;
     setCamera(c);
-    setTransitionDuration(undefined);
-  }, []);
-
-  const handleTransitionEnd = useCallback(() => {
-    isTransitioningRef.current = false;
     setTransitionDuration(undefined);
   }, []);
 
@@ -159,7 +146,6 @@ function ScrollytellingBlock({
               transitionDuration ? flyToRef.current : undefined
             }
             interactive={false}
-            onTransitionEnd={handleTransitionEnd}
           />
         )}
         {activeDataset === null && !hasConnection && (


### PR DESCRIPTION
## Summary

Removes the `isTransitioningRef` gate that was preventing fly-to animations from working.

**Git bisect finding:** Fly-to broke at `a3a32e9` which set `controller={false}` for non-interactive maps. PR #126 restored `controller={true}`, but the `isTransitioningRef` early-return (added in #120) was still blocking deck.gl from receiving intermediate animation frames.

**This PR restores the original working pattern:**
```typescript
// Before (broken): skips ALL updates during transition
if (isTransitioningRef.current) return;
setCamera(c);
setTransitionDuration(undefined);

// After (original working pattern): feeds frames back to deck.gl
setCamera(c);
setTransitionDuration(undefined);
```

deck.gl's controlled mode needs intermediate frames fed back via `onViewStateChange` → `setCamera()`. The controller handles animation internally once triggered — clearing `transitionDuration` doesn't kill an in-progress animation.

## Test plan

- [ ] Open a published story with multiple scrollytelling chapters at different locations
- [ ] Scroll between chapters — map should smoothly fly between locations
- [ ] Verify map is non-interactive in reader mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized transition handling logic in the story renderer component by simplifying internal state management and removing redundant transition guards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->