### PR TITLE
fix: proxy streaming response closes httpx client prematurely

### DIFF
--- a/ingestion/src/routes/proxy.py
+++ b/ingestion/src/routes/proxy.py
@@ -68,9 +68,7 @@ async def proxy_resource(url: str, request: Request):
     except httpx.RequestError as e:
         await client.aclose()
         logger.error("Proxy request failed for %s: %s", safe_url, e)
-        raise HTTPException(
-            status_code=502, detail="Upstream request failed"
-        ) from e
+        raise HTTPException(status_code=502, detail="Upstream request failed") from e
 
     if resp.status_code >= 400:
         await resp.aclose()


### PR DESCRIPTION
## Summary

- The proxy endpoint used `async with httpx.AsyncClient()` which closed the HTTP connection when the handler returned, but `StreamingResponse` continues reading afterward — causing `httpx.ReadError` → 500 for PMTiles range requests.
- Fix: manage client lifetime manually with a `stream_and_close()` generator that keeps the client alive until streaming completes, then cleans up in `finally`.

This was discovered when testing raster PMTiles connections (e.g., Riyadh Sentinel-2 from Source Cooperative). The probe's initial range request would intermittently fail with a 500.

## Test plan
- [x] 200 existing backend tests pass (4 pre-existing failures unrelated)
- [ ] Test adding a PMTiles connection with the Riyadh Sentinel-2 URL
- [ ] Verify range requests return 206 consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup so failed proxy requests and oversized responses reliably close resources and avoid hanging streams.

* **Refactor**
  * Stream handling and request lifecycle reorganized for more predictable streaming behavior and resource management across all request paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->