### PR TITLE
fix: make overview level check adaptive to raster dimensions

### DIFF
--- a/geo-conversions/geotiff-to-cog/scripts/validate.py
+++ b/geo-conversions/geotiff-to-cog/scripts/validate.py
@@ -233,14 +233,30 @@ def check_rendering_metadata(output_path: str) -> CheckResult:
         )
 
 
-def check_overviews(output_path: str, min_levels: int = 3) -> CheckResult:
-    """Check that internal overviews are present."""
+def check_overviews(output_path: str) -> CheckResult:
+    """Check that internal overviews cover the raster pyramid.
+
+    The expected count depends on the raster dimensions and the COG block
+    size: GDAL's COG driver and rio-cogeo stop adding levels once the
+    overview dimension drops below the block size, so a small raster that
+    only needs 1 or 2 levels should not be penalized. For a raster whose
+    largest dimension fits inside a single block, zero overviews is fine.
+    """
+    import math
+
     with rasterio.open(output_path) as dst:
         overviews = dst.overviews(1)
-        if len(overviews) >= min_levels:
+        blocksize = dst.block_shapes[0][0] if dst.block_shapes else 512
+        max_dim = max(dst.width, dst.height)
+        if max_dim <= blocksize:
+            expected = 0
+        else:
+            expected = max(1, math.floor(math.log2(max_dim / blocksize)))
+        if len(overviews) >= expected:
             return CheckResult("Overviews", True, f"{len(overviews)} levels: {overviews}")
         return CheckResult("Overviews", False,
-                           f"Found {len(overviews)} levels (need >= {min_levels}): {overviews}")
+                           f"Found {len(overviews)} levels (expected >= {expected} "
+                           f"for {dst.width}x{dst.height} at blocksize {blocksize}): {overviews}")
 
 
 def print_report(results: list[CheckResult]):

--- a/geo-conversions/hdf5-to-cog/scripts/validate.py
+++ b/geo-conversions/hdf5-to-cog/scripts/validate.py
@@ -64,14 +64,30 @@ def check_nodata_present(output_path: str) -> CheckResult:
         return CheckResult("NoData defined", False, "No nodata value set")
 
 
-def check_overviews(output_path: str, min_levels: int = 3) -> CheckResult:
-    """Check that internal overviews are present."""
+def check_overviews(output_path: str) -> CheckResult:
+    """Check that internal overviews cover the raster pyramid.
+
+    The expected count depends on the raster dimensions and the COG block
+    size: GDAL's COG driver and rio-cogeo stop adding levels once the
+    overview dimension drops below the block size, so a small raster that
+    only needs 1 or 2 levels should not be penalized. For a raster whose
+    largest dimension fits inside a single block, zero overviews is fine.
+    """
+    import math
+
     with rasterio.open(output_path) as dst:
         overviews = dst.overviews(1)
-        if len(overviews) >= min_levels:
+        blocksize = dst.block_shapes[0][0] if dst.block_shapes else 512
+        max_dim = max(dst.width, dst.height)
+        if max_dim <= blocksize:
+            expected = 0
+        else:
+            expected = max(1, math.floor(math.log2(max_dim / blocksize)))
+        if len(overviews) >= expected:
             return CheckResult("Overviews", True, f"{len(overviews)} levels: {overviews}")
         return CheckResult("Overviews", False,
-                           f"Found {len(overviews)} levels (need >= {min_levels}): {overviews}")
+                           f"Found {len(overviews)} levels (expected >= {expected} "
+                           f"for {dst.width}x{dst.height} at blocksize {blocksize}): {overviews}")
 
 
 def check_pixel_fidelity(input_path: str, output_path: str, variable: str = "",

--- a/geo-conversions/netcdf-to-cog/scripts/validate.py
+++ b/geo-conversions/netcdf-to-cog/scripts/validate.py
@@ -383,14 +383,30 @@ def check_rendering_metadata(output_path: str) -> CheckResult:
         )
 
 
-def check_overviews(output_path: str, min_levels: int = 3) -> CheckResult:
-    """Check that internal overviews are present."""
+def check_overviews(output_path: str) -> CheckResult:
+    """Check that internal overviews cover the raster pyramid.
+
+    The expected count depends on the raster dimensions and the COG block
+    size: GDAL's COG driver and rio-cogeo stop adding levels once the
+    overview dimension drops below the block size, so a small raster that
+    only needs 1 or 2 levels should not be penalized. For a raster whose
+    largest dimension fits inside a single block, zero overviews is fine.
+    """
+    import math
+
     with rasterio.open(output_path) as dst:
         overviews = dst.overviews(1)
-        if len(overviews) >= min_levels:
+        blocksize = dst.block_shapes[0][0] if dst.block_shapes else 512
+        max_dim = max(dst.width, dst.height)
+        if max_dim <= blocksize:
+            expected = 0
+        else:
+            expected = max(1, math.floor(math.log2(max_dim / blocksize)))
+        if len(overviews) >= expected:
             return CheckResult("Overviews", True, f"{len(overviews)} levels: {overviews}")
         return CheckResult("Overviews", False,
-                           f"Found {len(overviews)} levels (need >= {min_levels}): {overviews}")
+                           f"Found {len(overviews)} levels (expected >= {expected} "
+                           f"for {dst.width}x{dst.height} at blocksize {blocksize}): {overviews}")
 
 
 def print_report(results: list[CheckResult]):


### PR DESCRIPTION
## Summary

Fixes #174. Raster validators were rejecting valid COGs because they required a fixed minimum of 3 overview levels. Both GDAL's COG driver and rio-cogeo stop generating overviews once the overview dimension drops below the block size, so a small- or medium-sized raster that only needs 1 or 2 pyramid levels would always fail the check.

Soilmoisture HDF5 was hitting this: the COG was correctly produced with 2 overview levels ([2, 4]), but the validator required >= 3.

## Fix

Compute the expected count from the raster's dimensions and block size:

\`\`\`python
max(1, floor(log2(max_dim / blocksize)))
\`\`\`

Or zero when the entire raster fits in one block. Applied to geotiff, netcdf, and hdf5 validators for consistency.

## Test plan

- [x] Math verified against the reported failure (3000x1500 raster → expected 2 levels)
- [x] ruff check/format clean on ingestion src/tests
- [ ] Re-upload the soilmoisture HDF5 and confirm conversion succeeds
- [ ] Upload a large GeoTIFF (>4096 px) and confirm overview check still enforces ≥3 levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation logic for internal pyramid levels across geographic data conversion tools. The validation now dynamically determines appropriate levels based on file dimensions and block size, improving compatibility with various file sizes while maintaining performance standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->