### PR TITLE
fix: use raw pixel values for rescale stats, not scaled values

### DIFF
--- a/ingestion/src/services/remote_register.py
+++ b/ingestion/src/services/remote_register.py
@@ -85,18 +85,11 @@ def _compute_remote_stats_sync(
                             max(1, int(src.height / downsample)),
                             max(1, int(src.width / downsample)),
                         )
-                    raw = src.read(band_idx, out_shape=out_shape).astype(np.float64)
+                    data = src.read(band_idx, out_shape=out_shape).astype(np.float64)
                     if src.nodata is not None:
-                        mask = raw != src.nodata
+                        valid = data[data != src.nodata]
                     else:
-                        mask = ~np.isnan(raw)
-                    scale = src.scales[band_idx - 1] if src.scales else 1.0
-                    offset = src.offsets[band_idx - 1] if src.offsets else 0.0
-                    if scale != 1.0 or offset != 0.0:
-                        data = raw * scale + offset
-                    else:
-                        data = raw
-                    valid = data[mask]
+                        valid = data.ravel()
                     valid = valid[~np.isnan(valid)]
                     if valid.size > 0:
                         all_valid.append(valid)


### PR DESCRIPTION
## Summary
- titiler reads raw pixel values from COGs and uses `rescale` to map them to colormap range 0–255
- PR #193 applied scale/offset to get physical values (Celsius), but titiler needs the raw int16 range for rescaling
- Reverts the scale/offset application while keeping other improvements (bounded reads, URL redaction)
- GHRSST rescale should now be ~`-26800..5333` (raw int16) instead of `-1.8..30.3` (Celsius)

## Test plan
- [ ] Delete GHRSST dataset, rebuild ingestion, re-connect
- [ ] Verify map shows smooth temperature gradients (not two-tone yellow/purple)
- [ ] Verify temporal controls show different data per date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized remote raster per-band sampling by refining pixel validity detection and streamlining data transformation handling during statistics computation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->