### PR TITLE
fix: accept zipped shapefiles with multiple .shp layers

### DIFF
--- a/ingestion/src/services/pipeline.py
+++ b/ingestion/src/services/pipeline.py
@@ -690,9 +690,15 @@ def _convert_vector_to_geoparquet(input_path: str, output_path: str) -> None:
                         shp_paths.append(os.path.join(root, f))
             if not shp_paths:
                 raise FileNotFoundError(f"No .shp file found inside {input_path}")
+            shp_paths.sort()
             if len(shp_paths) > 1:
-                raise ValueError(
-                    f"Expected one .shp file inside {input_path}, found {len(shp_paths)}"
+                others = [os.path.basename(p) for p in shp_paths[1:]]
+                logger.warning(
+                    "Zip %s contains %d shapefiles; ingesting %s (ignored: %s)",
+                    input_path,
+                    len(shp_paths),
+                    os.path.basename(shp_paths[0]),
+                    ", ".join(others),
                 )
             gdf = gpd.read_file(shp_paths[0])
     else:


### PR DESCRIPTION
## Summary

Fixes #180. PR #172 tightened the zipped-shapefile handler to reject archives containing more than one \`.shp\` file, after CodeRabbit flagged the old "pick the first" behavior as ambiguous. Real-world multi-layer zips (Natural Earth admin bundles, etc.) legitimately contain several shapefiles, and the previous behavior worked for them.

## Fix

Go back to picking a single \`.shp\` per upload, but deterministically: sort the candidates alphabetically and take the first. Log a warning listing the other layers so operators can see exactly which file was chosen and which were ignored.

Full multi-layer support (layer picker UI, or one dataset per layer) is a larger follow-up.

## Test plan

- [x] ruff check/format clean
- [ ] Re-upload the failing zip from #180 and confirm conversion succeeds
- [ ] Verify the warning log shows the ignored layer names

🤖 Generated with [Claude Code](https://claude.com/claude-code)