### PR TITLE
fix: PMTiles connections not rendering when tile_type is null

### DIFF
--- a/frontend/src/components/InlineConnectionForm.tsx
+++ b/frontend/src/components/InlineConnectionForm.tsx
@@ -93,7 +93,15 @@ export function InlineConnectionForm({
         bounds: probeMetadata?.bounds ?? null,
         min_zoom: probeMetadata?.minZoom ?? null,
         max_zoom: probeMetadata?.maxZoom ?? null,
-        tile_type: probeMetadata?.tileType ?? null,
+        tile_type:
+          probeMetadata?.tileType ??
+          (connectionType === "pmtiles"
+            ? "vector"
+            : connectionType === "cog" || connectionType === "xyz_raster"
+              ? "raster"
+              : connectionType === "xyz_vector"
+                ? "vector"
+                : null),
         band_count: probeMetadata?.bandCount ?? null,
         rescale: probeMetadata?.rescale
           ? probeMetadata.rescale.join(",")

--- a/frontend/src/hooks/__tests__/useMapData.test.ts
+++ b/frontend/src/hooks/__tests__/useMapData.test.ts
@@ -138,6 +138,17 @@ describe("useMapData", () => {
     expect(result.current.data!.dataType).toBe("vector");
   });
 
+  it("defaults pmtiles with null tile_type to vector", async () => {
+    mockConnectionsGet.mockResolvedValue({
+      ...MOCK_CONNECTION,
+      connection_type: "pmtiles",
+      tile_type: null,
+    });
+    const { result } = renderHook(() => useMapData("conn-4", true));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data!.dataType).toBe("vector");
+  });
+
   it("returns error on fetch failure", async () => {
     mockWorkspaceFetch.mockResolvedValue({ ok: false, status: 500 });
 

--- a/frontend/src/hooks/useLayerBuilder.ts
+++ b/frontend/src/hooks/useLayerBuilder.ts
@@ -6,6 +6,7 @@ import type { TileCacheEntry } from "../lib/layers";
 import type { Table } from "apache-arrow";
 import {
   buildRasterTileLayers,
+  buildRasterPMTilesLayer,
   buildCogLayer,
   buildVectorLayer,
   buildGeoJsonLayer,
@@ -121,11 +122,14 @@ export function useLayerBuilder({
             }),
           ];
         }
-        return buildRasterTileLayers({
-          tileUrl,
-          opacity,
-          isTemporalActive: false,
-        });
+        return [
+          buildRasterPMTilesLayer({
+            tileUrl,
+            opacity,
+            minZoom: item.minZoom ?? undefined,
+            maxZoom: item.maxZoom ?? undefined,
+          }),
+        ];
       }
 
       if (connType === "xyz_raster") {

--- a/frontend/src/hooks/useMapData.ts
+++ b/frontend/src/hooks/useMapData.ts
@@ -30,7 +30,7 @@ function datasetToMapItem(ds: Dataset): MapItem {
 
 function getConnectionDataType(conn: Connection): "raster" | "vector" {
   if (conn.connection_type === "xyz_vector") return "vector";
-  if (conn.connection_type === "pmtiles" && conn.tile_type === "vector")
+  if (conn.connection_type === "pmtiles" && conn.tile_type !== "raster")
     return "vector";
   return "raster";
 }

--- a/frontend/src/lib/layers/index.ts
+++ b/frontend/src/lib/layers/index.ts
@@ -2,5 +2,6 @@ export { type CameraState, DEFAULT_CAMERA, cameraFromBounds } from "./types";
 export { buildRasterTileLayers } from "./rasterTileLayer";
 export { buildCogLayer } from "./cogLayer";
 export type { TileCacheEntry } from "./cogLayer";
+export { buildRasterPMTilesLayer } from "./rasterPMTilesLayer";
 export { buildVectorLayer } from "./vectorLayer";
 export { buildGeoJsonLayer, arrowTableToGeoJSON } from "./geojsonLayer";

--- a/frontend/src/lib/layers/rasterPMTilesLayer.ts
+++ b/frontend/src/lib/layers/rasterPMTilesLayer.ts
@@ -1,0 +1,63 @@
+import { TileLayer } from "@deck.gl/geo-layers";
+import { BitmapLayer } from "@deck.gl/layers";
+import { PMTiles } from "pmtiles";
+
+interface RasterPMTilesLayerOptions {
+  id?: string;
+  tileUrl: string;
+  opacity: number;
+  minZoom?: number;
+  maxZoom?: number;
+}
+
+export function buildRasterPMTilesLayer({
+  id = "raster-pmtiles",
+  tileUrl,
+  opacity,
+  minZoom,
+  maxZoom,
+}: RasterPMTilesLayerOptions) {
+  const isExternal = tileUrl.startsWith("http");
+  const absoluteUrl = isExternal
+    ? `${window.location.origin}/api/proxy?url=${encodeURIComponent(tileUrl)}`
+    : `${window.location.origin}${tileUrl}`;
+  const pmtilesSource = new PMTiles(absoluteUrl);
+
+  return new TileLayer({
+    id,
+    data: `${absoluteUrl}/{z}/{x}/{y}.png`,
+    opacity,
+    tileSize: 256,
+    ...(minZoom !== undefined && { minZoom }),
+    ...(maxZoom !== undefined && { maxZoom }),
+    fetch: async (url: string) => {
+      const match = url.match(/\/(\d+)\/(\d+)\/(\d+)\.png$/);
+      if (!match) return null;
+      const [, z, x, y] = match.map(Number);
+      try {
+        const tile = await pmtilesSource.getZxy(z, x, y);
+        if (!tile?.data) return null;
+        const blob = new Blob([tile.data]);
+        const imageBitmap = await createImageBitmap(blob);
+        return imageBitmap;
+      } catch {
+        return null;
+      }
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    renderSubLayers: (props: any) => {
+      const { boundingBox } = props.tile;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return new BitmapLayer(props as any, {
+        data: undefined,
+        image: props.data,
+        bounds: [
+          boundingBox[0][0],
+          boundingBox[0][1],
+          boundingBox[1][0],
+          boundingBox[1][1],
+        ],
+      });
+    },
+  });
+}

--- a/frontend/src/lib/layers/vectorLayer.ts
+++ b/frontend/src/lib/layers/vectorLayer.ts
@@ -75,13 +75,17 @@ export function buildVectorLayer({
         const match = url.match(/\/(\d+)\/(\d+)\/(\d+)\.pbf$/);
         if (!match) return null;
         const [, z, x, y] = match.map(Number);
-        const tile = await pmtilesSource.getZxy(z, x, y);
-        if (!tile?.data) return null;
-        // Parse through loaders.gl so MVTLayer gets properly structured data
-        return load(tile.data, MVTLoader, {
-          ...context.loadOptions,
-          mimeType: "application/x-protobuf",
-        });
+        try {
+          const tile = await pmtilesSource.getZxy(z, x, y);
+          if (!tile?.data) return null;
+          // Parse through loaders.gl so MVTLayer gets properly structured data
+          return load(tile.data, MVTLoader, {
+            ...context.loadOptions,
+            mimeType: "application/x-protobuf",
+          });
+        } catch {
+          return null;
+        }
       },
     });
   }

--- a/frontend/src/lib/story/rendering.ts
+++ b/frontend/src/lib/story/rendering.ts
@@ -1,4 +1,8 @@
-import { buildRasterTileLayers, buildVectorLayer } from "../layers";
+import {
+  buildRasterTileLayers,
+  buildRasterPMTilesLayer,
+  buildVectorLayer,
+} from "../layers";
 import { buildConnectionTileUrl } from "../connections";
 import { DEFAULT_LAYER_CONFIG } from "./types";
 import type { Chapter } from "./types";
@@ -77,6 +81,18 @@ export function buildLayersForChapter(
         buildVectorLayer({
           tileUrl,
           isPMTiles: true,
+          opacity: lc.opacity,
+          minZoom: conn.min_zoom ?? undefined,
+          maxZoom: conn.max_zoom ?? undefined,
+        }),
+      ];
+    }
+
+    // PMTiles raster
+    if (conn.connection_type === "pmtiles" && conn.tile_type === "raster") {
+      return [
+        buildRasterPMTilesLayer({
+          tileUrl,
           opacity: lc.opacity,
           minZoom: conn.min_zoom ?? undefined,
           maxZoom: conn.max_zoom ?? undefined,


### PR DESCRIPTION
## Summary

- PMTiles connections with null `tile_type` (from failed probes) were misclassified as raster, then passed to `createCOGLayer` which expects a `{z}/{x}/{y}` URL template — not a PMTiles archive URL. This caused deck.gl to error on every tile fetch (50+ errors per page load).
- Root cause: `getConnectionDataType` treated null `tile_type` as raster; `InlineConnectionForm` didn't default `tile_type` when probe failed; no raster PMTiles rendering existed at all.

### Fixes
- **`getConnectionDataType`**: PMTiles now defaults to vector when `tile_type` is null
- **`InlineConnectionForm`**: defaults `tile_type` based on `connection_type` when probe fails (matching `ConnectionModal`)
- **`buildRasterPMTilesLayer`**: new layer builder for raster PMTiles using the PMTiles library with range requests
- **Vector PMTiles fetch**: added try/catch to prevent cascading errors when archive is unreachable
- Also fixed the existing broken connection in prod DB (`tile_type` set to `vector`)

## Test plan
- [x] New test: PMTiles connection with null `tile_type` defaults to vector
- [x] All 190 existing tests pass
- [x] TypeScript compiles cleanly
- [ ] Verify the reported connection renders on prod after deploy

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for displaying raster imagery from PMTiles data sources in maps
  * Improved automatic detection of tile types for PMTiles connections

* **Bug Fixes**
  * Enhanced error handling when loading PMTiles tile data

* **Tests**
  * Expanded test coverage for PMTiles data handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->