### PR TITLE
fix: hide preload progress in browse mode

### DIFF
--- a/frontend/src/components/TemporalControls.tsx
+++ b/frontend/src/components/TemporalControls.tsx
@@ -86,8 +86,8 @@ export function TemporalControls({
 
         {/* Top row: three groups */}
         <Flex align="center" justify="space-between" gap={2}>
-          {/* Left: Calendar date picker (dark pill wrapper so white text is visible) */}
-          <Box bg="#2d1b10" borderRadius="8px" px={1} py={0.5} flexShrink={0}>
+          {/* Left: Calendar date picker */}
+          <Box bg="#2d1b10" borderRadius="12px" px={2} py={1} flexShrink={0}>
             <CalendarPopover
               timesteps={timesteps}
               activeIndex={activeIndex}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -121,10 +121,6 @@ export default function MapPage() {
   }, [item?.id]);
 
   const isPreloaded = !ds?.is_temporal || loadedCount >= frameCount;
-  const preloadProgress =
-    ds?.is_temporal && !isPreloaded
-      ? { current: loadedCount, total: frameCount }
-      : null;
 
   const cadence = useMemo(
     () =>
@@ -140,6 +136,11 @@ export default function MapPage() {
     isPreloaded,
     initialTimestep
   );
+
+  const preloadProgress =
+    ds?.is_temporal && animation.isAnimateMode && !isPreloaded
+      ? { current: loadedCount, total: frameCount }
+      : null;
 
   // Progressive preloading: only render the active layer + already-loaded
   // layers + one more unloaded layer at a time. This lets the first timestep


### PR DESCRIPTION
## Summary

- Only show preload progress bar ("Loading X of Y") when in animate mode — browse mode uses single-layer loading and shouldn't show preloading status
- Improve calendar date picker pill padding and border radius for better visual fit

Fixes issue where temporal datasets showed a confusing "Loading X of Y" indicator even when not animating.

## Test plan

- [ ] Open a temporal dataset — no loading indicator should appear (browse mode)
- [ ] Click play — loading indicator should appear while frames preload
- [ ] Stop animation — loading indicator should disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated calendar date picker styling with increased border radius and padding for better visual appearance.

* **Bug Fixes**
  * Adjusted preload progress indicator to display only during temporal animation mode, improving visibility behavior in browse flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->