### PR TITLE
fix: use 95th percentile for reprojected pixel fidelity check

### DIFF
--- a/geo-conversions/hdf5-to-cog/scripts/validate.py
+++ b/geo-conversions/hdf5-to-cog/scripts/validate.py
@@ -193,13 +193,20 @@ def check_pixel_fidelity(input_path: str, output_path: str, variable: str = "",
 
     diffs = np.abs(src_vals[valid] - cog_vals[valid])
     max_diff = float(np.max(diffs))
+    p95_diff = float(np.percentile(diffs, 95))
 
-    if max_diff > tolerance:
+    # Use the 95th percentile rather than max: reprojection + nearest-neighbor
+    # resampling legitimately produces large outliers at steep gradients or
+    # pixel boundaries because a sub-pixel coordinate drift lands on a neighbor
+    # with a very different value. A few such outliers don't mean the data is
+    # corrupt — failing on p95 catches actual systemic problems instead.
+    if p95_diff > tolerance:
         return CheckResult("Pixel fidelity", False,
-                           f"max diff={max_diff:.6f} exceeds tolerance={tolerance}")
+                           f"p95 diff={p95_diff:.6f} exceeds tolerance={tolerance} "
+                           f"(max={max_diff:.6f}, {valid.sum()}/{n} data pixels)")
 
     return CheckResult("Pixel fidelity", True,
-                       f"{valid.sum()}/{n} data pixels, max diff={max_diff:.6f}")
+                       f"{valid.sum()}/{n} data pixels, p95 diff={p95_diff:.6f}, max={max_diff:.6f}")
 
 
 def run_checks(input_path: str, output_path: str, variable: str = "",

--- a/geo-conversions/netcdf-to-cog/scripts/validate.py
+++ b/geo-conversions/netcdf-to-cog/scripts/validate.py
@@ -267,13 +267,23 @@ def check_pixel_fidelity(input_path: str, output_path: str, variable: str | None
             return CheckResult("Pixel fidelity", False,
                                "No valid COG pixels found at reprojected sample locations")
 
-        max_diff = float(np.max(np.abs(src_vals[valid] - cog_vals[valid])))
-        if max_diff > tolerance:
+        diffs = np.abs(src_vals[valid] - cog_vals[valid])
+        max_diff = float(np.max(diffs))
+        p95_diff = float(np.percentile(diffs, 95))
+
+        # Use the 95th percentile rather than max: reprojection + nearest-neighbor
+        # resampling legitimately produces large outliers at steep gradients or
+        # pixel boundaries because a sub-pixel coordinate drift lands on a neighbor
+        # with a very different value. A few such outliers don't mean the data is
+        # corrupt — failing on p95 catches actual systemic problems instead.
+        if p95_diff > tolerance:
             return CheckResult("Pixel fidelity", False,
-                               f"max diff={max_diff:.6f} exceeds tolerance={tolerance}")
+                               f"p95 diff={p95_diff:.6f} exceeds tolerance={tolerance} "
+                               f"(max={max_diff:.6f}, {valid.sum()}/{n} data pixels)")
 
         return CheckResult("Pixel fidelity", True,
-                           f"{valid.sum()}/{n} data pixels (reprojected), max diff={max_diff:.6f}")
+                           f"{valid.sum()}/{n} data pixels (reprojected), "
+                           f"p95 diff={p95_diff:.6f}, max={max_diff:.6f}")
 
     else:
         lat_names = [d for d in da.dims if d.lower() in ("lat", "latitude", "y")]


### PR DESCRIPTION
## Summary

Fixes #177. The HDF5 and NetCDF reprojected pixel-fidelity checks compared the **max** of 1000 sample diffs against a fixed tolerance of 0.5. Reprojection from a native CRS to EPSG:4326 with nearest-neighbor resampling legitimately produces large diffs at steep gradients or pixel boundaries — a sub-pixel coordinate drift lands the reader on a neighboring pixel whose value can differ arbitrarily from the source. A single unlucky sample would fail an otherwise-correct conversion.

Issue #177 reported \`max diff=3.231212 exceeds tolerance=0.5\` on a valid HDF5 upload.

## Fix

Switch the reprojected pixel-fidelity check to compare the **95th percentile** of diffs instead. Systemic corruption (byte-swap, coordinate shift, wrong band) still shows up in the p95; isolated edge-effect outliers no longer trip the check. Both p95 and max are reported for visibility.

## Test plan

- [x] Lint passes
- [ ] Re-upload the failing HDF5 and confirm conversion succeeds
- [ ] Upload a known-good GeoTIFF and confirm pixel fidelity still reports reasonable values

🤖 Generated with [Claude Code](https://claude.com/claude-code)