### PR TITLE
fix: About page styling and routing improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,16 +215,45 @@ cd ingestion && uv run pytest -v
 
 ### Key endpoints
 
+**Upload & conversion:**
 - `POST /api/upload` — Upload a file (multipart form); returns 409 with `{"detail": "duplicate_dataset", "dataset_id": ..., "filename": ...}` if a file with the same name already exists in the workspace
 - `POST /api/convert-url` — Fetch and convert a file from a URL; same 409 duplicate response as above
 - `GET /api/check-duplicate?filename=<name>` — Preflight duplicate check; returns 409 if a dataset with that filename exists, or `{"duplicate": false}` if not
 - `POST /api/check-format` — Pre-upload format validation; accepts a file chunk and filename, returns `{"valid": true}` or `{"valid": false, "error": "..."}`
 - `POST /api/upload-temporal` — Upload multiple raster files as a time series (2–50 files, same format)
+- `POST /api/scan/{scan_id}/convert` — Trigger conversion after a scan completes
+
+**Jobs:**
+- `GET /api/jobs/{id}` — Get job status
 - `GET /api/jobs/{id}/stream` — SSE stream of conversion progress
+
+**Datasets:**
 - `GET /api/datasets` — List all converted datasets
 - `GET /api/datasets/{id}` — Get dataset metadata (includes `tile_url`)
+- `DELETE /api/datasets/{id}` — Delete a dataset
 - `PATCH /api/datasets/{id}/categories` — Update category labels for a categorical raster; body is a list of `{"value": int, "label": str}` objects; returns 400 if dataset is not categorical or a value doesn't exist
+
+**Stories (shareable map narratives):**
+- `POST /api/stories` — Create a story with chapters linking to datasets
+- `GET /api/stories` — List stories in the workspace
+- `GET /api/stories/{id}` — Get a story by ID
+- `PATCH /api/stories/{id}` — Update a story
+- `DELETE /api/stories/{id}` — Delete a story
+
+**Connections (external tile sources):**
+- `GET /api/connections` — List connections in the workspace
+- `POST /api/connections` — Register an external tile source (XYZ raster/vector, COG, PMTiles)
+- `GET /api/connections/{id}` — Get a connection by ID
+- `DELETE /api/connections/{id}` — Delete a connection
+
+**Remote data discovery:**
+- `POST /api/discover` — Discover geospatial files at a URL or S3 prefix
+- `POST /api/connect-remote` — Connect remote files as a mosaic or temporal dataset
 - `POST /api/connect-source-coop` — Register a curated source.coop product as a zero-copy pgSTAC collection (v1 products: `ghrsst-mur-v2-2024`, `gebco-2024`, `lg-land-carbon`)
+
+**Other:**
+- `POST /api/bug-report` — Submit a bug report (creates a GitHub issue)
+- `GET /api/proxy` — Proxy GET requests to external URLs (used by the frontend for CORS-restricted resources)
 - `GET /api/health` — Health check
 
 ### Conversion pipeline

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,6 @@ import StoryEmbedPage from "./pages/StoryEmbedPage";
 import AboutPage from "./pages/AboutPage";
 import { WelcomeToast } from "./components/WelcomeToast";
 
