### PR TITLE
fix: library page empty on refresh due to workspace ID race condition

### DIFF
--- a/frontend/src/hooks/useWorkspace.tsx
+++ b/frontend/src/hooks/useWorkspace.tsx
@@ -39,11 +39,15 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
   const { workspaceId } = useParams<{ workspaceId: string }>();
   const activeId = workspaceId!;
 
+  // Set workspace ID synchronously so child useEffect hooks (e.g. LibraryPage
+  // data fetches) can read it on the first render cycle. A useEffect here would
+  // race with child effects and lose on a fresh page load.
+  setWorkspaceId(activeId);
+
   useEffect(() => {
     if (!localStorage.getItem(STORAGE_KEY)) {
       localStorage.setItem(STORAGE_KEY, activeId);
     }
-    setWorkspaceId(activeId);
   }, [activeId]);
 
   const value = useMemo(


### PR DESCRIPTION
## Summary

On a fresh page load or hard refresh of the library page, no datasets, connections, or stories loaded. Navigating from the home page worked fine.

**Root cause:** `WorkspaceProvider` set the workspace ID in a `useEffect`, which races with `LibraryPage`'s data-fetching `useEffect`s. On a fresh load, the child effects fired before the parent effect, sending API requests with an empty `X-Workspace-Id` header.

**Fix:** Set the workspace ID synchronously during render (before effects run) so it's available when child components mount.

Closes #160

## Test plan
- [x] 190 frontend tests pass
- [x] TypeScript compiles cleanly
- [ ] Hard refresh on library page loads all data
- [ ] Navigation from home → library still works
- [ ] Workspace isolation still works (different workspace IDs see different data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved workspace ID synchronization and localStorage persistence to enhance application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->