### PR TITLE
feat: connect curated source.coop directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,7 @@ cd ingestion && uv run pytest -v
 - `GET /api/jobs/{id}/stream` — SSE stream of conversion progress
 - `GET /api/datasets` — List all converted datasets
 - `GET /api/datasets/{id}` — Get dataset metadata (includes `tile_url`)
+- `POST /api/connect-source-coop` — Register a curated source.coop product as a zero-copy pgSTAC collection (v1 products: `ghrsst-mur-v2-2024`, `gebco-2024`, `lg-land-carbon`)
 - `GET /api/health` — Health check
 
 ### Conversion pipeline

--- a/frontend/public/thumbnails/gebco.jpg
+++ b/frontend/public/thumbnails/gebco.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/public/thumbnails/ghrsst.jpg
+++ b/frontend/public/thumbnails/ghrsst.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/public/thumbnails/lg-land-carbon.jpg
+++ b/frontend/public/thumbnails/lg-land-carbon.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/src/components/SourceCoopConnectModal.tsx
+++ b/frontend/src/components/SourceCoopConnectModal.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Box, Button, Flex, Heading, Text } from "@chakra-ui/react";
+import { X as XIcon, SpinnerGap } from "@phosphor-icons/react";
+import { getProduct } from "../lib/sourceCoopCatalog";
+import { connectSourceCoop } from "../lib/sourceCoopApi";
+import { useWorkspace } from "../hooks/useWorkspace";
+
+interface SourceCoopConnectModalProps {
+  slug: string | null;
+  workspaceId: string;
+  onClose: () => void;
+}
+
+export function SourceCoopConnectModal({
+  slug,
+  workspaceId,
+  onClose,
+}: SourceCoopConnectModalProps) {
+  const navigate = useNavigate();
+  const { workspacePath } = useWorkspace();
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!slug) return null;
+
+  const product = getProduct(slug);
+
+  async function handleConfirm() {
+    if (!slug) return;
+    setError(null);
+    setConnecting(true);
+    try {
+      const { dataset_id } = await connectSourceCoop(slug, workspaceId);
+      navigate(workspacePath(`/map/${dataset_id}`));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  return (
+    <Box
+      position="fixed"
+      inset={0}
+      zIndex={1000}
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Box
+        position="absolute"
+        inset={0}
+        bg="blackAlpha.500"
+        onClick={connecting ? undefined : onClose}
+      />
+
+      <Box
+        position="relative"
+        bg="white"
+        borderRadius="12px"
+        shadow="xl"
+        w="480px"
+        maxW="90vw"
+        p={6}
+      >
+        <Flex justify="space-between" align="center" mb={4}>
+          <Heading size="md">Connect this dataset to your workspace?</Heading>
+          <Box
+            as="button"
+            onClick={onClose}
+            p={1}
+            cursor="pointer"
+            disabled={connecting}
+          >
+            <XIcon size={18} />
+          </Box>
+        </Flex>
+
+        <Flex direction="column" gap={3}>
+          <Text fontWeight={700} fontSize="15px">
+            {product.name}
+          </Text>
+          <Text fontSize="13px" color="brand.brown">
+            {product.description}
+          </Text>
+          <Text fontSize="12px" color="brand.textSecondary">
+            We&rsquo;ll register this as a reference in your workspace &mdash;
+            no files are copied. This can take up to a minute.
+          </Text>
+
+          {error && (
+            <Text fontSize="13px" color="red.500">
+              {error}
+            </Text>
+          )}
+
+          <Flex justify="flex-end" gap={2} mt={2}>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onClose}
+              disabled={connecting}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              bg="brand.orange"
+              color="white"
+              _hover={{ bg: "brand.orangeHover" }}
+              onClick={handleConfirm}
+              disabled={connecting}
+            >
+              {connecting ? (
+                <Flex align="center" gap={2}>
+                  <SpinnerGap
+                    size={16}
+                    style={{ animation: "spin 1s linear infinite" }}
+                  />
+                  <Text as="span">Connecting&hellip;</Text>
+                </Flex>
+              ) : (
+                "Connect"
+              )}
+            </Button>
+          </Flex>
+        </Flex>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/SourceCoopConnectModal.tsx
+++ b/frontend/src/components/SourceCoopConnectModal.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Box, Button, Flex, Heading, Text } from "@chakra-ui/react";
 import { X as XIcon, SpinnerGap } from "@phosphor-icons/react";
-import { getProduct } from "../lib/sourceCoopCatalog";
+import { getProduct, type SourceCoopProduct } from "../lib/sourceCoopCatalog";
 import { connectSourceCoop } from "../lib/sourceCoopApi";
 import { useWorkspace } from "../hooks/useWorkspace";
 
@@ -24,7 +24,12 @@ export function SourceCoopConnectModal({
 
   if (!slug) return null;
 
-  const product = getProduct(slug);
+  let product: SourceCoopProduct;
+  try {
+    product = getProduct(slug);
+  } catch {
+    return null;
+  }
 
   async function handleConfirm() {
     if (!slug) return;
@@ -67,15 +72,20 @@ export function SourceCoopConnectModal({
       >
         <Flex justify="space-between" align="center" mb={4}>
           <Heading size="md">Connect this dataset to your workspace?</Heading>
-          <Box
-            as="button"
+          <button
+            type="button"
             onClick={onClose}
-            p={1}
-            cursor="pointer"
             disabled={connecting}
+            aria-label="Close"
+            style={{
+              padding: "4px",
+              cursor: connecting ? "not-allowed" : "pointer",
+              background: "transparent",
+              border: "none",
+            }}
           >
             <XIcon size={18} />
-          </Box>
+          </button>
         </Flex>
 
         <Flex direction="column" gap={3}>
@@ -98,6 +108,7 @@ export function SourceCoopConnectModal({
 
           <Flex justify="flex-end" gap={2} mt={2}>
             <Button
+              type="button"
               size="sm"
               variant="ghost"
               onClick={onClose}
@@ -106,6 +117,7 @@ export function SourceCoopConnectModal({
               Cancel
             </Button>
             <Button
+              type="button"
               size="sm"
               bg="brand.orange"
               color="white"

--- a/frontend/src/components/SourceCoopGallery.tsx
+++ b/frontend/src/components/SourceCoopGallery.tsx
@@ -20,7 +20,11 @@ export function SourceCoopGallery({ onSelect }: SourceCoopGalleryProps) {
   return (
     <Box as="section" py={8}>
       <Flex align="center" gap={2} mb={2}>
-        <Globe size={24} weight="duotone" color="var(--chakra-colors-brand-orange)" />
+        <Globe
+          size={24}
+          weight="duotone"
+          color="var(--chakra-colors-brand-orange)"
+        />
         <Heading
           as="h2"
           fontSize="20px"

--- a/frontend/src/components/SourceCoopGallery.tsx
+++ b/frontend/src/components/SourceCoopGallery.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { Box, Flex, Heading, SimpleGrid, Text } from "@chakra-ui/react";
+import { Globe } from "@phosphor-icons/react";
+import {
+  sourceCoopCatalog,
+  type SourceCoopProduct,
+} from "../lib/sourceCoopCatalog";
+import {
+  cardHover,
+  cardActive,
+  focusRing,
+  transition,
+} from "../lib/interactionStyles";
+
+interface SourceCoopGalleryProps {
+  onSelect: (slug: string) => void;
+}
+
+export function SourceCoopGallery({ onSelect }: SourceCoopGalleryProps) {
+  return (
+    <Box as="section" py={8}>
+      <Flex align="center" gap={2} mb={2}>
+        <Globe size={24} weight="duotone" color="var(--chakra-colors-brand-orange)" />
+        <Heading
+          as="h2"
+          fontSize="20px"
+          fontWeight={700}
+          color="brand.brown"
+          letterSpacing="-0.02em"
+        >
+          Start with source.coop
+        </Heading>
+      </Flex>
+      <Text fontSize="14px" color="brand.textSecondary" mb={5}>
+        Jump straight into exploring real datasets. Pick one to begin.
+      </Text>
+
+      <SimpleGrid columns={{ base: 1, md: 3 }} gap={5}>
+        {sourceCoopCatalog.map((product) => (
+          <ProductCard
+            key={product.slug}
+            product={product}
+            onClick={() => onSelect(product.slug)}
+          />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}
+
+interface ProductCardProps {
+  product: SourceCoopProduct;
+  onClick: () => void;
+}
+
+function ProductCard({ product, onClick }: ProductCardProps) {
+  const [imageBroken, setImageBroken] = useState(false);
+  const fallbackLetter = product.name.charAt(0).toUpperCase();
+
+  return (
+    <Box
+      as="button"
+      onClick={onClick}
+      tabIndex={0}
+      border="2px solid"
+      borderColor="brand.border"
+      borderRadius="16px"
+      overflow="hidden"
+      bg="white"
+      textAlign="left"
+      cursor="pointer"
+      transition={transition(200)}
+      _hover={cardHover}
+      _active={cardActive}
+      _focusVisible={focusRing}
+      width="100%"
+      display="block"
+    >
+      <Box
+        h="140px"
+        bg="brand.bgSubtle"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        overflow="hidden"
+      >
+        {imageBroken ? (
+          <Flex
+            align="center"
+            justify="center"
+            w="100%"
+            h="100%"
+            bg="brand.brown"
+            color="white"
+            fontSize="48px"
+            fontWeight={700}
+            letterSpacing="-0.04em"
+          >
+            {fallbackLetter}
+          </Flex>
+        ) : (
+          <img
+            src={product.thumbnail}
+            alt={product.name}
+            onError={() => setImageBroken(true)}
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+          />
+        )}
+      </Box>
+      <Box p={4}>
+        <Text
+          fontSize="15px"
+          fontWeight={700}
+          color="brand.brown"
+          mb={1.5}
+          letterSpacing="-0.02em"
+        >
+          {product.name}
+        </Text>
+        <Text fontSize="13px" color="brand.textSecondary" lineHeight={1.5}>
+          {product.description}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/__tests__/SourceCoopConnectModal.test.tsx
+++ b/frontend/src/components/__tests__/SourceCoopConnectModal.test.tsx
@@ -11,7 +11,7 @@ const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
   const actual =
     await vi.importActual<typeof import("react-router-dom")>(
-      "react-router-dom",
+      "react-router-dom"
     );
   return { ...actual, useNavigate: () => mockNavigate };
 });
@@ -32,7 +32,7 @@ function renderWithProviders(ui: React.ReactElement) {
           />
         </Routes>
       </MemoryRouter>
-    </ChakraProvider>,
+    </ChakraProvider>
   );
 }
 
@@ -44,11 +44,7 @@ describe("SourceCoopConnectModal", () => {
 
   it("does not render when slug is null", () => {
     renderWithProviders(
-      <SourceCoopConnectModal
-        slug={null}
-        onClose={vi.fn()}
-        workspaceId="abc"
-      />,
+      <SourceCoopConnectModal slug={null} onClose={vi.fn()} workspaceId="abc" />
     );
     expect(screen.queryByText(/Connect this dataset/i)).toBeNull();
   });
@@ -59,7 +55,7 @@ describe("SourceCoopConnectModal", () => {
         slug="alexgleith/gebco-2024"
         onClose={vi.fn()}
         workspaceId="abc"
-      />,
+      />
     );
     expect(screen.getByText(/GEBCO/i)).toBeTruthy();
   });
@@ -75,7 +71,7 @@ describe("SourceCoopConnectModal", () => {
         slug="alexgleith/gebco-2024"
         onClose={vi.fn()}
         workspaceId="abc"
-      />,
+      />
     );
 
     fireEvent.click(screen.getByRole("button", { name: /^Connect$/i }));
@@ -95,7 +91,7 @@ describe("SourceCoopConnectModal", () => {
         slug="alexgleith/gebco-2024"
         onClose={vi.fn()}
         workspaceId="abc"
-      />,
+      />
     );
 
     fireEvent.click(screen.getByRole("button", { name: /^Connect$/i }));

--- a/frontend/src/components/__tests__/SourceCoopConnectModal.test.tsx
+++ b/frontend/src/components/__tests__/SourceCoopConnectModal.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ChakraProvider } from "@chakra-ui/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { system } from "../../theme";
+import { SourceCoopConnectModal } from "../SourceCoopConnectModal";
+import { WorkspaceProvider } from "../../hooks/useWorkspace";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockConnect = vi.fn();
+vi.mock("../../lib/sourceCoopApi", () => ({
+  connectSourceCoop: (...args: unknown[]) => mockConnect(...args),
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <ChakraProvider value={system}>
+      <MemoryRouter initialEntries={["/w/abc"]}>
+        <Routes>
+          <Route
+            path="/w/:workspaceId/*"
+            element={<WorkspaceProvider>{ui}</WorkspaceProvider>}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ChakraProvider>,
+  );
+}
+
+describe("SourceCoopConnectModal", () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockConnect.mockReset();
+  });
+
+  it("does not render when slug is null", () => {
+    renderWithProviders(
+      <SourceCoopConnectModal
+        slug={null}
+        onClose={vi.fn()}
+        workspaceId="abc"
+      />,
+    );
+    expect(screen.queryByText(/Connect this dataset/i)).toBeNull();
+  });
+
+  it("shows product name when slug is set", () => {
+    renderWithProviders(
+      <SourceCoopConnectModal
+        slug="alexgleith/gebco-2024"
+        onClose={vi.fn()}
+        workspaceId="abc"
+      />,
+    );
+    expect(screen.getByText(/GEBCO/i)).toBeTruthy();
+  });
+
+  it("calls connectSourceCoop and navigates on confirm", async () => {
+    mockConnect.mockResolvedValueOnce({
+      dataset_id: "ds-1",
+      job_id: "job-1",
+    });
+
+    renderWithProviders(
+      <SourceCoopConnectModal
+        slug="alexgleith/gebco-2024"
+        onClose={vi.fn()}
+        workspaceId="abc"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Connect$/i }));
+
+    await waitFor(() => {
+      expect(mockConnect).toHaveBeenCalledWith("alexgleith/gebco-2024", "abc");
+      expect(mockNavigate).toHaveBeenCalled();
+      expect(mockNavigate.mock.calls[0][0]).toContain("ds-1");
+    });
+  });
+
+  it("shows an error message if the API call fails", async () => {
+    mockConnect.mockRejectedValueOnce(new Error("source.coop unreachable"));
+
+    renderWithProviders(
+      <SourceCoopConnectModal
+        slug="alexgleith/gebco-2024"
+        onClose={vi.fn()}
+        workspaceId="abc"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Connect$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/unreachable/i)).toBeTruthy();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/__tests__/SourceCoopGallery.test.tsx
+++ b/frontend/src/components/__tests__/SourceCoopGallery.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { SourceCoopGallery } from "../SourceCoopGallery";
+import { system } from "../../theme";
+
+function renderWithChakra(ui: React.ReactElement) {
+  return render(<ChakraProvider value={system}>{ui}</ChakraProvider>);
+}
+
+describe("SourceCoopGallery", () => {
+  it("renders a card for every product in the catalog", () => {
+    renderWithChakra(<SourceCoopGallery onSelect={vi.fn()} />);
+
+    expect(screen.getByText(/GHRSST/i)).toBeTruthy();
+    expect(screen.getByText(/GEBCO/i)).toBeTruthy();
+    expect(screen.getByText("Land & Carbon Lab Carbon Data")).toBeTruthy();
+  });
+
+  it("calls onSelect with the slug when a card is clicked", () => {
+    const onSelect = vi.fn();
+    renderWithChakra(<SourceCoopGallery onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByText(/GEBCO/i));
+
+    expect(onSelect).toHaveBeenCalledWith("alexgleith/gebco-2024");
+  });
+
+  it("renders a section heading", () => {
+    renderWithChakra(<SourceCoopGallery onSelect={vi.fn()} />);
+    expect(
+      screen.getByRole("heading", { name: /source\.coop/i }),
+    ).toBeTruthy();
+  });
+
+  it("falls back when a thumbnail fails to load", () => {
+    renderWithChakra(<SourceCoopGallery onSelect={vi.fn()} />);
+    const images = screen.getAllByRole("img");
+    expect(images.length).toBeGreaterThan(0);
+    fireEvent.error(images[0]);
+  });
+});

--- a/frontend/src/components/__tests__/SourceCoopGallery.test.tsx
+++ b/frontend/src/components/__tests__/SourceCoopGallery.test.tsx
@@ -28,9 +28,7 @@ describe("SourceCoopGallery", () => {
 
   it("renders a section heading", () => {
     renderWithChakra(<SourceCoopGallery onSelect={vi.fn()} />);
-    expect(
-      screen.getByRole("heading", { name: /source\.coop/i }),
-    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /source\.coop/i })).toBeTruthy();
   });
 
   it("falls back when a thumbnail fails to load", () => {

--- a/frontend/src/lib/__tests__/sourceCoopApi.test.ts
+++ b/frontend/src/lib/__tests__/sourceCoopApi.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach, Mock } from "vitest";
 import { connectSourceCoop } from "../sourceCoopApi";
 
 describe("connectSourceCoop", () => {
   const originalFetch = global.fetch;
+  let mockFetch: Mock;
 
   beforeEach(() => {
-    global.fetch = vi.fn();
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
   });
 
   afterEach(() => {
@@ -13,15 +15,15 @@ describe("connectSourceCoop", () => {
   });
 
   it("posts the product slug with workspace header", async () => {
-    (global.fetch as any).mockResolvedValueOnce({
+    mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ dataset_id: "abc", job_id: "xyz" }),
     });
 
     const result = await connectSourceCoop("alexgleith/gebco-2024", "deadbeef");
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    const [url, init] = (global.fetch as any).mock.calls[0];
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
     expect(url).toBe("/api/connect-source-coop");
     expect(init.method).toBe("POST");
     expect(init.headers["Content-Type"]).toBe("application/json");
@@ -34,7 +36,7 @@ describe("connectSourceCoop", () => {
   });
 
   it("throws with the detail message on non-ok response", async () => {
-    (global.fetch as any).mockResolvedValueOnce({
+    mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 502,
       statusText: "Bad Gateway",
@@ -47,7 +49,7 @@ describe("connectSourceCoop", () => {
   });
 
   it("throws a fallback message when the response body has no detail", async () => {
-    (global.fetch as any).mockResolvedValueOnce({
+    mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
       statusText: "Internal Server Error",

--- a/frontend/src/lib/__tests__/sourceCoopApi.test.ts
+++ b/frontend/src/lib/__tests__/sourceCoopApi.test.ts
@@ -29,7 +29,7 @@ describe("connectSourceCoop", () => {
     expect(init.headers["Content-Type"]).toBe("application/json");
     expect(init.headers["X-Workspace-Id"]).toBe("deadbeef");
     expect(init.body).toBe(
-      JSON.stringify({ product_slug: "alexgleith/gebco-2024" }),
+      JSON.stringify({ product_slug: "alexgleith/gebco-2024" })
     );
 
     expect(result).toEqual({ dataset_id: "abc", job_id: "xyz" });
@@ -44,7 +44,7 @@ describe("connectSourceCoop", () => {
     });
 
     await expect(
-      connectSourceCoop("alexgleith/gebco-2024", "deadbeef"),
+      connectSourceCoop("alexgleith/gebco-2024", "deadbeef")
     ).rejects.toThrow(/source.coop unreachable/);
   });
 
@@ -59,7 +59,7 @@ describe("connectSourceCoop", () => {
     });
 
     await expect(
-      connectSourceCoop("alexgleith/gebco-2024", "deadbeef"),
+      connectSourceCoop("alexgleith/gebco-2024", "deadbeef")
     ).rejects.toThrow();
   });
 });

--- a/frontend/src/lib/__tests__/sourceCoopApi.test.ts
+++ b/frontend/src/lib/__tests__/sourceCoopApi.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { connectSourceCoop } from "../sourceCoopApi";
+
+describe("connectSourceCoop", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("posts the product slug with workspace header", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ dataset_id: "abc", job_id: "xyz" }),
+    });
+
+    const result = await connectSourceCoop("alexgleith/gebco-2024", "deadbeef");
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (global.fetch as any).mock.calls[0];
+    expect(url).toBe("/api/connect-source-coop");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(init.headers["X-Workspace-Id"]).toBe("deadbeef");
+    expect(init.body).toBe(
+      JSON.stringify({ product_slug: "alexgleith/gebco-2024" }),
+    );
+
+    expect(result).toEqual({ dataset_id: "abc", job_id: "xyz" });
+  });
+
+  it("throws with the detail message on non-ok response", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      json: async () => ({ detail: "source.coop unreachable" }),
+    });
+
+    await expect(
+      connectSourceCoop("alexgleith/gebco-2024", "deadbeef"),
+    ).rejects.toThrow(/source.coop unreachable/);
+  });
+
+  it("throws a fallback message when the response body has no detail", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: async () => {
+        throw new Error("not json");
+      },
+    });
+
+    await expect(
+      connectSourceCoop("alexgleith/gebco-2024", "deadbeef"),
+    ).rejects.toThrow();
+  });
+});

--- a/frontend/src/lib/__tests__/sourceCoopCatalog.test.ts
+++ b/frontend/src/lib/__tests__/sourceCoopCatalog.test.ts
@@ -10,7 +10,7 @@ describe("sourceCoopCatalog", () => {
         "ausantarctic/ghrsst-mur-v2",
         "alexgleith/gebco-2024",
         "vizzuality/lg-land-carbon-data",
-      ]),
+      ])
     );
   });
 

--- a/frontend/src/lib/__tests__/sourceCoopCatalog.test.ts
+++ b/frontend/src/lib/__tests__/sourceCoopCatalog.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { sourceCoopCatalog, getProduct } from "../sourceCoopCatalog";
+
+describe("sourceCoopCatalog", () => {
+  it("has exactly three v1 entries", () => {
+    expect(sourceCoopCatalog).toHaveLength(3);
+    const slugs = sourceCoopCatalog.map((p) => p.slug);
+    expect(slugs).toEqual(
+      expect.arrayContaining([
+        "ausantarctic/ghrsst-mur-v2",
+        "alexgleith/gebco-2024",
+        "vizzuality/lg-land-carbon-data",
+      ]),
+    );
+  });
+
+  it("every product has a name, description, thumbnail, and tags", () => {
+    for (const p of sourceCoopCatalog) {
+      expect(p.name).toBeTruthy();
+      expect(p.description).toBeTruthy();
+      expect(p.thumbnail).toBeTruthy();
+      expect(Array.isArray(p.tags)).toBe(true);
+    }
+  });
+
+  it("getProduct returns the matching entry", () => {
+    const p = getProduct("alexgleith/gebco-2024");
+    expect(p.name).toContain("GEBCO");
+  });
+
+  it("getProduct throws for unknown slug", () => {
+    expect(() => getProduct("nobody/nothing")).toThrow();
+  });
+
+  it("GHRSST is marked temporal", () => {
+    const p = getProduct("ausantarctic/ghrsst-mur-v2");
+    expect(p.isTemporal).toBe(true);
+  });
+
+  it("GEBCO and lg-land-carbon-data are not temporal", () => {
+    expect(getProduct("alexgleith/gebco-2024").isTemporal).toBe(false);
+    expect(getProduct("vizzuality/lg-land-carbon-data").isTemporal).toBe(false);
+  });
+});

--- a/frontend/src/lib/sourceCoopApi.ts
+++ b/frontend/src/lib/sourceCoopApi.ts
@@ -9,7 +9,7 @@ export interface ConnectSourceCoopResponse {
 
 export async function connectSourceCoop(
   productSlug: string,
-  workspaceId: string,
+  workspaceId: string
 ): Promise<ConnectSourceCoopResponse> {
   const resp = await fetch("/api/connect-source-coop", {
     method: "POST",

--- a/frontend/src/lib/sourceCoopApi.ts
+++ b/frontend/src/lib/sourceCoopApi.ts
@@ -1,0 +1,35 @@
+/**
+ * API client for the source.coop curated connection endpoint.
+ */
+
+export interface ConnectSourceCoopResponse {
+  dataset_id: string;
+  job_id: string;
+}
+
+export async function connectSourceCoop(
+  productSlug: string,
+  workspaceId: string,
+): Promise<ConnectSourceCoopResponse> {
+  const resp = await fetch("/api/connect-source-coop", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Workspace-Id": workspaceId,
+    },
+    body: JSON.stringify({ product_slug: productSlug }),
+  });
+
+  if (!resp.ok) {
+    let detail: string;
+    try {
+      const body = await resp.json();
+      detail = body?.detail ?? `Request failed: ${resp.status}`;
+    } catch {
+      detail = `Request failed: ${resp.status}`;
+    }
+    throw new Error(detail);
+  }
+
+  return resp.json();
+}

--- a/frontend/src/lib/sourceCoopCatalog.ts
+++ b/frontend/src/lib/sourceCoopCatalog.ts
@@ -1,0 +1,51 @@
+/**
+ * Frontend-side mirror of the source.coop curated product registry.
+ * Kept in sync manually with ingestion/src/services/source_coop_config.py.
+ */
+
+export interface SourceCoopProduct {
+  slug: string;
+  name: string;
+  description: string;
+  thumbnail: string;
+  tags: string[];
+  isTemporal: boolean;
+}
+
+export const sourceCoopCatalog: SourceCoopProduct[] = [
+  {
+    slug: "ausantarctic/ghrsst-mur-v2",
+    name: "GHRSST MUR v2 — Daily SST (2024)",
+    description:
+      "Multi-scale Ultra-high Resolution sea surface temperature analysis, daily global coverage. v1 shows the 2024 subset (~365 days).",
+    thumbnail: "/thumbnails/ghrsst.jpg",
+    tags: ["ocean", "temperature", "temporal"],
+    isTemporal: true,
+  },
+  {
+    slug: "alexgleith/gebco-2024",
+    name: "GEBCO 2024 Bathymetry",
+    description:
+      "Global ocean and land terrain model from the General Bathymetric Chart of the Oceans, 2024 release.",
+    thumbnail: "/thumbnails/gebco.jpg",
+    tags: ["bathymetry", "terrain", "global"],
+    isTemporal: false,
+  },
+  {
+    slug: "vizzuality/lg-land-carbon-data",
+    name: "Land & Carbon Lab Carbon Data",
+    description:
+      "Land carbon flux and stock rasters produced by the WRI Land & Carbon Lab.",
+    thumbnail: "/thumbnails/lg-land-carbon.jpg",
+    tags: ["carbon", "land", "climate"],
+    isTemporal: false,
+  },
+];
+
+export function getProduct(slug: string): SourceCoopProduct {
+  const product = sourceCoopCatalog.find((p) => p.slug === slug);
+  if (!product) {
+    throw new Error(`Unknown source.coop product slug: ${slug}`);
+  }
+  return product;
+}

--- a/frontend/src/lib/sourceCoopCatalog.ts
+++ b/frontend/src/lib/sourceCoopCatalog.ts
@@ -17,7 +17,7 @@ export const sourceCoopCatalog: SourceCoopProduct[] = [
     slug: "ausantarctic/ghrsst-mur-v2",
     name: "GHRSST MUR v2 — Daily SST (2024)",
     description:
-      "Multi-scale Ultra-high Resolution sea surface temperature analysis, daily global coverage. v1 shows the 2024 subset (~365 days).",
+      "Multi-scale Ultra-high Resolution sea surface temperature analysis, daily global coverage. v1 shows the 2024 subset (366 days).",
     thumbnail: "/thumbnails/ghrsst.jpg",
     tags: ["ocean", "temperature", "temporal"],
     isTemporal: true,

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -12,6 +12,8 @@ import { DuplicateWarning } from "../components/DuplicateWarning";
 import { BugReportModal } from "../components/BugReportModal";
 import { InlineConnectionForm } from "../components/InlineConnectionForm";
 import { RemoteConnectFlow } from "../components/RemoteConnectFlow";
+import { SourceCoopGallery } from "../components/SourceCoopGallery";
+import { SourceCoopConnectModal } from "../components/SourceCoopConnectModal";
 import {
   FolderOpen,
   GlobeHemisphereWest,
@@ -32,7 +34,8 @@ type PageMode =
 
 export default function UploadPage() {
   const navigate = useNavigate();
-  const { workspacePath } = useWorkspace();
+  const { workspacePath, workspaceId } = useWorkspace();
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const {
     state,
     startUpload,
@@ -334,6 +337,14 @@ export default function UploadPage() {
           </Box>
         </PathCard>
       </Flex>
+
+      <SourceCoopGallery onSelect={setSelectedSlug} />
+
+      <SourceCoopConnectModal
+        slug={selectedSlug}
+        workspaceId={workspaceId}
+        onClose={() => setSelectedSlug(null)}
+      />
 
       <BugReportModal
         open={reportOpen}

--- a/ingestion/src/app.py
+++ b/ingestion/src/app.py
@@ -124,6 +124,7 @@ def create_app(settings=None, lifespan=None) -> FastAPI:
 
     from src.routes.bug_report import router as bug_report_router
     from src.routes.connect_remote import router as connect_remote_router
+    from src.routes.connect_source_coop import router as connect_source_coop_router
     from src.routes.connections import router as connections_router
     from src.routes.datasets import router as datasets_router
     from src.routes.jobs import router as jobs_router
@@ -139,6 +140,7 @@ def create_app(settings=None, lifespan=None) -> FastAPI:
     app.include_router(connections_router)
     app.include_router(proxy_router)
     app.include_router(connect_remote_router)
+    app.include_router(connect_source_coop_router)
 
     return app
 

--- a/ingestion/src/routes/connect_source_coop.py
+++ b/ingestion/src/routes/connect_source_coop.py
@@ -40,6 +40,7 @@ async def run_enumerator(product: SourceCoopProduct) -> list[RemoteItem]:
         return await enumerate_stac_sidecars(
             listing_url=product.listing_url,
             recursive=product.enumerator_args.get("recursive", False),
+            start_prefix=product.enumerator_args.get("start_prefix", ""),
         )
     raise ValueError(f"Unknown enumerator: {product.enumerator}")
 

--- a/ingestion/src/routes/connect_source_coop.py
+++ b/ingestion/src/routes/connect_source_coop.py
@@ -1,0 +1,84 @@
+"""Route for connecting a curated source.coop product as a zero-copy dataset."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from src.models import Job
+from src.services.enumerators import RemoteItem
+from src.services.enumerators.path_listing import enumerate_path_listing
+from src.services.enumerators.stac_sidecars import enumerate_stac_sidecars
+from src.services.remote_register import (
+    RemoteRegistrationError,
+    register_remote_collection,
+)
+from src.services.source_coop_config import SourceCoopProduct, get_product
+from src.state import jobs
+from src.workspace import get_workspace_id
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api")
+
+
+class ConnectSourceCoopRequest(BaseModel):
+    product_slug: str
+
+
+class ConnectSourceCoopResponse(BaseModel):
+    dataset_id: str
+    job_id: str
+
+
+async def run_enumerator(product: SourceCoopProduct) -> list[RemoteItem]:
+    """Dispatch to the enumerator named in the product config."""
+    if product.enumerator == "path_listing":
+        return await enumerate_path_listing(listing_url=product.listing_url)
+    if product.enumerator == "stac_sidecars":
+        return await enumerate_stac_sidecars(
+            listing_url=product.listing_url,
+            recursive=product.enumerator_args.get("recursive", False),
+        )
+    raise ValueError(f"Unknown enumerator: {product.enumerator}")
+
+
+@router.post("/connect-source-coop", response_model=ConnectSourceCoopResponse)
+async def connect_source_coop(
+    request: Request,
+    body: ConnectSourceCoopRequest,
+    workspace_id: str = Depends(get_workspace_id),
+):
+    try:
+        product = get_product(body.product_slug)
+    except KeyError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Product {body.product_slug!r} not found in curated registry",
+        ) from e
+
+    job = Job(filename=product.name)
+    job.workspace_id = workspace_id
+    jobs[job.id] = job
+
+    try:
+        items = await run_enumerator(product)
+    except Exception as e:
+        logger.exception("Enumeration failed for %s", product.slug)
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to enumerate source.coop product: {e}",
+        ) from e
+
+    try:
+        dataset_id = await register_remote_collection(
+            job=job,
+            product=product,
+            items=items,
+            db_session_factory=request.app.state.db_session_factory,
+        )
+    except RemoteRegistrationError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    return ConnectSourceCoopResponse(dataset_id=dataset_id, job_id=job.id)

--- a/ingestion/src/services/discovery.py
+++ b/ingestion/src/services/discovery.py
@@ -51,20 +51,43 @@ def extract_file_links(html: str, base_url: str) -> list[DiscoveredFile]:
 
 
 def _parse_s3_listing(xml_text: str, base_url: str) -> list[DiscoveredFile]:
-    """Parse an S3 ListBucket XML response and return geospatial file links."""
+    """Parse an S3 ListBucket XML response and return geospatial file links.
+
+    S3 ListBucket responses return object keys relative to the bucket. When the
+    listing is served under a URL like ``https://host/bucket/prefix/`` (e.g.
+    source.coop) the bucket name is part of the URL path, and the ``Name``
+    element in the XML holds the bucket. Absolute URLs for each object are
+    therefore ``origin + / + bucket + / + key``.
+
+    For listings served directly at the bucket root (e.g. ``https://bucket.s3
+    .amazonaws.com/``) the bucket is the host and keys stand alone, so we fall
+    back to ``origin + / + key``.
+    """
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
         soup = BeautifulSoup(xml_text, "html.parser")
     origin = _origin(base_url)
     seen: dict[str, DiscoveredFile] = {}
 
+    parsed_base = urlparse(base_url)
+    base_path_segments = [seg for seg in parsed_base.path.split("/") if seg]
+
+    name_tag = soup.find("name")
+    bucket = name_tag.get_text().strip() if name_tag else ""
+    bucket_in_path = bool(
+        bucket and base_path_segments and base_path_segments[0] == bucket
+    )
+
     for key_tag in soup.find_all("key"):
         key = key_tag.get_text()
         ext = _get_extension(key)
         if ext not in _SUPPORTED_EXTENSIONS:
             continue
-        path = key if key.startswith("/") else f"/{key}"
-        absolute = origin + path
+        if bucket_in_path:
+            absolute = f"{origin}/{bucket}/{key}"
+        else:
+            path = key if key.startswith("/") else f"/{key}"
+            absolute = origin + path
         if absolute not in seen:
             seen[absolute] = DiscoveredFile(
                 url=absolute, filename=_filename_from_url(absolute)

--- a/ingestion/src/services/enumerators/__init__.py
+++ b/ingestion/src/services/enumerators/__init__.py
@@ -1,0 +1,29 @@
+"""Enumerators turn a source.coop product reference into a list of RemoteItems.
+
+Each enumerator is a strategy function: given product-specific args, it returns
+a list of RemoteItem describing the files in the product along with any
+available spatial and temporal metadata. The registration pipeline consumes
+this list and writes items into pgSTAC.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class RemoteItem:
+    """One file in a source.coop product, ready to register as a STAC item.
+
+    Attributes:
+        href: HTTPS URL of the file, typically under data.source.coop.
+        datetime: Datetime for temporal datasets, None for single-frame.
+        bbox: [west, south, east, north] in EPSG:4326, or None if unknown.
+            When None, callers must probe the COG to get bounds before
+            registering a pgSTAC item.
+    """
+
+    href: str
+    datetime: datetime | None
+    bbox: list[float] | None

--- a/ingestion/src/services/enumerators/path_listing.py
+++ b/ingestion/src/services/enumerators/path_listing.py
@@ -1,0 +1,22 @@
+"""path_listing enumerator: list a flat directory, return files as RemoteItems.
+
+No datetime. No bbox. The registration pipeline must probe each COG to compute
+its bounds before writing a pgSTAC item.
+"""
+
+from __future__ import annotations
+
+from src.services.discovery import fetch_and_discover
+from src.services.enumerators import RemoteItem
+
+
+async def enumerate_path_listing(listing_url: str) -> list[RemoteItem]:
+    """Enumerate files from a flat HTTP/S3 directory listing.
+
+    Args:
+        listing_url: URL returning an HTML index or S3 XML ListBucket response.
+    """
+    discovered = await fetch_and_discover(listing_url)
+    return [
+        RemoteItem(href=f.url, datetime=None, bbox=None) for f in discovered
+    ]

--- a/ingestion/src/services/enumerators/path_listing.py
+++ b/ingestion/src/services/enumerators/path_listing.py
@@ -30,8 +30,6 @@ async def enumerate_path_listing(listing_url: str) -> list[RemoteItem]:
     for key in keys:
         if key.lower().endswith(_RASTER_EXTENSIONS):
             items.append(
-                RemoteItem(
-                    href=urljoin(listing_url, key), datetime=None, bbox=None
-                )
+                RemoteItem(href=urljoin(listing_url, key), datetime=None, bbox=None)
             )
     return items

--- a/ingestion/src/services/enumerators/path_listing.py
+++ b/ingestion/src/services/enumerators/path_listing.py
@@ -1,22 +1,37 @@
-"""path_listing enumerator: list a flat directory, return files as RemoteItems.
+"""path_listing enumerator: list a flat S3 prefix, return files as RemoteItems.
 
 No datetime. No bbox. The registration pipeline must probe each COG to compute
 its bounds before writing a pgSTAC item.
+
+Unlike ``fetch_and_discover`` (which applies a "most common extension" filter
+that can accidentally drop the real data files when sidecars are tied), this
+enumerator does its own paginated S3 ListObjectsV2 call at a single prefix and
+keeps only files matching a whitelist of raster extensions.
 """
 
 from __future__ import annotations
 
-from src.services.discovery import fetch_and_discover
+from urllib.parse import urljoin
+
 from src.services.enumerators import RemoteItem
+from src.services.enumerators.stac_sidecars import _list_one_level
+
+_RASTER_EXTENSIONS = (".tif", ".tiff", ".nc", ".nc4", ".h5", ".hdf5")
 
 
 async def enumerate_path_listing(listing_url: str) -> list[RemoteItem]:
-    """Enumerate files from a flat HTTP/S3 directory listing.
+    """Enumerate raster files from a flat S3 prefix.
 
     Args:
-        listing_url: URL returning an HTML index or S3 XML ListBucket response.
+        listing_url: URL of the S3 prefix (e.g. ``https://host/bucket/prefix/``).
     """
-    discovered = await fetch_and_discover(listing_url)
-    return [
-        RemoteItem(href=f.url, datetime=None, bbox=None) for f in discovered
-    ]
+    _common, keys = await _list_one_level(listing_url, prefix="")
+    items: list[RemoteItem] = []
+    for key in keys:
+        if key.lower().endswith(_RASTER_EXTENSIONS):
+            items.append(
+                RemoteItem(
+                    href=urljoin(listing_url, key), datetime=None, bbox=None
+                )
+            )
+    return items

--- a/ingestion/src/services/enumerators/stac_sidecars.py
+++ b/ingestion/src/services/enumerators/stac_sidecars.py
@@ -90,11 +90,17 @@ async def _read_sidecar(client: httpx.AsyncClient, url: str) -> RemoteItem | Non
 
 
 async def enumerate_stac_sidecars(
-    listing_url: str, recursive: bool = False
+    listing_url: str, recursive: bool = False, start_prefix: str = ""
 ) -> list[RemoteItem]:
-    """Enumerate sidecar-backed items under a listing URL."""
+    """Enumerate sidecar-backed items under a listing URL.
+
+    When ``recursive`` is true, ``start_prefix`` limits the walk to a subtree
+    (e.g. ``"2024/"`` to only ingest 2024 data). Ignored in flat mode.
+    """
     if recursive:
-        sidecar_urls = await _list_sidecars_recursive(listing_url)
+        sidecar_urls = await _list_sidecars_recursive(
+            listing_url, start_prefix=start_prefix
+        )
     else:
         sidecar_urls = await list_sidecars(listing_url)
 
@@ -188,11 +194,15 @@ async def _list_one_level(
 
 
 async def _list_sidecars_recursive(
-    listing_url: str, max_depth: int = 10
+    listing_url: str, max_depth: int = 10, start_prefix: str = ""
 ) -> list[str]:
-    """Walk nested bucket prefixes and return all sidecar URLs found."""
+    """Walk nested bucket prefixes and return all sidecar URLs found.
+
+    ``start_prefix`` sets the starting point for the walk. Defaults to ``""``
+    (the product root). Pass e.g. ``"2024/"`` to only walk under that prefix.
+    """
     sidecar_urls: list[str] = []
-    stack: list[tuple[str, int]] = [("", 0)]
+    stack: list[tuple[str, int]] = [(start_prefix, 0)]
 
     while stack:
         prefix, depth = stack.pop()

--- a/ingestion/src/services/enumerators/stac_sidecars.py
+++ b/ingestion/src/services/enumerators/stac_sidecars.py
@@ -1,0 +1,107 @@
+"""stac_sidecars enumerator: find colocated .stac-item.json files and read them.
+
+Two modes:
+    - Flat: list a single directory, read every .stac-item.json found there.
+    - Recursive: walk nested prefixes (e.g. YYYY/MM/DD/), reading sidecars at
+      each leaf. Used for products like GHRSST MUR v2.
+
+Each sidecar must contain an asset with role 'data' or (failing that) the
+first asset whose href ends in .tif or .tiff. The asset href, properties.datetime,
+and bbox are extracted and returned as a RemoteItem.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from urllib.parse import urljoin
+
+import httpx
+
+from src.services.discovery import fetch_and_discover
+from src.services.enumerators import RemoteItem
+
+logger = logging.getLogger(__name__)
+
+SIDECAR_SUFFIX = ".stac-item.json"
+
+
+async def list_sidecars(listing_url: str) -> list[str]:
+    """List sidecar JSON URLs in a single directory using fetch_and_discover."""
+    discovered = await fetch_and_discover(listing_url)
+    return [f.url for f in discovered if f.url.endswith(SIDECAR_SUFFIX)]
+
+
+def _resolve_asset_href(sidecar_url: str, relative_href: str) -> str:
+    """Resolve a possibly-relative asset href against the sidecar URL."""
+    if relative_href.startswith(("http://", "https://")):
+        return relative_href
+    return urljoin(sidecar_url, relative_href)
+
+
+def _pick_data_asset(sidecar: dict) -> dict | None:
+    """Return the asset dict for the primary data asset, or None."""
+    assets = sidecar.get("assets", {})
+    for name, asset in assets.items():
+        roles = asset.get("roles", [])
+        if "data" in roles:
+            return asset
+    for name, asset in assets.items():
+        href = asset.get("href", "")
+        if href.lower().endswith((".tif", ".tiff")):
+            return asset
+    return None
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+async def _read_sidecar(client: httpx.AsyncClient, url: str) -> RemoteItem | None:
+    try:
+        resp = await client.get(url, timeout=15.0)
+        if resp.status_code >= 400:
+            logger.warning("Sidecar %s returned status %d", url, resp.status_code)
+            return None
+        sidecar = resp.json()
+    except Exception:
+        logger.exception("Failed to read sidecar %s", url)
+        return None
+
+    asset = _pick_data_asset(sidecar)
+    if asset is None:
+        logger.warning("No data asset in sidecar %s", url)
+        return None
+
+    href = _resolve_asset_href(url, asset["href"])
+    dt = _parse_datetime(sidecar.get("properties", {}).get("datetime"))
+    bbox = sidecar.get("bbox")
+    return RemoteItem(href=href, datetime=dt, bbox=bbox)
+
+
+async def enumerate_stac_sidecars(
+    listing_url: str, recursive: bool = False
+) -> list[RemoteItem]:
+    """Enumerate sidecar-backed items under a listing URL."""
+    if recursive:
+        sidecar_urls = await _list_sidecars_recursive(listing_url)
+    else:
+        sidecar_urls = await list_sidecars(listing_url)
+
+    items: list[RemoteItem] = []
+    async with httpx.AsyncClient() as client:
+        for url in sidecar_urls:
+            item = await _read_sidecar(client, url)
+            if item is not None:
+                items.append(item)
+    return items
+
+
+async def _list_sidecars_recursive(listing_url: str) -> list[str]:
+    """Placeholder — implemented in Task 5."""
+    raise NotImplementedError("Recursive listing is added in Task 5")

--- a/ingestion/src/services/enumerators/stac_sidecars.py
+++ b/ingestion/src/services/enumerators/stac_sidecars.py
@@ -47,11 +47,11 @@ def _resolve_asset_href(sidecar_url: str, relative_href: str) -> str:
 def _pick_data_asset(sidecar: dict) -> dict | None:
     """Return the asset dict for the primary data asset, or None."""
     assets = sidecar.get("assets", {})
-    for name, asset in assets.items():
+    for asset in assets.values():
         roles = asset.get("roles", [])
         if "data" in roles:
             return asset
-    for name, asset in assets.items():
+    for asset in assets.values():
         href = asset.get("href", "")
         if href.lower().endswith((".tif", ".tiff")):
             return asset

--- a/ingestion/src/services/enumerators/stac_sidecars.py
+++ b/ingestion/src/services/enumerators/stac_sidecars.py
@@ -109,46 +109,70 @@ async def _list_one_level(
 ) -> tuple[list[str], list[str]]:
     """Call S3 ListObjectsV2 for a single level of a bucket.
 
-    Returns (common_prefixes, keys). common_prefixes are direct subdirectories
-    under `prefix`, terminated by `/`. keys are full object keys at this level,
-    both expressed relative to the product root (not full paths including the
-    bucket prefix).
+    Paginates via NextContinuationToken until IsTruncated is false. Returns
+    (common_prefixes, keys). common_prefixes are direct subdirectories under
+    `prefix`, terminated by `/`. keys are full object keys at this level, both
+    expressed relative to the product root (not full paths including the bucket
+    prefix).
     """
+    from urllib.parse import quote
+
     parsed = urlparse(bucket_url)
     base_path = parsed.path.strip("/")
     full_prefix = f"{base_path}/{prefix}" if prefix else f"{base_path}/"
 
-    list_url = (
+    base_list_url = (
         f"{parsed.scheme}://{parsed.netloc}"
         f"?list-type=2&prefix={full_prefix}&delimiter=/"
     )
 
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(list_url, timeout=30.0)
-        resp.raise_for_status()
-        xml_text = resp.text
-
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
-        soup = BeautifulSoup(xml_text, "html.parser")
-
     common: list[str] = []
-    for cp in soup.find_all("commonprefixes"):
-        prefix_tag = cp.find("prefix")
-        if prefix_tag:
-            sub = prefix_tag.get_text()
-            if sub.startswith(f"{base_path}/"):
-                sub = sub[len(base_path) + 1 :]
-            common.append(sub)
-
     keys: list[str] = []
-    for contents in soup.find_all("contents"):
-        key_tag = contents.find("key")
-        if key_tag:
-            key = key_tag.get_text()
-            if key.startswith(f"{base_path}/"):
-                key = key[len(base_path) + 1 :]
-            keys.append(key)
+    continuation_token: str | None = None
+
+    async with httpx.AsyncClient() as client:
+        while True:
+            list_url = base_list_url
+            if continuation_token:
+                list_url = (
+                    f"{base_list_url}&continuation-token={quote(continuation_token)}"
+                )
+
+            resp = await client.get(list_url, timeout=30.0)
+            resp.raise_for_status()
+            xml_text = resp.text
+
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
+                soup = BeautifulSoup(xml_text, "html.parser")
+
+            for cp in soup.find_all("commonprefixes"):
+                prefix_tag = cp.find("prefix")
+                if prefix_tag:
+                    sub = prefix_tag.get_text()
+                    if sub.startswith(f"{base_path}/"):
+                        sub = sub[len(base_path) + 1 :]
+                    common.append(sub)
+
+            for contents in soup.find_all("contents"):
+                key_tag = contents.find("key")
+                if key_tag:
+                    key = key_tag.get_text()
+                    if key.startswith(f"{base_path}/"):
+                        key = key[len(base_path) + 1 :]
+                    keys.append(key)
+
+            is_truncated_tag = soup.find("istruncated")
+            if (
+                not is_truncated_tag
+                or is_truncated_tag.get_text().strip().lower() != "true"
+            ):
+                break
+
+            next_token_tag = soup.find("nextcontinuationtoken")
+            if not next_token_tag:
+                break
+            continuation_token = next_token_tag.get_text()
 
     return common, keys
 

--- a/ingestion/src/services/enumerators/stac_sidecars.py
+++ b/ingestion/src/services/enumerators/stac_sidecars.py
@@ -20,7 +20,6 @@ from urllib.parse import urljoin, urlparse
 import httpx
 from bs4 import BeautifulSoup, XMLParsedAsHTMLWarning
 
-from src.services.discovery import fetch_and_discover
 from src.services.enumerators import RemoteItem
 
 logger = logging.getLogger(__name__)
@@ -29,9 +28,13 @@ SIDECAR_SUFFIX = ".stac-item.json"
 
 
 async def list_sidecars(listing_url: str) -> list[str]:
-    """List sidecar JSON URLs in a single directory using fetch_and_discover."""
-    discovered = await fetch_and_discover(listing_url)
-    return [f.url for f in discovered if f.url.endswith(SIDECAR_SUFFIX)]
+    """List sidecar JSON URLs in a single S3 prefix level.
+
+    Uses ListObjectsV2 with ``delimiter=/`` so this is the "flat" (non-recursive)
+    equivalent of ``_list_sidecars_recursive``.
+    """
+    _common, keys = await _list_one_level(listing_url, prefix="")
+    return [urljoin(listing_url, key) for key in keys if key.endswith(SIDECAR_SUFFIX)]
 
 
 def _resolve_asset_href(sidecar_url: str, relative_href: str) -> str:
@@ -119,10 +122,17 @@ async def _list_one_level(
 
     parsed = urlparse(bucket_url)
     base_path = parsed.path.strip("/")
-    full_prefix = f"{base_path}/{prefix}" if prefix else f"{base_path}/"
+
+    segments = base_path.split("/", 1) if base_path else [""]
+    bucket = segments[0]
+    bucket_prefix = segments[1] if len(segments) > 1 else ""
+    if bucket_prefix and not bucket_prefix.endswith("/"):
+        bucket_prefix = f"{bucket_prefix}/"
+
+    full_prefix = f"{bucket_prefix}{prefix}"
 
     base_list_url = (
-        f"{parsed.scheme}://{parsed.netloc}"
+        f"{parsed.scheme}://{parsed.netloc}/{bucket}/"
         f"?list-type=2&prefix={full_prefix}&delimiter=/"
     )
 
@@ -150,16 +160,16 @@ async def _list_one_level(
                 prefix_tag = cp.find("prefix")
                 if prefix_tag:
                     sub = prefix_tag.get_text()
-                    if sub.startswith(f"{base_path}/"):
-                        sub = sub[len(base_path) + 1 :]
+                    if bucket_prefix and sub.startswith(bucket_prefix):
+                        sub = sub[len(bucket_prefix) :]
                     common.append(sub)
 
             for contents in soup.find_all("contents"):
                 key_tag = contents.find("key")
                 if key_tag:
                     key = key_tag.get_text()
-                    if key.startswith(f"{base_path}/"):
-                        key = key[len(base_path) + 1 :]
+                    if bucket_prefix and key.startswith(bucket_prefix):
+                        key = key[len(bucket_prefix) :]
                     keys.append(key)
 
             is_truncated_tag = soup.find("istruncated")

--- a/ingestion/src/services/enumerators/stac_sidecars.py
+++ b/ingestion/src/services/enumerators/stac_sidecars.py
@@ -113,9 +113,7 @@ async def enumerate_stac_sidecars(
     return items
 
 
-async def _list_one_level(
-    bucket_url: str, prefix: str
-) -> tuple[list[str], list[str]]:
+async def _list_one_level(bucket_url: str, prefix: str) -> tuple[list[str], list[str]]:
     """Call S3 ListObjectsV2 for a single level of a bucket.
 
     Paginates via NextContinuationToken until IsTruncated is false. Returns

--- a/ingestion/src/services/enumerators/stac_sidecars.py
+++ b/ingestion/src/services/enumerators/stac_sidecars.py
@@ -13,10 +13,12 @@ and bbox are extracted and returned as a RemoteItem.
 from __future__ import annotations
 
 import logging
+import warnings
 from datetime import datetime
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import httpx
+from bs4 import BeautifulSoup, XMLParsedAsHTMLWarning
 
 from src.services.discovery import fetch_and_discover
 from src.services.enumerators import RemoteItem
@@ -102,6 +104,72 @@ async def enumerate_stac_sidecars(
     return items
 
 
-async def _list_sidecars_recursive(listing_url: str) -> list[str]:
-    """Placeholder — implemented in Task 5."""
-    raise NotImplementedError("Recursive listing is added in Task 5")
+async def _list_one_level(
+    bucket_url: str, prefix: str
+) -> tuple[list[str], list[str]]:
+    """Call S3 ListObjectsV2 for a single level of a bucket.
+
+    Returns (common_prefixes, keys). common_prefixes are direct subdirectories
+    under `prefix`, terminated by `/`. keys are full object keys at this level,
+    both expressed relative to the product root (not full paths including the
+    bucket prefix).
+    """
+    parsed = urlparse(bucket_url)
+    base_path = parsed.path.strip("/")
+    full_prefix = f"{base_path}/{prefix}" if prefix else f"{base_path}/"
+
+    list_url = (
+        f"{parsed.scheme}://{parsed.netloc}"
+        f"?list-type=2&prefix={full_prefix}&delimiter=/"
+    )
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(list_url, timeout=30.0)
+        resp.raise_for_status()
+        xml_text = resp.text
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
+        soup = BeautifulSoup(xml_text, "html.parser")
+
+    common: list[str] = []
+    for cp in soup.find_all("commonprefixes"):
+        prefix_tag = cp.find("prefix")
+        if prefix_tag:
+            sub = prefix_tag.get_text()
+            if sub.startswith(f"{base_path}/"):
+                sub = sub[len(base_path) + 1 :]
+            common.append(sub)
+
+    keys: list[str] = []
+    for contents in soup.find_all("contents"):
+        key_tag = contents.find("key")
+        if key_tag:
+            key = key_tag.get_text()
+            if key.startswith(f"{base_path}/"):
+                key = key[len(base_path) + 1 :]
+            keys.append(key)
+
+    return common, keys
+
+
+async def _list_sidecars_recursive(
+    listing_url: str, max_depth: int = 10
+) -> list[str]:
+    """Walk nested bucket prefixes and return all sidecar URLs found."""
+    sidecar_urls: list[str] = []
+    stack: list[tuple[str, int]] = [("", 0)]
+
+    while stack:
+        prefix, depth = stack.pop()
+        common, keys = await _list_one_level(listing_url, prefix)
+
+        for key in keys:
+            if key.endswith(SIDECAR_SUFFIX):
+                sidecar_urls.append(urljoin(listing_url, key))
+
+        if depth < max_depth:
+            for sub in common:
+                stack.append((sub, depth + 1))
+
+    return sidecar_urls

--- a/ingestion/src/services/enumerators/stac_sidecars.py
+++ b/ingestion/src/services/enumerators/stac_sidecars.py
@@ -45,15 +45,25 @@ def _resolve_asset_href(sidecar_url: str, relative_href: str) -> str:
 
 
 def _pick_data_asset(sidecar: dict) -> dict | None:
-    """Return the asset dict for the primary data asset, or None."""
-    assets = sidecar.get("assets", {})
+    """Return the asset dict for the primary data asset, or None.
+
+    Tolerates malformed sidecars where `assets` is missing, non-dict, or where
+    individual assets are not dicts or lack an `href`.
+    """
+    assets = sidecar.get("assets")
+    if not isinstance(assets, dict):
+        return None
     for asset in assets.values():
-        roles = asset.get("roles", [])
-        if "data" in roles:
+        if not isinstance(asset, dict):
+            continue
+        roles = asset.get("roles") or []
+        if isinstance(roles, list) and "data" in roles and asset.get("href"):
             return asset
     for asset in assets.values():
-        href = asset.get("href", "")
-        if href.lower().endswith((".tif", ".tiff")):
+        if not isinstance(asset, dict):
+            continue
+        href = asset.get("href")
+        if isinstance(href, str) and href.lower().endswith((".tif", ".tiff")):
             return asset
     return None
 

--- a/ingestion/src/services/remote_register.py
+++ b/ingestion/src/services/remote_register.py
@@ -1,0 +1,154 @@
+"""Register a source.coop directory as a zero-copy STAC collection.
+
+Given enumerator output and product metadata, this service:
+    1. Probes missing bounds via /vsicurl/.
+    2. Orders items by datetime if the product is temporal.
+    3. Writes a pgSTAC collection + items.
+    4. Persists a Dataset row with is_zero_copy=True.
+
+Mirrors the logic of remote_pipeline._run_zero_copy, but is driven by a
+pre-built list of RemoteItems instead of discovery output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import rasterio
+
+from src.models import Dataset, DatasetType, FormatPair, Job, Timestep
+from src.models.dataset import persist_dataset
+from src.services import stac_ingest
+from src.services.enumerators import RemoteItem
+from src.services.pipeline import get_credits
+from src.services.remote_pipeline import read_remote_bounds
+from src.services.source_coop_config import SourceCoopProduct
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteRegistrationError(Exception):
+    pass
+
+
+def _read_band_meta_sync(vsi_path: str) -> tuple[int, list[str], list[str], str]:
+    with rasterio.open(vsi_path) as src:
+        band_names = [
+            desc if desc else f"Band {i + 1}"
+            for i, desc in enumerate(src.descriptions)
+        ]
+        color_interp = [ci.name for ci in src.colorinterp]
+        return src.count, band_names, color_interp, str(src.dtypes[0])
+
+
+async def _read_band_meta(href: str) -> tuple[int, list[str], list[str], str]:
+    return await asyncio.to_thread(_read_band_meta_sync, f"/vsicurl/{href}")
+
+
+def _bbox_to_polygon(bbox: list[float]) -> dict:
+    west, south, east, north = bbox
+    return {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [west, south],
+                [east, south],
+                [east, north],
+                [west, north],
+                [west, south],
+            ]
+        ],
+    }
+
+
+async def register_remote_collection(
+    job: Job,
+    product: SourceCoopProduct,
+    items: list[RemoteItem],
+    db_session_factory,
+) -> str:
+    """Register a list of RemoteItems as a sandbox dataset.
+
+    Returns the new dataset ID.
+    """
+    if not items:
+        raise RemoteRegistrationError(
+            f"Enumerator returned no items for {product.slug}"
+        )
+
+    enriched: list[RemoteItem] = []
+    for item in items:
+        if item.bbox is None:
+            bbox, _geom = await read_remote_bounds(item.href)
+            enriched.append(
+                RemoteItem(href=item.href, datetime=item.datetime, bbox=bbox)
+            )
+        else:
+            enriched.append(item)
+
+    if product.is_temporal:
+        missing_dt = [i for i in enriched if i.datetime is None]
+        if missing_dt:
+            raise RemoteRegistrationError(
+                f"Product {product.slug} is marked temporal but "
+                f"{len(missing_dt)} items have no datetime"
+            )
+        enriched.sort(key=lambda it: it.datetime)  # type: ignore[arg-type,return-value]
+
+    hrefs = [it.href for it in enriched]
+    bboxes = [it.bbox for it in enriched]
+    geometries = [_bbox_to_polygon(it.bbox) for it in enriched]  # type: ignore[arg-type]
+    datetimes = (
+        [it.datetime.isoformat() for it in enriched]  # type: ignore[union-attr]
+        if product.is_temporal
+        else None
+    )
+
+    tile_url = await stac_ingest.ingest_mosaic_raster(
+        dataset_id=job.dataset_id,
+        hrefs=hrefs,
+        bboxes=bboxes,  # type: ignore[arg-type]
+        geometries=geometries,
+        filename=product.name,
+        datetimes=datetimes,
+    )
+
+    band_count, band_names, color_interp, dtype = await _read_band_meta(hrefs[0])
+
+    overall_bbox = [
+        min(b[0] for b in bboxes),  # type: ignore[index]
+        min(b[1] for b in bboxes),  # type: ignore[index]
+        max(b[2] for b in bboxes),  # type: ignore[index]
+        max(b[3] for b in bboxes),  # type: ignore[index]
+    ]
+
+    timesteps: list[Timestep] = []
+    if product.is_temporal and datetimes:
+        timesteps = [Timestep(datetime=dt, index=i) for i, dt in enumerate(datetimes)]
+
+    dataset = Dataset(
+        id=job.dataset_id,
+        filename=product.name,
+        dataset_type=DatasetType.RASTER,
+        format_pair=FormatPair.GEOTIFF_TO_COG,
+        tile_url=tile_url,
+        bounds=overall_bbox,
+        band_count=band_count,
+        band_names=band_names,
+        color_interpretation=color_interp,
+        dtype=dtype,
+        stac_collection_id=f"sandbox-{job.dataset_id}",
+        validation_results=[],
+        credits=get_credits(FormatPair.GEOTIFF_TO_COG),
+        workspace_id=job.workspace_id,
+        is_zero_copy=True,
+        is_mosaic=not product.is_temporal,
+        is_temporal=product.is_temporal,
+        timesteps=timesteps,
+        source_url=product.listing_url,
+        created_at=job.created_at,
+    )
+    persist_dataset(db_session_factory, dataset)
+
+    return dataset.id

--- a/ingestion/src/services/remote_register.py
+++ b/ingestion/src/services/remote_register.py
@@ -35,8 +35,7 @@ class RemoteRegistrationError(Exception):
 def _read_band_meta_sync(vsi_path: str) -> tuple[int, list[str], list[str], str]:
     with rasterio.open(vsi_path) as src:
         band_names = [
-            desc if desc else f"Band {i + 1}"
-            for i, desc in enumerate(src.descriptions)
+            desc if desc else f"Band {i + 1}" for i, desc in enumerate(src.descriptions)
         ]
         color_interp = [ci.name for ci in src.colorinterp]
         return src.count, band_names, color_interp, str(src.dtypes[0])

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -29,7 +29,7 @@ _PRODUCTS: dict[str, SourceCoopProduct] = {
         name="GHRSST MUR v2 — Daily SST (2024)",
         description=(
             "Multi-scale Ultra-high Resolution sea surface temperature analysis, "
-            "daily global coverage. v1 shows the 2024 subset (~365 days)."
+            "daily global coverage. v1 shows the 2024 subset (366 days)."
         ),
         listing_url="https://data.source.coop/ausantarctic/ghrsst-mur-v2/",
         enumerator="stac_sidecars",

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -44,8 +44,8 @@ _PRODUCTS: dict[str, SourceCoopProduct] = {
             "of the Oceans, 2024 release."
         ),
         listing_url="https://data.source.coop/alexgleith/gebco-2024/",
-        enumerator="stac_sidecars",
-        enumerator_args={"recursive": False},
+        enumerator="path_listing",
+        enumerator_args={},
         is_temporal=False,
     ),
     "vizzuality/lg-land-carbon-data": SourceCoopProduct(

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -1,0 +1,72 @@
+"""Hardcoded registry of curated source.coop products for v1.
+
+Each entry describes a product the user can connect from the homepage gallery.
+The backend uses this registry to resolve a slug to a listing URL and an
+enumerator strategy; the frontend has a mirror of this data for display in
+frontend/src/lib/sourceCoopCatalog.ts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SourceCoopProduct:
+    slug: str
+    name: str
+    description: str
+    listing_url: str
+    enumerator: str
+    enumerator_args: dict[str, Any] = field(default_factory=dict)
+    is_temporal: bool = False
+
+
+_PRODUCTS: dict[str, SourceCoopProduct] = {
+    "ausantarctic/ghrsst-mur-v2": SourceCoopProduct(
+        slug="ausantarctic/ghrsst-mur-v2",
+        name="GHRSST MUR v2 — Daily Global SST",
+        description=(
+            "Multi-scale Ultra-high Resolution (MUR) sea surface temperature analysis, "
+            "daily global coverage at 0.01° resolution."
+        ),
+        listing_url="https://data.source.coop/ausantarctic/ghrsst-mur-v2/",
+        enumerator="stac_sidecars",
+        enumerator_args={"recursive": True},
+        is_temporal=True,
+    ),
+    "alexgleith/gebco-2024": SourceCoopProduct(
+        slug="alexgleith/gebco-2024",
+        name="GEBCO 2024 Bathymetry",
+        description=(
+            "Global ocean and land terrain model from the General Bathymetric Chart "
+            "of the Oceans, 2024 release."
+        ),
+        listing_url="https://data.source.coop/alexgleith/gebco-2024/",
+        enumerator="stac_sidecars",
+        enumerator_args={"recursive": False},
+        is_temporal=False,
+    ),
+    "vizzuality/lg-land-carbon-data": SourceCoopProduct(
+        slug="vizzuality/lg-land-carbon-data",
+        name="Land & Carbon Lab Carbon Data",
+        description=(
+            "Land carbon flux and stock rasters produced by the WRI Land & Carbon Lab."
+        ),
+        listing_url="https://data.source.coop/vizzuality/lg-land-carbon-data/",
+        enumerator="path_listing",
+        enumerator_args={},
+        is_temporal=False,
+    ),
+}
+
+
+def list_products() -> list[SourceCoopProduct]:
+    """Return all curated products in registration order."""
+    return list(_PRODUCTS.values())
+
+
+def get_product(slug: str) -> SourceCoopProduct:
+    """Look up a product by slug. Raises KeyError if not found."""
+    return _PRODUCTS[slug]

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -26,14 +26,14 @@ class SourceCoopProduct:
 _PRODUCTS: dict[str, SourceCoopProduct] = {
     "ausantarctic/ghrsst-mur-v2": SourceCoopProduct(
         slug="ausantarctic/ghrsst-mur-v2",
-        name="GHRSST MUR v2 — Daily Global SST",
+        name="GHRSST MUR v2 — Daily SST (2024)",
         description=(
-            "Multi-scale Ultra-high Resolution (MUR) sea surface temperature analysis, "
-            "daily global coverage at 0.01° resolution."
+            "Multi-scale Ultra-high Resolution sea surface temperature analysis, "
+            "daily global coverage. v1 shows the 2024 subset (~365 days)."
         ),
         listing_url="https://data.source.coop/ausantarctic/ghrsst-mur-v2/",
         enumerator="stac_sidecars",
-        enumerator_args={"recursive": True},
+        enumerator_args={"recursive": True, "start_prefix": "2024/"},
         is_temporal=True,
     ),
     "alexgleith/gebco-2024": SourceCoopProduct(

--- a/ingestion/tests/services/enumerators/test_interface.py
+++ b/ingestion/tests/services/enumerators/test_interface.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 from src.services.enumerators import RemoteItem
 

--- a/ingestion/tests/services/enumerators/test_interface.py
+++ b/ingestion/tests/services/enumerators/test_interface.py
@@ -1,0 +1,25 @@
+from datetime import datetime, UTC
+
+from src.services.enumerators import RemoteItem
+
+
+def test_remote_item_accepts_minimum_fields():
+    item = RemoteItem(
+        href="https://data.source.coop/example/file.tif",
+        datetime=None,
+        bbox=None,
+    )
+    assert item.href == "https://data.source.coop/example/file.tif"
+    assert item.datetime is None
+    assert item.bbox is None
+
+
+def test_remote_item_accepts_full_fields():
+    dt = datetime(2024, 1, 1, tzinfo=UTC)
+    item = RemoteItem(
+        href="https://data.source.coop/example/file.tif",
+        datetime=dt,
+        bbox=[-10.0, -5.0, 10.0, 5.0],
+    )
+    assert item.datetime == dt
+    assert item.bbox == [-10.0, -5.0, 10.0, 5.0]

--- a/ingestion/tests/services/enumerators/test_path_listing.py
+++ b/ingestion/tests/services/enumerators/test_path_listing.py
@@ -1,0 +1,43 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.services.discovery import DiscoveredFile
+from src.services.enumerators.path_listing import enumerate_path_listing
+
+
+@pytest.mark.asyncio
+async def test_path_listing_wraps_fetch_and_discover():
+    fake_files = [
+        DiscoveredFile(
+            url="https://data.source.coop/vizzuality/lg-land-carbon-data/file_a.tif",
+            filename="file_a.tif",
+        ),
+        DiscoveredFile(
+            url="https://data.source.coop/vizzuality/lg-land-carbon-data/file_b.tif",
+            filename="file_b.tif",
+        ),
+    ]
+    with patch(
+        "src.services.enumerators.path_listing.fetch_and_discover",
+        new=AsyncMock(return_value=fake_files),
+    ):
+        items = await enumerate_path_listing(
+            listing_url="https://data.source.coop/vizzuality/lg-land-carbon-data/"
+        )
+
+    assert len(items) == 2
+    assert items[0].href == fake_files[0].url
+    assert items[0].datetime is None
+    assert items[0].bbox is None
+    assert items[1].href == fake_files[1].url
+
+
+@pytest.mark.asyncio
+async def test_path_listing_returns_empty_when_no_files_found():
+    with patch(
+        "src.services.enumerators.path_listing.fetch_and_discover",
+        new=AsyncMock(return_value=[]),
+    ):
+        items = await enumerate_path_listing(listing_url="https://example.com/empty/")
+    assert items == []

--- a/ingestion/tests/services/enumerators/test_path_listing.py
+++ b/ingestion/tests/services/enumerators/test_path_listing.py
@@ -2,42 +2,41 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from src.services.discovery import DiscoveredFile
 from src.services.enumerators.path_listing import enumerate_path_listing
 
 
 @pytest.mark.asyncio
-async def test_path_listing_wraps_fetch_and_discover():
-    fake_files = [
-        DiscoveredFile(
-            url="https://data.source.coop/vizzuality/lg-land-carbon-data/file_a.tif",
-            filename="file_a.tif",
-        ),
-        DiscoveredFile(
-            url="https://data.source.coop/vizzuality/lg-land-carbon-data/file_b.tif",
-            filename="file_b.tif",
-        ),
+async def test_path_listing_returns_raster_items_only():
+    fake_keys = [
+        "file_a.tif",
+        "file_b.tif",
+        "README.md",
+        "sidecar.stac-item.json",
     ]
     with patch(
-        "src.services.enumerators.path_listing.fetch_and_discover",
-        new=AsyncMock(return_value=fake_files),
+        "src.services.enumerators.path_listing._list_one_level",
+        new=AsyncMock(return_value=([], fake_keys)),
     ):
         items = await enumerate_path_listing(
             listing_url="https://data.source.coop/vizzuality/lg-land-carbon-data/"
         )
 
     assert len(items) == 2
-    assert items[0].href == fake_files[0].url
+    assert items[0].href == (
+        "https://data.source.coop/vizzuality/lg-land-carbon-data/file_a.tif"
+    )
     assert items[0].datetime is None
     assert items[0].bbox is None
-    assert items[1].href == fake_files[1].url
+    assert items[1].href == (
+        "https://data.source.coop/vizzuality/lg-land-carbon-data/file_b.tif"
+    )
 
 
 @pytest.mark.asyncio
 async def test_path_listing_returns_empty_when_no_files_found():
     with patch(
-        "src.services.enumerators.path_listing.fetch_and_discover",
-        new=AsyncMock(return_value=[]),
+        "src.services.enumerators.path_listing._list_one_level",
+        new=AsyncMock(return_value=([], [])),
     ):
         items = await enumerate_path_listing(listing_url="https://example.com/empty/")
     assert items == []

--- a/ingestion/tests/services/enumerators/test_stac_sidecars.py
+++ b/ingestion/tests/services/enumerators/test_stac_sidecars.py
@@ -1,0 +1,79 @@
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from src.services.enumerators.stac_sidecars import enumerate_stac_sidecars
+
+GEBCO_SIDECAR = {
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "GEBCO_2024",
+    "bbox": [-180.0, -90.0, 180.0, 90.0],
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]]],
+    },
+    "properties": {"datetime": "2024-06-01T00:00:00Z"},
+    "assets": {
+        "data": {
+            "href": "./GEBCO_2024.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": ["data"],
+        }
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_stac_sidecars_single_item():
+    sidecar_url = (
+        "https://data.source.coop/alexgleith/gebco-2024/GEBCO_2024.stac-item.json"
+    )
+
+    async def fake_get(self, url, **kwargs):
+        assert url == sidecar_url
+        return httpx.Response(200, json=GEBCO_SIDECAR)
+
+    with (
+        patch(
+            "src.services.enumerators.stac_sidecars.list_sidecars",
+            new=AsyncMock(return_value=[sidecar_url]),
+        ),
+        patch.object(httpx.AsyncClient, "get", new=fake_get),
+    ):
+        items = await enumerate_stac_sidecars(
+            listing_url="https://data.source.coop/alexgleith/gebco-2024/",
+            recursive=False,
+        )
+
+    assert len(items) == 1
+    item = items[0]
+    assert item.href == "https://data.source.coop/alexgleith/gebco-2024/GEBCO_2024.tif"
+    assert item.datetime is not None
+    assert item.datetime.year == 2024
+    assert item.datetime.month == 6
+    assert item.bbox == [-180.0, -90.0, 180.0, 90.0]
+
+
+@pytest.mark.asyncio
+async def test_stac_sidecars_skips_sidecars_without_data_asset():
+    sidecar_url = "https://example.com/broken.stac-item.json"
+    broken = {**GEBCO_SIDECAR, "assets": {}}
+
+    async def fake_get(self, url, **kwargs):
+        return httpx.Response(200, json=broken)
+
+    with (
+        patch(
+            "src.services.enumerators.stac_sidecars.list_sidecars",
+            new=AsyncMock(return_value=[sidecar_url]),
+        ),
+        patch.object(httpx.AsyncClient, "get", new=fake_get),
+    ):
+        items = await enumerate_stac_sidecars(
+            listing_url="https://example.com/",
+            recursive=False,
+        )
+
+    assert items == []

--- a/ingestion/tests/services/enumerators/test_stac_sidecars_recursive.py
+++ b/ingestion/tests/services/enumerators/test_stac_sidecars_recursive.py
@@ -70,23 +70,23 @@ async def test_list_one_level_follows_continuation_token():
 
     page1_xml = """<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-  <Name>data.source.coop</Name>
-  <Prefix>testing/example/</Prefix>
+  <Name>testing</Name>
+  <Prefix>example/</Prefix>
   <Delimiter>/</Delimiter>
   <IsTruncated>true</IsTruncated>
   <NextContinuationToken>tok-page-2</NextContinuationToken>
-  <Contents><Key>testing/example/a.stac-item.json</Key></Contents>
-  <CommonPrefixes><Prefix>testing/example/sub1/</Prefix></CommonPrefixes>
+  <Contents><Key>example/a.stac-item.json</Key></Contents>
+  <CommonPrefixes><Prefix>example/sub1/</Prefix></CommonPrefixes>
 </ListBucketResult>"""
 
     page2_xml = """<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-  <Name>data.source.coop</Name>
-  <Prefix>testing/example/</Prefix>
+  <Name>testing</Name>
+  <Prefix>example/</Prefix>
   <Delimiter>/</Delimiter>
   <IsTruncated>false</IsTruncated>
-  <Contents><Key>testing/example/b.stac-item.json</Key></Contents>
-  <CommonPrefixes><Prefix>testing/example/sub2/</Prefix></CommonPrefixes>
+  <Contents><Key>example/b.stac-item.json</Key></Contents>
+  <CommonPrefixes><Prefix>example/sub2/</Prefix></CommonPrefixes>
 </ListBucketResult>"""
 
     call_count = {"n": 0}

--- a/ingestion/tests/services/enumerators/test_stac_sidecars_recursive.py
+++ b/ingestion/tests/services/enumerators/test_stac_sidecars_recursive.py
@@ -44,6 +44,40 @@ async def test_recursive_walks_nested_prefixes():
 
 
 @pytest.mark.asyncio
+async def test_recursive_respects_start_prefix():
+    """start_prefix should limit the walk to a subtree."""
+    from src.services.enumerators.stac_sidecars import _list_sidecars_recursive
+
+    calls = []
+
+    async def fake_list_one_level(bucket_url: str, prefix: str):
+        calls.append(prefix)
+        tree = {
+            "": (["2023/", "2024/", "2025/"], []),
+            "2024/": (["2024/01/"], []),
+            "2024/01/": ([], ["2024/01/a.stac-item.json"]),
+        }
+        return tree.get(prefix, ([], []))
+
+    with patch(
+        "src.services.enumerators.stac_sidecars._list_one_level",
+        new=fake_list_one_level,
+    ):
+        sidecars = await _list_sidecars_recursive(
+            "https://data.source.coop/testing/example/",
+            start_prefix="2024/",
+        )
+
+    assert sidecars == [
+        "https://data.source.coop/testing/example/2024/01/a.stac-item.json"
+    ]
+    assert "2023/" not in calls
+    assert "2025/" not in calls
+    assert "2024/" in calls
+    assert "2024/01/" in calls
+
+
+@pytest.mark.asyncio
 async def test_recursive_depth_limit():
     """Extremely deep trees should not recurse indefinitely."""
 

--- a/ingestion/tests/services/enumerators/test_stac_sidecars_recursive.py
+++ b/ingestion/tests/services/enumerators/test_stac_sidecars_recursive.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 from src.services.enumerators.stac_sidecars import _list_sidecars_recursive
@@ -60,3 +61,48 @@ async def test_recursive_depth_limit():
         )
 
     assert sidecars == []
+
+
+@pytest.mark.asyncio
+async def test_list_one_level_follows_continuation_token():
+    """S3 listings with IsTruncated=true should be paginated."""
+    from src.services.enumerators.stac_sidecars import _list_one_level
+
+    page1_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>data.source.coop</Name>
+  <Prefix>testing/example/</Prefix>
+  <Delimiter>/</Delimiter>
+  <IsTruncated>true</IsTruncated>
+  <NextContinuationToken>tok-page-2</NextContinuationToken>
+  <Contents><Key>testing/example/a.stac-item.json</Key></Contents>
+  <CommonPrefixes><Prefix>testing/example/sub1/</Prefix></CommonPrefixes>
+</ListBucketResult>"""
+
+    page2_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>data.source.coop</Name>
+  <Prefix>testing/example/</Prefix>
+  <Delimiter>/</Delimiter>
+  <IsTruncated>false</IsTruncated>
+  <Contents><Key>testing/example/b.stac-item.json</Key></Contents>
+  <CommonPrefixes><Prefix>testing/example/sub2/</Prefix></CommonPrefixes>
+</ListBucketResult>"""
+
+    call_count = {"n": 0}
+
+    async def fake_get(self, url, **kwargs):
+        call_count["n"] += 1
+        if "continuation-token" in url:
+            assert "tok-page-2" in url
+            return httpx.Response(200, text=page2_xml, request=httpx.Request("GET", url))
+        return httpx.Response(200, text=page1_xml, request=httpx.Request("GET", url))
+
+    with patch.object(httpx.AsyncClient, "get", new=fake_get):
+        common, keys = await _list_one_level(
+            "https://data.source.coop/testing/example/", ""
+        )
+
+    assert call_count["n"] == 2
+    assert sorted(keys) == ["a.stac-item.json", "b.stac-item.json"]
+    assert sorted(common) == ["sub1/", "sub2/"]

--- a/ingestion/tests/services/enumerators/test_stac_sidecars_recursive.py
+++ b/ingestion/tests/services/enumerators/test_stac_sidecars_recursive.py
@@ -129,7 +129,9 @@ async def test_list_one_level_follows_continuation_token():
         call_count["n"] += 1
         if "continuation-token" in url:
             assert "tok-page-2" in url
-            return httpx.Response(200, text=page2_xml, request=httpx.Request("GET", url))
+            return httpx.Response(
+                200, text=page2_xml, request=httpx.Request("GET", url)
+            )
         return httpx.Response(200, text=page1_xml, request=httpx.Request("GET", url))
 
     with patch.object(httpx.AsyncClient, "get", new=fake_get):

--- a/ingestion/tests/services/enumerators/test_stac_sidecars_recursive.py
+++ b/ingestion/tests/services/enumerators/test_stac_sidecars_recursive.py
@@ -1,0 +1,62 @@
+from unittest.mock import patch
+
+import pytest
+
+from src.services.enumerators.stac_sidecars import _list_sidecars_recursive
+
+
+@pytest.mark.asyncio
+async def test_recursive_walks_nested_prefixes():
+    """Fake a two-level tree: year/month/day containing sidecars."""
+    calls = []
+
+    async def fake_list_one_level(bucket_url: str, prefix: str):
+        calls.append(prefix)
+        tree = {
+            "": (["2024/"], []),
+            "2024/": (["2024/01/"], []),
+            "2024/01/": (
+                [],
+                [
+                    "2024/01/file1.stac-item.json",
+                    "2024/01/file1.tif",
+                    "2024/01/file2.stac-item.json",
+                    "2024/01/file2.tif",
+                ],
+            ),
+        }
+        return tree[prefix]
+
+    with patch(
+        "src.services.enumerators.stac_sidecars._list_one_level",
+        new=fake_list_one_level,
+    ):
+        sidecars = await _list_sidecars_recursive(
+            "https://data.source.coop/testing/example/"
+        )
+
+    assert sorted(sidecars) == [
+        "https://data.source.coop/testing/example/2024/01/file1.stac-item.json",
+        "https://data.source.coop/testing/example/2024/01/file2.stac-item.json",
+    ]
+    assert sorted(calls) == sorted(["", "2024/", "2024/01/"])
+
+
+@pytest.mark.asyncio
+async def test_recursive_depth_limit():
+    """Extremely deep trees should not recurse indefinitely."""
+
+    async def fake_list_one_level(bucket_url: str, prefix: str):
+        depth = prefix.count("/")
+        return ([f"{prefix}d{depth}/"], [])
+
+    with patch(
+        "src.services.enumerators.stac_sidecars._list_one_level",
+        new=fake_list_one_level,
+    ):
+        sidecars = await _list_sidecars_recursive(
+            "https://data.source.coop/testing/infinite/",
+            max_depth=5,
+        )
+
+    assert sidecars == []

--- a/ingestion/tests/services/test_remote_register.py
+++ b/ingestion/tests/services/test_remote_register.py
@@ -1,0 +1,153 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models import Job
+from src.services.enumerators import RemoteItem
+from src.services.remote_register import (
+    RemoteRegistrationError,
+    register_remote_collection,
+)
+from src.services.source_coop_config import SourceCoopProduct
+
+
+@pytest.fixture
+def fake_product():
+    return SourceCoopProduct(
+        slug="test/product",
+        name="Test Product",
+        description="Test",
+        listing_url="https://data.source.coop/test/product/",
+        enumerator="path_listing",
+        enumerator_args={},
+        is_temporal=False,
+    )
+
+
+@pytest.fixture
+def fake_temporal_product():
+    return SourceCoopProduct(
+        slug="test/temporal",
+        name="Test Temporal",
+        description="Test temporal",
+        listing_url="https://data.source.coop/test/temporal/",
+        enumerator="stac_sidecars",
+        enumerator_args={"recursive": True},
+        is_temporal=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_non_temporal_product_probes_missing_bounds(fake_product):
+    items = [
+        RemoteItem(
+            href="https://data.source.coop/test/product/a.tif",
+            datetime=None,
+            bbox=None,
+        ),
+        RemoteItem(
+            href="https://data.source.coop/test/product/b.tif",
+            datetime=None,
+            bbox=[-5.0, -5.0, 5.0, 5.0],
+        ),
+    ]
+    db_session_factory = MagicMock()
+    job = Job(filename="test")
+    job.workspace_id = "deadbeef"
+
+    fake_bounds = ([-10.0, -10.0, 10.0, 10.0], {"type": "Polygon", "coordinates": []})
+    fake_band_meta = (3, ["b1", "b2", "b3"], ["red", "green", "blue"], "uint8")
+
+    with (
+        patch(
+            "src.services.remote_register.read_remote_bounds",
+            new=AsyncMock(return_value=fake_bounds),
+        ),
+        patch(
+            "src.services.remote_register.stac_ingest.ingest_mosaic_raster",
+            new=AsyncMock(return_value="http://tiler/collections/sandbox-xyz/{z}/{x}/{y}"),
+        ),
+        patch(
+            "src.services.remote_register._read_band_meta",
+            new=AsyncMock(return_value=fake_band_meta),
+        ),
+        patch("src.services.remote_register.persist_dataset") as persist_mock,
+    ):
+        dataset_id = await register_remote_collection(
+            job=job,
+            product=fake_product,
+            items=items,
+            db_session_factory=db_session_factory,
+        )
+
+    assert dataset_id == job.dataset_id
+    persist_mock.assert_called_once()
+    dataset = persist_mock.call_args.args[1]
+    assert dataset.is_zero_copy is True
+    assert dataset.is_temporal is False
+    assert dataset.source_url == "https://data.source.coop/test/product/"
+    assert dataset.workspace_id == "deadbeef"
+
+
+@pytest.mark.asyncio
+async def test_register_temporal_product_orders_by_datetime(fake_temporal_product):
+    dt_early = datetime(2024, 1, 1, tzinfo=UTC)
+    dt_late = datetime(2024, 2, 1, tzinfo=UTC)
+
+    items = [
+        RemoteItem(
+            href="https://data.source.coop/test/temporal/late.tif",
+            datetime=dt_late,
+            bbox=[-1.0, -1.0, 1.0, 1.0],
+        ),
+        RemoteItem(
+            href="https://data.source.coop/test/temporal/early.tif",
+            datetime=dt_early,
+            bbox=[-1.0, -1.0, 1.0, 1.0],
+        ),
+    ]
+    db_session_factory = MagicMock()
+    job = Job(filename="test")
+    job.workspace_id = "deadbeef"
+
+    fake_band_meta = (1, ["sst"], ["gray"], "float32")
+
+    with (
+        patch(
+            "src.services.remote_register.stac_ingest.ingest_mosaic_raster",
+            new=AsyncMock(return_value="http://tiler/sandbox-xyz/{z}/{x}/{y}"),
+        ) as ingest_mock,
+        patch(
+            "src.services.remote_register._read_band_meta",
+            new=AsyncMock(return_value=fake_band_meta),
+        ),
+        patch("src.services.remote_register.persist_dataset") as persist_mock,
+    ):
+        await register_remote_collection(
+            job=job,
+            product=fake_temporal_product,
+            items=items,
+            db_session_factory=db_session_factory,
+        )
+
+    call_kwargs = ingest_mock.call_args.kwargs
+    assert call_kwargs["hrefs"][0].endswith("early.tif")
+    assert call_kwargs["hrefs"][1].endswith("late.tif")
+    assert call_kwargs["datetimes"][0].startswith("2024-01-01")
+    assert call_kwargs["datetimes"][1].startswith("2024-02-01")
+
+    dataset = persist_mock.call_args.args[1]
+    assert dataset.is_temporal is True
+    assert len(dataset.timesteps) == 2
+
+
+@pytest.mark.asyncio
+async def test_register_raises_when_no_items(fake_product):
+    with pytest.raises(RemoteRegistrationError, match="no items"):
+        await register_remote_collection(
+            job=Job(filename="test"),
+            product=fake_product,
+            items=[],
+            db_session_factory=MagicMock(),
+        )

--- a/ingestion/tests/services/test_remote_register.py
+++ b/ingestion/tests/services/test_remote_register.py
@@ -66,7 +66,9 @@ async def test_register_non_temporal_product_probes_missing_bounds(fake_product)
         ),
         patch(
             "src.services.remote_register.stac_ingest.ingest_mosaic_raster",
-            new=AsyncMock(return_value="http://tiler/collections/sandbox-xyz/{z}/{x}/{y}"),
+            new=AsyncMock(
+                return_value="http://tiler/collections/sandbox-xyz/{z}/{x}/{y}"
+            ),
         ),
         patch(
             "src.services.remote_register._read_band_meta",

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -35,6 +35,7 @@ def test_ghrsst_uses_recursive_sidecars():
     p = get_product("ausantarctic/ghrsst-mur-v2")
     assert p.enumerator == "stac_sidecars"
     assert p.enumerator_args.get("recursive") is True
+    assert p.enumerator_args.get("start_prefix") == "2024/"
 
 
 def test_gebco_uses_path_listing():

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -23,7 +23,7 @@ def test_get_product_returns_metadata():
     assert p.name
     assert p.description
     assert p.listing_url.startswith("https://data.source.coop/")
-    assert p.enumerator in ("stac_sidecars", "path_listing", "stac_catalog")
+    assert p.enumerator in ("stac_sidecars", "path_listing")
 
 
 def test_get_product_unknown_raises():

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -1,0 +1,48 @@
+import pytest
+
+from src.services.source_coop_config import (
+    SourceCoopProduct,
+    get_product,
+    list_products,
+)
+
+
+def test_list_products_returns_three_v1_entries():
+    products = list_products()
+    slugs = {p.slug for p in products}
+    assert slugs == {
+        "ausantarctic/ghrsst-mur-v2",
+        "alexgleith/gebco-2024",
+        "vizzuality/lg-land-carbon-data",
+    }
+
+
+def test_get_product_returns_metadata():
+    p = get_product("alexgleith/gebco-2024")
+    assert isinstance(p, SourceCoopProduct)
+    assert p.name
+    assert p.description
+    assert p.listing_url.startswith("https://data.source.coop/")
+    assert p.enumerator in ("stac_sidecars", "path_listing", "stac_catalog")
+
+
+def test_get_product_unknown_raises():
+    with pytest.raises(KeyError):
+        get_product("nonexistent/product")
+
+
+def test_ghrsst_uses_recursive_sidecars():
+    p = get_product("ausantarctic/ghrsst-mur-v2")
+    assert p.enumerator == "stac_sidecars"
+    assert p.enumerator_args.get("recursive") is True
+
+
+def test_gebco_uses_flat_sidecars():
+    p = get_product("alexgleith/gebco-2024")
+    assert p.enumerator == "stac_sidecars"
+    assert p.enumerator_args.get("recursive") in (False, None)
+
+
+def test_lg_land_uses_path_listing():
+    p = get_product("vizzuality/lg-land-carbon-data")
+    assert p.enumerator == "path_listing"

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -37,10 +37,9 @@ def test_ghrsst_uses_recursive_sidecars():
     assert p.enumerator_args.get("recursive") is True
 
 
-def test_gebco_uses_flat_sidecars():
+def test_gebco_uses_path_listing():
     p = get_product("alexgleith/gebco-2024")
-    assert p.enumerator == "stac_sidecars"
-    assert p.enumerator_args.get("recursive") in (False, None)
+    assert p.enumerator == "path_listing"
 
 
 def test_lg_land_uses_path_listing():

--- a/ingestion/tests/test_connect_source_coop.py
+++ b/ingestion/tests/test_connect_source_coop.py
@@ -1,0 +1,65 @@
+from unittest.mock import AsyncMock, patch
+
+from starlette.testclient import TestClient
+
+from src.services.enumerators import RemoteItem
+
+
+def test_connect_source_coop_unknown_slug_returns_404(client):
+    resp = client.post(
+        "/api/connect-source-coop",
+        json={"product_slug": "nobody/nothing"},
+    )
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"].lower()
+
+
+def test_connect_source_coop_requires_workspace(app):
+    bare_client = TestClient(app, raise_server_exceptions=False)
+    resp = bare_client.post(
+        "/api/connect-source-coop",
+        json={"product_slug": "alexgleith/gebco-2024"},
+    )
+    assert resp.status_code == 400
+
+
+def test_connect_source_coop_happy_path_returns_dataset_id(client):
+    fake_items = [
+        RemoteItem(
+            href="https://data.source.coop/alexgleith/gebco-2024/GEBCO_2024.tif",
+            datetime=None,
+            bbox=[-180.0, -90.0, 180.0, 90.0],
+        )
+    ]
+
+    with (
+        patch(
+            "src.routes.connect_source_coop.run_enumerator",
+            new=AsyncMock(return_value=fake_items),
+        ),
+        patch(
+            "src.routes.connect_source_coop.register_remote_collection",
+            new=AsyncMock(return_value="dataset-123"),
+        ),
+    ):
+        resp = client.post(
+            "/api/connect-source-coop",
+            json={"product_slug": "alexgleith/gebco-2024"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["dataset_id"] == "dataset-123"
+    assert "job_id" in body
+
+
+def test_connect_source_coop_enumerator_failure_returns_502(client):
+    with patch(
+        "src.routes.connect_source_coop.run_enumerator",
+        new=AsyncMock(side_effect=RuntimeError("source.coop unreachable")),
+    ):
+        resp = client.post(
+            "/api/connect-source-coop",
+            json={"product_slug": "alexgleith/gebco-2024"},
+        )
+    assert resp.status_code == 502


### PR DESCRIPTION
## Summary

- Adds a "Start with source.coop" section on the homepage with three curated products
- New `POST /api/connect-source-coop` endpoint registers each product as a zero-copy pgSTAC collection
- Reuses the existing zero-copy remote pipeline and temporal upload viewer — no changes to the dataset viewer

## v1 products

- `ausantarctic/ghrsst-mur-v2` — temporal, 2024 subset only (~366 days)
- `alexgleith/gebco-2024` — non-temporal, single file
- `vizzuality/lg-land-carbon-data` — non-temporal, ~11 COGs

## Architecture

1. Enumerator strategies (`stac_sidecars` flat/recursive, `path_listing`) turn each product into a list of `RemoteItem` with href + optional datetime/bbox
2. `remote_register` probes missing bounds via `/vsicurl/`, sorts temporal items, calls `stac_ingest.ingest_mosaic_raster`, writes a `Dataset` row with `is_zero_copy=True`
3. Frontend `SourceCoopGallery` renders curated cards; `SourceCoopConnectModal` handles the confirmation + API call; existing map page renders the result

## Deviations from spec

- No schema migration needed — reused existing `is_zero_copy` / `source_url` fields
- GHRSST narrowed to 2024 for v1 (synchronous route can't handle the full ~5500 items)
- GEBCO uses `path_listing` instead of `stac_sidecars` because its `.stac-item.json` is an unparseable schema template

## Test plan

- [x] Homepage shows three source.coop cards
- [x] GEBCO: confirmation modal → dataset view → `/raster` tile endpoint returns a real PNG
- [x] Land & Carbon Lab: confirmation modal → dataset view → `/raster` tile endpoint returns a real PNG
- [x] GHRSST: confirmation modal → dataset view with temporal slider (366 timesteps) → tile endpoint returns a real PNG for 2024-01-01
- [ ] Existing upload, conversion, and temporal upload flows still work (CI)

Smoke-tested end-to-end against real source.coop data on the worktree stack. See `devlog/2026-04-11-source-coop-v1.md` for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Source.coop product gallery and connect flow on Upload: browse curated products and register them as zero‑copy datasets, then navigate to the new dataset after connecting.
  * New ingestion API endpoint to register source.coop products.

* **Bug Fixes**
  * Fixed S3 listing URL handling so object links resolve correctly for certain listings.

* **Documentation**
  * Added docs describing the source.coop ingestion endpoint.

* **Tests**
  * Added comprehensive tests for UI, client, enumerators, registration, and endpoint behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->