-
 function StoryReaderRedirect() {
   const { id } = useParams<{ id: string }>();
   return <Navigate to={`/story/${id}`} replace />;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import StoryEmbedPage from "./pages/StoryEmbedPage";
 import AboutPage from "./pages/AboutPage";
 import { WelcomeToast } from "./components/WelcomeToast";
 
+
 function StoryReaderRedirect() {
   const { id } = useParams<{ id: string }>();
   return <Navigate to={`/story/${id}`} replace />;
@@ -38,6 +39,7 @@ function WorkspaceRoutes() {
         <Route path="/story/new" element={<StoryEditorPage />} />
         <Route path="/story/:id" element={<StoryReaderRedirect />} />
         <Route path="/story/:id/edit" element={<StoryEditorPage />} />
+        <Route path="/about" element={<AboutPage />} />
       </Routes>
     </WorkspaceProvider>
   );
@@ -51,7 +53,6 @@ export default function App() {
       <Route path="/map/:id" element={<MapPage shared />} />
       <Route path="/story/:id" element={<StoryReaderPage />} />
       <Route path="/w/:workspaceId/*" element={<WorkspaceRoutes />} />
-      <Route path="/about" element={<AboutPage />} />
       <Route path="*" element={<WorkspaceRedirect />} />
     </Routes>
   );

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -59,7 +59,7 @@ export function Header({ children }: HeaderProps) {
             Library
           </Text>
         </Link>
-        <Link to="/about" style={{ textDecoration: "none" }}>
+        <Link to={workspacePath("/about")} style={{ textDecoration: "none" }}>
           <Text
             fontSize="sm"
             fontWeight={500}

--- a/frontend/src/components/SharedHeader.tsx
+++ b/frontend/src/components/SharedHeader.tsx
@@ -22,35 +22,23 @@ export function SharedHeader() {
           </Text>
         </Flex>
       </Link>
-      <Flex align="center" gap={6}>
-        <Link to="/about" style={{ textDecoration: "none" }}>
-          <Text
-            fontSize="sm"
-            fontWeight={500}
-            color="gray.600"
-            _hover={{ color: "gray.800" }}
-          >
-            About
-          </Text>
-        </Link>
-        <Link to="/" style={{ textDecoration: "none" }}>
-          <Flex
-            align="center"
-            gap={1.5}
-            bg="brand.orange"
-            color="white"
-            px={4}
-            py={1.5}
-            borderRadius="4px"
-            fontWeight={600}
-            fontSize="sm"
-            _hover={{ bg: "brand.orangeHover" }}
-          >
-            Make your own map
-            <ArrowRight size={14} weight="bold" />
-          </Flex>
-        </Link>
-      </Flex>
+      <Link to="/" style={{ textDecoration: "none" }}>
+        <Flex
+          align="center"
+          gap={1.5}
+          bg="brand.orange"
+          color="white"
+          px={4}
+          py={1.5}
+          borderRadius="4px"
+          fontWeight={600}
+          fontSize="sm"
+          _hover={{ bg: "brand.orangeHover" }}
+        >
+          Make your own map
+          <ArrowRight size={14} weight="bold" />
+        </Flex>
+      </Link>
     </Flex>
   );
 }

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -104,15 +104,32 @@ export default function AboutPage() {
             About CNG Sandbox
           </Heading>
           <Text color="gray.700" fontSize="md" lineHeight="tall" mb={3}>
-            CNG Sandbox is a hands-on demonstration of the cloud-native
-            geospatial ecosystem. Upload your data and see what open source
-            tools from the CNG community can do — converting, tiling, and
-            visualizing geospatial formats in the browser.
+            The cloud-native geospatial ecosystem has produced an incredible set
+            of open source tools for working with spatial data. CNG Sandbox lets
+            you see them in action. Upload a GeoTIFF, GeoJSON, Shapefile, or
+            NetCDF file and watch it get converted, tiled, and rendered as an
+            interactive map in your browser.
+          </Text>
+          <Text color="gray.700" fontSize="md" lineHeight="tall" mb={3}>
+            Think of it as a playground for the CNG stack. We built it to show
+            what these tools can do when wired together, and to make it easy for
+            anyone to try them without setting up infrastructure.
           </Text>
           <Text color="gray.700" fontSize="md" lineHeight="tall" mb={4}>
-            It's not a SaaS platform, a conversion engine, or a data warehouse.
-            It's a sandbox — a place to explore the capabilities that these
-            tools make possible when assembled together.
+            CNG Sandbox is a{" "}
+            <a
+              href="https://developmentseed.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: "var(--chakra-colors-brand-orange)",
+                fontWeight: 600,
+              }}
+            >
+              Development Seed
+            </a>{" "}
+            project, built on top of tools maintained by the broader geospatial
+            community.
           </Text>
           <Text fontSize="sm" color="gray.600">
             Learn more about the cloud-native geospatial movement at{" "}
@@ -241,19 +258,7 @@ export default function AboutPage() {
 
         <Box mb={8}>
           <Text color="gray.500" fontSize="sm">
-            Built by{" "}
-            <a
-              href="https://developmentseed.org/"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                color: "var(--chakra-colors-brand-orange)",
-                fontWeight: 600,
-              }}
-            >
-              Development Seed
-            </a>
-            {" · "}v1.15.1
+            v1.15.1
           </Text>
         </Box>
       </Box>

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -6,7 +6,7 @@ import {
   GlobeHemisphereWest,
   ArrowRight,
 } from "@phosphor-icons/react";
