### PR TITLE
fix: add name to uptime workflow to prevent spurious push failures

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,3 +1,5 @@
+name: Uptime Monitor
+
 on:
   schedule:
     - cron: "*/5 * * * *"


### PR DESCRIPTION
## Summary

The uptime workflow lacked a `name` field, causing GitHub Actions to evaluate it on every push event. Since it only has `schedule` and `workflow_dispatch` triggers, GitHub marked each evaluation as a failed run (0 jobs executed) — generating failure email notifications on every PR push and merge.

Adding `name: Uptime Monitor` should resolve this. The workflow itself is unchanged.

## Test plan
- [ ] Push to this branch should NOT trigger a failed `uptime.yml` run
- [ ] After merge, subsequent pushes should no longer show uptime failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration for improved organization and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->