### PR TITLE
fix: apply scale/offset when computing remote raster stats

### DIFF
--- a/ingestion/src/services/remote_register.py
+++ b/ingestion/src/services/remote_register.py
@@ -80,16 +80,23 @@ def _compute_remote_stats_sync(
                             max(1, src.width // level),
                         )
                     else:
-                        scale = max(1.0, max(src.height, src.width) / 1024)
+                        downsample = max(1.0, max(src.height, src.width) / 1024)
                         out_shape = (
-                            max(1, int(src.height / scale)),
-                            max(1, int(src.width / scale)),
+                            max(1, int(src.height / downsample)),
+                            max(1, int(src.width / downsample)),
                         )
-                    data = src.read(band_idx, out_shape=out_shape).astype(np.float64)
+                    raw = src.read(band_idx, out_shape=out_shape).astype(np.float64)
                     if src.nodata is not None:
-                        valid = data[data != src.nodata]
+                        mask = raw != src.nodata
                     else:
-                        valid = data.ravel()
+                        mask = ~np.isnan(raw)
+                    scale = src.scales[band_idx - 1] if src.scales else 1.0
+                    offset = src.offsets[band_idx - 1] if src.offsets else 0.0
+                    if scale != 1.0 or offset != 0.0:
+                        data = raw * scale + offset
+                    else:
+                        data = raw
+                    valid = data[mask]
                     valid = valid[~np.isnan(valid)]
                     if valid.size > 0:
                         all_valid.append(valid)


### PR DESCRIPTION
## Summary
- Remote COGs (e.g. GHRSST SST) store data as `int16` with scale/offset metadata baked into the GeoTIFF tags
- `_compute_remote_stats` was reading raw pixel values without applying these transforms, producing rescale ranges like `-26800..5333` instead of correct physical values (~270–310K for SST)
- Now applies `src.scales` and `src.offsets` per band before computing p2/p98 percentiles
- Also fixes a variable name collision between the decimation factor and the band scale factor

## Test plan
- [ ] Delete existing GHRSST dataset, rebuild ingestion container, re-connect GHRSST
- [ ] Verify `raster_min`/`raster_max` are in a sensible range (e.g. ~271–305 for Kelvin SST)
- [ ] Verify map renders smooth temperature gradients, not noise
- [ ] Verify changing dates in temporal controls shows visually different tiles
- [ ] Connect GEBCO and LG Land Carbon to verify they still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing and invalid values in remote raster data processing
  * Corrected application of linear transformations to raster values during statistics computation
  * Enhanced support for rasters with diverse encoding formats and nodata representations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->