### PR TITLE
fix: fully reset job state on 'Upload another file'

### DIFF
--- a/frontend/src/hooks/useConversionJob.ts
+++ b/frontend/src/hooks/useConversionJob.ts
@@ -319,6 +319,10 @@ export function useConversionJob() {
 
   const startUpload = useCallback(
     async (file: File) => {
+      esRef.current?.close();
+      esRef.current = null;
+      datasetIdRef.current = null;
+      sseRetryCountRef.current = 0;
       setState((prev) => ({
         ...prev,
         isUploading: true,
@@ -326,6 +330,9 @@ export function useConversionJob() {
         error: null,
         stages: buildCheckingFormatStages(),
         duplicate: null,
+        jobId: null,
+        scanResult: null,
+        datasetId: null,
       }));
 
       // Pre-upload format check — send first 1MB to server for validation
@@ -460,6 +467,10 @@ export function useConversionJob() {
 
   const startUrlFetch = useCallback(
     async (url: string) => {
+      esRef.current?.close();
+      esRef.current = null;
+      datasetIdRef.current = null;
+      sseRetryCountRef.current = 0;
       setState((prev) => ({
         ...prev,
         isUploading: true,
@@ -467,6 +478,9 @@ export function useConversionJob() {
         error: null,
         stages: buildUploadingStages(),
         duplicate: null,
+        jobId: null,
+        scanResult: null,
+        datasetId: null,
       }));
 
       // Preflight duplicate check
@@ -559,6 +573,10 @@ export function useConversionJob() {
 
   const startTemporalUpload = useCallback(
     async (files: File[]) => {
+      esRef.current?.close();
+      esRef.current = null;
+      datasetIdRef.current = null;
+      sseRetryCountRef.current = 0;
       setState((prev) => ({
         ...prev,
         isUploading: true,
@@ -566,6 +584,9 @@ export function useConversionJob() {
         error: null,
         stages: buildUploadingStages(),
         duplicate: null,
+        jobId: null,
+        scanResult: null,
+        datasetId: null,
       }));
 
       const formData = new FormData();
@@ -610,11 +631,23 @@ export function useConversionJob() {
     [connectSSE]
   );
 
-  const resetDuplicate = useCallback(() => {
-    setState((prev) => ({
-      ...prev,
+  const resetJob = useCallback(() => {
+    esRef.current?.close();
+    esRef.current = null;
+    datasetIdRef.current = null;
+    sseRetryCountRef.current = 0;
+    setState({
+      jobId: null,
+      status: "pending",
+      datasetId: null,
+      error: null,
+      stages: buildInitialStages(),
+      progressCurrent: null,
+      progressTotal: null,
+      isUploading: false,
+      scanResult: null,
       duplicate: null,
-    }));
+    });
   }, []);
 
   return {
@@ -623,6 +656,6 @@ export function useConversionJob() {
     startUrlFetch,
     startTemporalUpload,
     confirmVariable,
-    resetDuplicate,
+    resetJob,
   };
 }

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -39,7 +39,7 @@ export default function UploadPage() {
     startUrlFetch,
     startTemporalUpload,
     confirmVariable,
-    resetDuplicate,
+    resetJob,
   } = useConversionJob();
   const fileRef = useRef<{ name: string; size: string }>({
     name: "",
@@ -110,9 +110,9 @@ export default function UploadPage() {
   }, []);
 
   const handleUploadAnother = useCallback(() => {
-    resetDuplicate();
+    resetJob();
     setMode("upload-idle");
-  }, [resetDuplicate]);
+  }, [resetJob]);
 
   const handleReport = useCallback(() => {
     setReportOpen(true);

--- a/frontend/src/pages/__tests__/UploadPage.test.tsx
+++ b/frontend/src/pages/__tests__/UploadPage.test.tsx
@@ -40,7 +40,7 @@ vi.mock("../../hooks/useConversionJob", () => ({
     startUrlFetch: vi.fn(),
     startTemporalUpload: vi.fn(),
     confirmVariable: vi.fn(),
-    resetDuplicate: vi.fn(),
+    resetJob: vi.fn(),
   }),
 }));
 
@@ -129,7 +129,7 @@ describe("UploadPage — duplicate warning", () => {
       startUrlFetch: vi.fn(),
       startTemporalUpload: vi.fn(),
       confirmVariable: vi.fn(),
-      resetDuplicate: vi.fn(),
+      resetJob: vi.fn(),
     });
 
     renderPage();


### PR DESCRIPTION
## Summary

Fixes #175. The \`Upload another file\` button on the duplicate-filename warning only cleared \`state.duplicate\`. Stale \`jobId\`, \`scanResult\`, \`datasetId\`, and the open SSE connection from any prior job were left behind. With a stale \`jobId\` still set, the \`UploadPage\` mode-derivation effect computed \`isProcessing = (jobId !== null && status !== "failed")\` as \`true\`, forced \`mode\` back to \`"uploading"\`, and rendered a stuck \`ProgressTracker\` with the previous filename — the dead end in the screenshot.

## Fix

Replace \`resetDuplicate\` with \`resetJob\` that fully reinitializes transient job state and closes any open SSE. Also make \`startUpload\`, \`startUrlFetch\`, and \`startTemporalUpload\` clear \`jobId\` / \`scanResult\` / \`datasetId\` defensively at the start of every new attempt so stale state from a previous run cannot leak into the next one.

## Test plan

- [x] \`yarn vitest run src/pages/__tests__/UploadPage.test.tsx\` — 5/5 passing
- [x] \`yarn tsc --noEmit\` — clean
- [x] Reproduce duplicate → "Upload another file" → verify drop zone shows
- [ ] Try sequences that leave stale state (multiple uploads in quick succession, failed upload then retry) and confirm the card always returns to a fresh idle state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of upload session cleanup to prevent interference from previous operations when starting new uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->