### PR TITLE
feat: add About page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import LibraryPage from "./pages/LibraryPage";
 import StoryReaderPage from "./pages/StoryReaderPage";
 import StoryEditorPage from "./pages/StoryEditorPage";
 import StoryEmbedPage from "./pages/StoryEmbedPage";
+import AboutPage from "./pages/AboutPage";
 import { WelcomeToast } from "./components/WelcomeToast";
 
 function StoryReaderRedirect() {
@@ -50,6 +51,7 @@ export default function App() {
       <Route path="/map/:id" element={<MapPage shared />} />
       <Route path="/story/:id" element={<StoryReaderPage />} />
       <Route path="/w/:workspaceId/*" element={<WorkspaceRoutes />} />
+      <Route path="/about" element={<AboutPage />} />
       <Route path="*" element={<WorkspaceRedirect />} />
     </Routes>
   );

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -59,6 +59,16 @@ export function Header({ children }: HeaderProps) {
             Library
           </Text>
         </Link>
+        <Link to="/about" style={{ textDecoration: "none" }}>
+          <Text
+            fontSize="sm"
+            fontWeight={500}
+            color="gray.600"
+            _hover={{ color: "gray.800" }}
+          >
+            About
+          </Text>
+        </Link>
       </Flex>
       <Flex
         align="center"

--- a/frontend/src/components/SharedHeader.tsx
+++ b/frontend/src/components/SharedHeader.tsx
@@ -22,23 +22,35 @@ export function SharedHeader() {
           </Text>
         </Flex>
       </Link>
-      <Link to="/" style={{ textDecoration: "none" }}>
-        <Flex
-          align="center"
-          gap={1.5}
-          bg="brand.orange"
-          color="white"
-          px={4}
-          py={1.5}
-          borderRadius="4px"
-          fontWeight={600}
-          fontSize="sm"
-          _hover={{ bg: "brand.orangeHover" }}
-        >
-          Make your own map
-          <ArrowRight size={14} weight="bold" />
-        </Flex>
-      </Link>
+      <Flex align="center" gap={6}>
+        <Link to="/about" style={{ textDecoration: "none" }}>
+          <Text
+            fontSize="sm"
+            fontWeight={500}
+            color="gray.600"
+            _hover={{ color: "gray.800" }}
+          >
+            About
+          </Text>
+        </Link>
+        <Link to="/" style={{ textDecoration: "none" }}>
+          <Flex
+            align="center"
+            gap={1.5}
+            bg="brand.orange"
+            color="white"
+            px={4}
+            py={1.5}
+            borderRadius="4px"
+            fontWeight={600}
+            fontSize="sm"
+            _hover={{ bg: "brand.orangeHover" }}
+          >
+            Make your own map
+            <ArrowRight size={14} weight="bold" />
+          </Flex>
+        </Link>
+      </Flex>
     </Flex>
   );
 }

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -12,8 +12,7 @@ const PIPELINE_STEPS = [
   {
     icon: UploadSimple,
     label: "Upload",
-    description:
-      "Bring your GeoTIFF, GeoJSON, Shapefile, NetCDF, or HDF5 file",
+    description: "Bring your GeoTIFF, GeoJSON, Shapefile, NetCDF, or HDF5 file",
   },
   {
     icon: ArrowsClockwise,
@@ -106,14 +105,14 @@ export default function AboutPage() {
           </Heading>
           <Text color="gray.700" fontSize="md" lineHeight="tall" mb={3}>
             CNG Sandbox is a hands-on demonstration of the cloud-native
-            geospatial ecosystem. Upload your data and see what open source tools
-            from the CNG community can do — converting, tiling, and visualizing
-            geospatial formats in the browser.
+            geospatial ecosystem. Upload your data and see what open source
+            tools from the CNG community can do — converting, tiling, and
+            visualizing geospatial formats in the browser.
           </Text>
           <Text color="gray.700" fontSize="md" lineHeight="tall" mb={4}>
             It's not a SaaS platform, a conversion engine, or a data warehouse.
-            It's a sandbox — a place to explore the capabilities that these tools
-            make possible when assembled together.
+            It's a sandbox — a place to explore the capabilities that these
+            tools make possible when assembled together.
           </Text>
           <Text fontSize="sm" color="gray.600">
             Learn more about the cloud-native geospatial movement at{" "}
@@ -121,7 +120,10 @@ export default function AboutPage() {
               href="https://cloudnativegeo.org/"
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: "var(--chakra-colors-brand-orange)", fontWeight: 600 }}
+              style={{
+                color: "var(--chakra-colors-brand-orange)",
+                fontWeight: 600,
+              }}
             >
               cloudnativegeo.org
             </a>
@@ -250,7 +252,10 @@ export default function AboutPage() {
               href="https://developmentseed.org/"
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: "var(--chakra-colors-brand-orange)", fontWeight: 600 }}
+              style={{
+                color: "var(--chakra-colors-brand-orange)",
+                fontWeight: 600,
+              }}
             >
               Development Seed
             </a>

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,0 +1,263 @@
+import { Box, Flex, Text, Heading, Table } from "@chakra-ui/react";
+import {
+  UploadSimple,
+  ArrowsClockwise,
+  GridFour,
+  GlobeHemisphereWest,
+  ArrowRight,
+} from "@phosphor-icons/react";
+import { SharedHeader } from "../components/SharedHeader";
+
+const PIPELINE_STEPS = [
+  {
+    icon: UploadSimple,
+    label: "Upload",
+    description:
+      "Bring your GeoTIFF, GeoJSON, Shapefile, NetCDF, or HDF5 file",
+  },
+  {
+    icon: ArrowsClockwise,
+    label: "Convert",
+    description: "Data is converted to cloud-native formats (COG, GeoParquet)",
+  },
+  {
+    icon: GridFour,
+    label: "Tile",
+    description: "Tilers serve your data as map tiles on demand",
+  },
+  {
+    icon: GlobeHemisphereWest,
+    label: "View",
+    description: "Explore your data on an interactive map in the browser",
+  },
+];
+
+const OPEN_SOURCE_STACK = [
+  {
+    role: "Spatial catalog",
+    project: "pgSTAC",
+    url: "https://github.com/stac-utils/pgstac",
+    maintainer: "stac-utils community",
+  },
+  {
+    role: "Catalog API",
+    project: "stac-fastapi",
+    url: "https://github.com/stac-utils/stac-fastapi-pgstac",
+    maintainer: "stac-utils community",
+  },
+  {
+    role: "Raster tiles",
+    project: "titiler",
+    url: "https://github.com/developmentseed/titiler",
+    maintainer: "Development Seed",
+  },
+  {
+    role: "STAC raster tiles",
+    project: "titiler-pgstac",
+    url: "https://github.com/stac-utils/titiler-pgstac",
+    maintainer: "stac-utils / Development Seed",
+  },
+  {
+    role: "Vector tiles",
+    project: "tipg",
+    url: "https://github.com/developmentseed/tipg",
+    maintainer: "Development Seed",
+  },
+  {
+    role: "Vector maps",
+    project: "MapLibre GL JS",
+    url: "https://github.com/maplibre/maplibre-gl-js",
+    maintainer: "MapLibre community",
+  },
+  {
+    role: "Raster visualization",
+    project: "deck.gl",
+    url: "https://github.com/visgl/deck.gl",
+    maintainer: "vis.gl / Open Visualization",
+  },
+  {
+    role: "Database",
+    project: "PostGIS",
+    url: "https://github.com/postgis/postgis",
+    maintainer: "PostGIS PSC",
+  },
+  {
+    role: "Browser SQL",
+    project: "DuckDB-WASM",
+    url: "https://github.com/duckdb/duckdb-wasm",
+    maintainer: "DuckDB Foundation",
+  },
+  {
+    role: "Tile format",
+    project: "PMTiles",
+    url: "https://github.com/protomaps/PMTiles",
+    maintainer: "Protomaps / Brandon Liu",
+  },
+];
+
+export default function AboutPage() {
+  return (
+    <Box minH="100vh" bg="gray.50">
+      <SharedHeader />
+      <Box maxW="960px" mx="auto" py={8} px={4}>
+        <Box mb={10}>
+          <Heading size="lg" color="brand.brown" mb={4}>
+            About CNG Sandbox
+          </Heading>
+          <Text color="gray.700" fontSize="md" lineHeight="tall" mb={3}>
+            CNG Sandbox is a hands-on demonstration of the cloud-native
+            geospatial ecosystem. Upload your data and see what open source tools
+            from the CNG community can do — converting, tiling, and visualizing
+            geospatial formats in the browser.
+          </Text>
+          <Text color="gray.700" fontSize="md" lineHeight="tall" mb={4}>
+            It's not a SaaS platform, a conversion engine, or a data warehouse.
+            It's a sandbox — a place to explore the capabilities that these tools
+            make possible when assembled together.
+          </Text>
+          <Text fontSize="sm" color="gray.600">
+            Learn more about the cloud-native geospatial movement at{" "}
+            <a
+              href="https://cloudnativegeo.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: "var(--chakra-colors-brand-orange)", fontWeight: 600 }}
+            >
+              cloudnativegeo.org
+            </a>
+          </Text>
+        </Box>
+
+        <Box mb={10}>
+          <Heading size="md" color="gray.700" mb={4}>
+            How it works
+          </Heading>
+          <Flex
+            direction={{ base: "column", md: "row" }}
+            gap={{ base: 4, md: 0 }}
+            align={{ base: "stretch", md: "flex-start" }}
+          >
+            {PIPELINE_STEPS.map((step, i) => (
+              <Flex
+                key={step.label}
+                direction={{ base: "row", md: "column" }}
+                align={{ base: "center", md: "center" }}
+                textAlign={{ base: "left", md: "center" }}
+                flex={1}
+                gap={{ base: 3, md: 0 }}
+              >
+                <Flex
+                  align="center"
+                  justify="center"
+                  w={12}
+                  h={12}
+                  borderRadius="full"
+                  bg="brand.orange"
+                  color="white"
+                  flexShrink={0}
+                  mb={{ base: 0, md: 2 }}
+                >
+                  <step.icon size={24} />
+                </Flex>
+                <Box flex={1}>
+                  <Text fontWeight={600} color="gray.800" fontSize="sm">
+                    {step.label}
+                  </Text>
+                  <Text color="gray.600" fontSize="xs" mt={1}>
+                    {step.description}
+                  </Text>
+                </Box>
+                {i < PIPELINE_STEPS.length - 1 && (
+                  <Box
+                    display={{ base: "none", md: "flex" }}
+                    alignItems="center"
+                    px={3}
+                    pt={3}
+                  >
+                    <ArrowRight
+                      size={16}
+                      color="var(--chakra-colors-gray-400)"
+                    />
+                  </Box>
+                )}
+              </Flex>
+            ))}
+          </Flex>
+        </Box>
+
+        <Box mb={10}>
+          <Heading size="md" color="gray.700" mb={2}>
+            Open source stack
+          </Heading>
+          <Text color="gray.600" fontSize="sm" mb={4}>
+            CNG Sandbox is built entirely on open source tools from the
+            geospatial community.
+          </Text>
+          <Box
+            borderRadius="md"
+            overflow="hidden"
+            border="1px solid"
+            borderColor="gray.200"
+          >
+            <Table.Root size="sm">
+              <Table.Header>
+                <Table.Row bg="gray.100">
+                  <Table.ColumnHeader color="gray.600" fontWeight={600}>
+                    Role
+                  </Table.ColumnHeader>
+                  <Table.ColumnHeader color="gray.600" fontWeight={600}>
+                    Project
+                  </Table.ColumnHeader>
+                  <Table.ColumnHeader color="gray.600" fontWeight={600}>
+                    Maintained by
+                  </Table.ColumnHeader>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {OPEN_SOURCE_STACK.map((item) => (
+                  <Table.Row key={item.project}>
+                    <Table.Cell color="gray.600" fontSize="sm">
+                      {item.role}
+                    </Table.Cell>
+                    <Table.Cell>
+                      <a
+                        href={item.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                          color: "var(--chakra-colors-brand-orange)",
+                          fontWeight: 500,
+                          fontSize: "var(--chakra-fontSizes-sm)",
+                        }}
+                      >
+                        {item.project}
+                      </a>
+                    </Table.Cell>
+                    <Table.Cell color="gray.600" fontSize="sm">
+                      {item.maintainer}
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+              </Table.Body>
+            </Table.Root>
+          </Box>
+        </Box>
+
+        <Box mb={8}>
+          <Text color="gray.500" fontSize="sm">
+            Built by{" "}
+            <a
+              href="https://developmentseed.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: "var(--chakra-colors-brand-orange)", fontWeight: 600 }}
+            >
+              Development Seed
+            </a>
+            {" · "}v1.15.1
+          </Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/pages/__tests__/AboutPage.test.tsx
+++ b/frontend/src/pages/__tests__/AboutPage.test.tsx
@@ -53,7 +53,8 @@ describe("AboutPage", () => {
     renderAbout();
     const links = screen.getAllByText("Development Seed");
     const footerLink = links.find(
-      (el) => el.closest("a")?.getAttribute("href") === "https://developmentseed.org/"
+      (el) =>
+        el.closest("a")?.getAttribute("href") === "https://developmentseed.org/"
     );
     expect(footerLink).toBeTruthy();
   });

--- a/frontend/src/pages/__tests__/AboutPage.test.tsx
+++ b/frontend/src/pages/__tests__/AboutPage.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../../theme";
+import AboutPage from "../AboutPage";
+
+function renderAbout() {
+  return render(
+    <ChakraProvider value={system}>
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>
+    </ChakraProvider>
+  );
+}
+
+describe("AboutPage", () => {
+  it("renders the mission section", () => {
+    renderAbout();
+    expect(screen.getByText("About CNG Sandbox")).toBeTruthy();
+    expect(
+      screen.getByText(/hands-on demonstration of the cloud-native/)
+    ).toBeTruthy();
+  });
+
+  it("renders all pipeline steps", () => {
+    renderAbout();
+    expect(screen.getByText("Upload")).toBeTruthy();
+    expect(screen.getByText("Convert")).toBeTruthy();
+    expect(screen.getByText("Tile")).toBeTruthy();
+    expect(screen.getByText("View")).toBeTruthy();
+  });
+
+  it("renders the open source credits table", () => {
+    renderAbout();
+    expect(screen.getByText("pgSTAC")).toBeTruthy();
+    expect(screen.getByText("titiler")).toBeTruthy();
+    expect(screen.getByText("MapLibre GL JS")).toBeTruthy();
+    expect(screen.getByText("deck.gl")).toBeTruthy();
+    expect(screen.getByText("PostGIS")).toBeTruthy();
+  });
+
+  it("links to cloudnativegeo.org", () => {
+    renderAbout();
+    const link = screen.getByText("cloudnativegeo.org");
+    expect(link.closest("a")?.getAttribute("href")).toBe(
+      "https://cloudnativegeo.org/"
+    );
+  });
+
+  it("links to Development Seed", () => {
+    renderAbout();
+    const links = screen.getAllByText("Development Seed");
+    const footerLink = links.find(
+      (el) => el.closest("a")?.getAttribute("href") === "https://developmentseed.org/"
+    );
+    expect(footerLink).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `/about` route with a single-scroll About page that frames CNG Sandbox as a community-powered demonstration of the cloud-native geospatial ecosystem
- Credits the open source stack (pgSTAC, titiler, tipg, MapLibre, deck.gl, PostGIS, DuckDB, PMTiles) with links to repos and maintainers
- Links to [cloudnativegeo.org](https://cloudnativegeo.org/) and [Development Seed](https://developmentseed.org/)
- Adds "About" nav link to both workspace and shared headers

Closes #168

## Test plan
- [x] All 5 new AboutPage tests pass
- [x] Full test suite (238 tests) passes with no regressions
- [x] Visual verification: all sections render correctly, pipeline steps horizontal on desktop, credits table readable
- [x] "About" link visible in both Header (workspace) and SharedHeader (public)
- [ ] Verify responsive layout (pipeline stacks vertically on mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an About page with mission, pipeline overview, open-source stack credits, and version information.
  * Added navigation links to header and shared header for easy access to the About page.
* **Tests**
  * Added frontend tests verifying About page content, links, pipeline steps, and credits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->