### PR TITLE
feat: show warning when connection probe fails

### DIFF
--- a/frontend/src/components/ConnectionModal.tsx
+++ b/frontend/src/components/ConnectionModal.tsx
@@ -52,10 +52,12 @@ export function ConnectionModal({
     null
   );
   const [error, setError] = useState<string | null>(null);
+  const [probeWarning, setProbeWarning] = useState<string | null>(null);
 
   // Auto-detect type and name when URL changes
   const handleUrlBlur = useCallback(async () => {
     if (!url) return;
+    setProbeWarning(null);
     const detected = detectConnectionType(url);
     if (detected) {
       setConnectionType(detected);
@@ -73,8 +75,14 @@ export function ConnectionModal({
             ? await probePMTiles(url)
             : await probeCOG(url);
         setProbeMetadata(metadata);
-      } catch {
+      } catch (e) {
         setProbeMetadata(null);
+        const msg = e instanceof Error ? e.message : String(e);
+        setProbeWarning(
+          detected === "pmtiles"
+            ? `Could not read PMTiles header — file may not be valid PMTiles v3. ${msg}`
+            : `Could not read COG metadata. ${msg}`
+        );
       } finally {
         setProbing(false);
       }
@@ -93,6 +101,7 @@ export function ConnectionModal({
       setSaving(false);
       setProbing(false);
       setProbeMetadata(null);
+      setProbeWarning(null);
       setError(null);
     }
   }, [isOpen]);
@@ -254,6 +263,12 @@ export function ConnectionModal({
               {probeMetadata.bounds && " with bounds"}
               {probeMetadata.minZoom != null &&
                 `, zoom ${probeMetadata.minZoom}–${probeMetadata.maxZoom}`}
+            </Text>
+          )}
+
+          {probeWarning && !probing && (
+            <Text fontSize="13px" color="orange.500">
+              {probeWarning}
             </Text>
           )}
 

--- a/frontend/src/components/InlineConnectionForm.tsx
+++ b/frontend/src/components/InlineConnectionForm.tsx
@@ -47,11 +47,13 @@ export function InlineConnectionForm({
     null
   );
   const [error, setError] = useState<string | null>(null);
+  const [probeWarning, setProbeWarning] = useState<string | null>(null);
 
   const handleUrlBlur = useCallback(async () => {
     if (!url.trim()) return;
     setError(null);
     setProbeMetadata(null);
+    setProbeWarning(null);
 
     const detected = detectConnectionType(url);
     if (detected) {
@@ -72,8 +74,13 @@ export function InlineConnectionForm({
             ? await probePMTiles(url)
             : await probeCOG(url);
         setProbeMetadata(metadata);
-      } catch {
-        // Probe failure is non-fatal — user can still save
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setProbeWarning(
+          detected === "pmtiles"
+            ? `Could not read PMTiles header — file may not be valid PMTiles v3. ${msg}`
+            : `Could not read COG metadata. ${msg}`
+        );
       } finally {
         setProbing(false);
       }
@@ -214,6 +221,13 @@ export function InlineConnectionForm({
             </Text>
           )}
         </Box>
+      )}
+
+      {/* Probe warning */}
+      {probeWarning && !probing && (
+        <Text fontSize="xs" color="yellow.400" mb={3}>
+          {probeWarning}
+        </Text>
       )}
 
       {/* Error */}


### PR DESCRIPTION
## Summary

- When `probePMTiles` or `probeCOG` fails, both `InlineConnectionForm` and `ConnectionModal` now display a warning message instead of silently swallowing the error
- Warning text explains the likely cause (e.g. "Could not read PMTiles header — file may not be valid PMTiles v3") and includes the error message
- User can still save the connection — the warning is non-blocking

Discovered while testing with a Source Cooperative file (`obis_z10.pmtiles`) that turned out to be SQLite/MBTiles format, not PMTiles v3. The probe failed silently and the connection was created with no metadata, leading to a blank map with no feedback.

## Test plan
- [x] 190 frontend tests pass
- [x] TypeScript compiles cleanly
- [ ] Test with a valid PMTiles URL — probe succeeds, no warning shown
- [ ] Test with an invalid PMTiles URL — warning displayed, save still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Connection modals and inline forms now display clear warning messages when data source configuration encounters non-fatal issues during probing and detection, providing better transparency instead of failing silently.
  * Warning messages automatically clear when users modify the URL, attempt to reconnect, or close the connection setup dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->