### PR TITLE
fix: compute rescale stats for source.coop datasets

### DIFF
--- a/ingestion/src/services/remote_register.py
+++ b/ingestion/src/services/remote_register.py
@@ -75,12 +75,17 @@ def _compute_remote_stats_sync(
                     overviews = src.overviews(band_idx)
                     if overviews:
                         level = overviews[-1]
-                        data = src.read(
-                            band_idx,
-                            out_shape=(src.height // level, src.width // level),
-                        ).astype(np.float64)
+                        out_shape = (
+                            max(1, src.height // level),
+                            max(1, src.width // level),
+                        )
                     else:
-                        data = src.read(band_idx).astype(np.float64)
+                        scale = max(1.0, max(src.height, src.width) / 1024)
+                        out_shape = (
+                            max(1, int(src.height / scale)),
+                            max(1, int(src.width / scale)),
+                        )
+                    data = src.read(band_idx, out_shape=out_shape).astype(np.float64)
                     if src.nodata is not None:
                         valid = data[data != src.nodata]
                     else:
@@ -89,7 +94,8 @@ def _compute_remote_stats_sync(
                     if valid.size > 0:
                         all_valid.append(valid)
         except Exception:
-            logger.warning("Failed to read stats from %s, skipping", vsi_path)
+            safe_path = vsi_path.split("?", 1)[0]
+            logger.warning("Failed to read stats from %s, skipping", safe_path)
             continue
 
     if not all_valid:

--- a/ingestion/src/services/remote_register.py
+++ b/ingestion/src/services/remote_register.py
@@ -16,6 +16,7 @@ import asyncio
 import logging
 from datetime import UTC, datetime
 
+import numpy as np
 import rasterio
 
 from src.models import Dataset, DatasetType, FormatPair, Job, Timestep
@@ -44,6 +45,65 @@ def _read_band_meta_sync(vsi_path: str) -> tuple[int, list[str], list[str], str]
 
 async def _read_band_meta(href: str) -> tuple[int, list[str], list[str], str]:
     return await asyncio.to_thread(_read_band_meta_sync, f"/vsicurl/{href}")
+
+
+def _compute_remote_stats_sync(
+    hrefs: list[str], max_samples: int = 5
+) -> tuple[float | None, float | None]:
+    """Compute p2/p98 rescale values from a sample of remote COGs.
+
+    Samples files evenly spread across the list (first, last, and evenly
+    spaced in between) to get representative statistics without reading
+    every file. Uses the coarsest overview for minimal data transfer.
+    """
+    if not hrefs:
+        return None, None
+
+    # Pick evenly-spaced sample indices
+    n = len(hrefs)
+    if n <= max_samples:
+        indices = list(range(n))
+    else:
+        indices = [round(i * (n - 1) / (max_samples - 1)) for i in range(max_samples)]
+
+    all_valid: list[np.ndarray] = []
+    for idx in indices:
+        vsi_path = f"/vsicurl/{hrefs[idx]}"
+        try:
+            with rasterio.open(vsi_path) as src:
+                for band_idx in range(1, src.count + 1):
+                    overviews = src.overviews(band_idx)
+                    if overviews:
+                        level = overviews[-1]
+                        data = src.read(
+                            band_idx,
+                            out_shape=(src.height // level, src.width // level),
+                        ).astype(np.float64)
+                    else:
+                        data = src.read(band_idx).astype(np.float64)
+                    if src.nodata is not None:
+                        valid = data[data != src.nodata]
+                    else:
+                        valid = data.ravel()
+                    valid = valid[~np.isnan(valid)]
+                    if valid.size > 0:
+                        all_valid.append(valid)
+        except Exception:
+            logger.warning("Failed to read stats from %s, skipping", vsi_path)
+            continue
+
+    if not all_valid:
+        return None, None
+
+    combined = np.concatenate(all_valid)
+    p2, p98 = np.percentile(combined, [2, 98])
+    return float(p2), float(p98)
+
+
+async def _compute_remote_stats(
+    hrefs: list[str], max_samples: int = 5
+) -> tuple[float | None, float | None]:
+    return await asyncio.to_thread(_compute_remote_stats_sync, hrefs, max_samples)
 
 
 def _format_datetime_z(dt: datetime) -> str:
@@ -127,6 +187,7 @@ async def register_remote_collection(
     )
 
     band_count, band_names, color_interp, dtype = await _read_band_meta(hrefs[0])
+    raster_min, raster_max = await _compute_remote_stats(hrefs)
 
     overall_bbox = [
         min(b[0] for b in bboxes),  # type: ignore[index]
@@ -151,6 +212,8 @@ async def register_remote_collection(
         color_interpretation=color_interp,
         dtype=dtype,
         stac_collection_id=f"sandbox-{job.dataset_id}",
+        raster_min=raster_min,
+        raster_max=raster_max,
         validation_results=[],
         credits=get_credits(FormatPair.GEOTIFF_TO_COG),
         workspace_id=job.workspace_id,


### PR DESCRIPTION
## Summary
- Source.coop datasets (GHRSST, GEBCO, etc.) were rendered without `rescale` parameters, causing broken visualization — raw values mapped across the full dtype range instead of the meaningful data range
- Added `_compute_remote_stats` to sample up to 5 files evenly spread across the dataset, read coarsest overviews via `/vsicurl/`, and compute p2/p98 percentiles
- Stores `raster_min`/`raster_max` on the dataset, which the frontend already uses for `&rescale=` in tile URLs

## Test plan
- [ ] Delete existing GHRSST dataset and re-connect via source.coop gallery
- [ ] Verify GHRSST renders as smooth temperature gradients instead of noise
- [ ] Connect GEBCO and LG Land Carbon products, verify visualization looks correct
- [ ] Existing tests pass (16 source_coop/remote_register tests confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced remote collection registration now automatically derives raster value ranges by sampling provided cloud-optimized imagery. It filters invalid pixels, computes robust percentile-based min/max per band, and stores these statistics with the dataset to improve display, scaling, and downstream processing. Errors reading individual sources are skipped without blocking registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->