-import { SharedHeader } from "../components/SharedHeader";
+import { Header } from "../components/Header";
 
 const PIPELINE_STEPS = [
   {
@@ -97,7 +97,7 @@ const OPEN_SOURCE_STACK = [
 export default function AboutPage() {
   return (
     <Box minH="100vh" bg="gray.50">
-      <SharedHeader />
+      <Header />
       <Box maxW="960px" mx="auto" py={8} px={4}>
         <Box mb={10}>
           <Heading size="lg" color="brand.brown" mb={4}>
@@ -148,19 +148,13 @@ export default function AboutPage() {
                 flex={1}
                 gap={{ base: 3, md: 0 }}
               >
-                <Flex
-                  align="center"
-                  justify="center"
-                  w={12}
-                  h={12}
-                  borderRadius="full"
-                  bg="brand.orange"
-                  color="white"
-                  flexShrink={0}
-                  mb={{ base: 0, md: 2 }}
-                >
-                  <step.icon size={24} />
-                </Flex>
+                <Box flexShrink={0} mb={{ base: 0, md: 2 }}>
+                  <step.icon
+                    size={28}
+                    weight="duotone"
+                    color="var(--chakra-colors-gray-500)"
+                  />
+                </Box>
                 <Box flex={1}>
                   <Text fontWeight={600} color="gray.800" fontSize="sm">
                     {step.label}
@@ -211,7 +205,7 @@ export default function AboutPage() {
                     Project
                   </Table.ColumnHeader>
                   <Table.ColumnHeader color="gray.600" fontWeight={600}>
-                    Maintained by
+                    Primary maintainer(s)
                   </Table.ColumnHeader>
                 </Table.Row>
               </Table.Header>

--- a/frontend/src/pages/__tests__/AboutPage.test.tsx
+++ b/frontend/src/pages/__tests__/AboutPage.test.tsx
@@ -29,9 +29,7 @@ describe("AboutPage", () => {
   it("renders the mission section", () => {
     renderAbout();
     expect(screen.getByText("About CNG Sandbox")).toBeTruthy();
-    expect(
-      screen.getByText(/hands-on demonstration of the cloud-native/)
-    ).toBeTruthy();
+    expect(screen.getByText(/cloud-native geospatial ecosystem/)).toBeTruthy();
   });
 
   it("renders all pipeline steps", () => {

--- a/frontend/src/pages/__tests__/AboutPage.test.tsx
+++ b/frontend/src/pages/__tests__/AboutPage.test.tsx
@@ -1,15 +1,25 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, it, expect } from "vitest";
 import { ChakraProvider } from "@chakra-ui/react";
 import { system } from "../../theme";
+import { WorkspaceProvider } from "../../hooks/useWorkspace";
 import AboutPage from "../AboutPage";
 
 function renderAbout() {
   return render(
     <ChakraProvider value={system}>
-      <MemoryRouter>
-        <AboutPage />
+      <MemoryRouter initialEntries={["/w/test-workspace/about"]}>
+        <Routes>
+          <Route
+            path="/w/:workspaceId/*"
+            element={
+              <WorkspaceProvider>
+                <AboutPage />
+              </WorkspaceProvider>
+            }
+          />
+        </Routes>
       </MemoryRouter>
     </ChakraProvider>
   );


### PR DESCRIPTION
## Summary
- Moves `/about` to `/w/:workspaceId/about` so the About page uses the workspace header (consistent nav with Library link and workspace badge)
- Removes About link from SharedHeader (shared/public pages don't need it)
- Replaces orange circle icon backgrounds on pipeline steps with plain duotone Phosphor icons
- Changes table header from "Maintained by" to "Primary maintainer(s)"
- Fixes background color inconsistency (was white under header, gray.50 for content)

## Test plan
- [x] All 238 tests pass (AboutPage tests updated for WorkspaceProvider)
- [x] Visual verification: consistent header, no background color split, icons match app style
- [x] SharedHeader reverted to original (no About link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Navigation Updates**
  * About page routing is now workspace-scoped so header links resolve within the active workspace.

* **UI Improvements**
  * About page header replaced and icon/layouts refined; Open Source Stack label clarified and footer wording simplified.

* **Tests**
  * About page tests updated to run within workspace-scoped routing.

* **Documentation**
  * Ingestion API docs expanded with additional endpoints and detailed route listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->