### PR TITLE
fix: close SSRF holes and enforce access control

### DIFF
--- a/ingestion/src/routes/connect_remote.py
+++ b/ingestion/src/routes/connect_remote.py
@@ -9,6 +9,7 @@ from pydantic import field_validator
 from src.models import Job
 from src.services.discovery import DiscoveryError, fetch_and_discover
 from src.services.remote_pipeline import run_remote_pipeline
+from src.services.url_validation import SSRFError, validate_url_safe
 from src.state import jobs
 from src.workspace import get_workspace_id
 
@@ -20,12 +21,11 @@ class DiscoverRequest(PydanticBaseModel):
 
     @field_validator("url")
     @classmethod
-    def validate_url_scheme(cls, v: str) -> str:
-        if not (
-            v.startswith("http://") or v.startswith("https://") or v.startswith("s3://")
-        ):
-            raise ValueError("URL must start with http://, https://, or s3://")
-        return v
+    def validate_url_safe(cls, v: str) -> str:
+        try:
+            return validate_url_safe(v, allow_s3=True)
+        except SSRFError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 class DiscoverResponse(PydanticBaseModel):
@@ -38,6 +38,26 @@ class ConnectRequest(PydanticBaseModel):
     url: str
     mode: str
     files: list[dict]
+
+    @field_validator("url")
+    @classmethod
+    def validate_url_safe(cls, v: str) -> str:
+        try:
+            return validate_url_safe(v, allow_s3=True)
+        except SSRFError as exc:
+            raise ValueError(str(exc)) from exc
+
+    @field_validator("files")
+    @classmethod
+    def validate_file_urls(cls, v: list[dict]) -> list[dict]:
+        for f in v:
+            file_url = f.get("url", "")
+            if file_url:
+                try:
+                    validate_url_safe(file_url, allow_s3=True)
+                except SSRFError as exc:
+                    raise ValueError(str(exc)) from exc
+        return v
 
     @field_validator("mode")
     @classmethod

--- a/ingestion/src/routes/jobs.py
+++ b/ingestion/src/routes/jobs.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import time
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from sse_starlette.sse import EventSourceResponse
 
 from src.models import JobStatus
@@ -13,21 +13,28 @@ from src.state import jobs
 router = APIRouter(prefix="/api")
 
 
-@router.get("/jobs/{job_id}")
-async def get_job(job_id: str):
-    """Get the current status of a conversion job."""
+def _get_job_for_workspace(job_id: str, request: Request):
+    """Look up a job, enforcing workspace scoping."""
     job = jobs.get(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
+    workspace_id = request.headers.get("x-workspace-id", "")
+    if job.workspace_id and workspace_id != job.workspace_id:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+
+
+@router.get("/jobs/{job_id}")
+async def get_job(job_id: str, request: Request):
+    """Get the current status of a conversion job."""
+    job = _get_job_for_workspace(job_id, request)
     return job.model_dump()
 
 
 @router.get("/jobs/{job_id}/stream")
-async def stream_job(job_id: str):
+async def stream_job(job_id: str, request: Request):
     """SSE stream of job status updates."""
-    job = jobs.get(job_id)
-    if job is None:
-        raise HTTPException(status_code=404, detail="Job not found")
+    job = _get_job_for_workspace(job_id, request)
 
     async def event_generator():
         last_status = (None, None)

--- a/ingestion/src/routes/stories.py
+++ b/ingestion/src/routes/stories.py
@@ -90,10 +90,15 @@ async def list_stories(request: Request):
 
 @router.get("/stories/{story_id}")
 async def get_story(story_id: str, request: Request):
+    workspace_id = request.headers.get("x-workspace-id", "")
     session = get_session(request)
     try:
         row = session.get(StoryRow, story_id)
         if not row:
+            raise HTTPException(status_code=404, detail="Story not found")
+        # If the requester owns the story, return it regardless of published state.
+        # Otherwise, only return published stories.
+        if row.workspace_id != workspace_id and not row.published:
             raise HTTPException(status_code=404, detail="Story not found")
         return _row_to_response(row)
     finally:

--- a/ingestion/src/routes/upload.py
+++ b/ingestion/src/routes/upload.py
@@ -1,8 +1,6 @@
 """Upload route — accepts files and starts the conversion pipeline."""
 
-import ipaddress
 import os
-import socket
 import tempfile
 from contextlib import asynccontextmanager
 from urllib.parse import urlparse
@@ -27,6 +25,7 @@ from src.services.duplicate_check import check_duplicate_filename
 from src.services.format_checker import check_format
 from src.services.pipeline import run_pipeline
 from src.services.temporal_pipeline import run_temporal_pipeline
+from src.services.url_validation import SSRFError, validate_url_safe
 from src.state import jobs, scan_store, scan_store_lock
 from src.workspace import get_workspace_id
 
@@ -57,30 +56,10 @@ class ConvertUrlRequest(PydanticBaseModel):
     @field_validator("url")
     @classmethod
     def validate_url_scheme(cls, v: str) -> str:
-        parsed = urlparse(v)
-        if parsed.scheme not in ("http", "https"):
-            raise ValueError("Only http and https URLs are supported")
-        hostname = parsed.hostname
-        if not hostname:
-            raise ValueError("URL must include a hostname")
         try:
-            addr = ipaddress.ip_address(hostname)
-            if addr.is_private or addr.is_loopback or addr.is_reserved:
-                raise ValueError("URLs pointing to private networks are not allowed")
-        except ValueError as exc:
-            if "not allowed" in str(exc):
-                raise
-            try:
-                resolved = socket.getaddrinfo(hostname, None)
-                for _, _, _, _, sockaddr in resolved:
-                    addr = ipaddress.ip_address(sockaddr[0])
-                    if addr.is_private or addr.is_loopback or addr.is_reserved:
-                        raise ValueError(
-                            "URLs resolving to private networks are not allowed"
-                        )
-            except socket.gaierror:
-                pass
-        return v
+            return validate_url_safe(v)
+        except SSRFError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 @asynccontextmanager

--- a/ingestion/src/services/url_validation.py
+++ b/ingestion/src/services/url_validation.py
@@ -1,0 +1,52 @@
+"""Shared SSRF protection for all URL-fetching endpoints."""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+class SSRFError(ValueError):
+    pass
+
+
+def validate_url_safe(url: str, *, allow_s3: bool = False) -> str:
+    """Validate that a URL does not target private/internal networks.
+
+    Raises SSRFError if the URL points to a private, loopback, or reserved IP.
+    Returns the URL unchanged if safe.
+    """
+    parsed = urlparse(url)
+
+    allowed_schemes = {"http", "https"}
+    if allow_s3:
+        allowed_schemes.add("s3")
+
+    if parsed.scheme not in allowed_schemes:
+        schemes = ", ".join(sorted(allowed_schemes))
+        raise SSRFError(f"Only {schemes} URLs are supported")
+
+    if parsed.scheme == "s3":
+        return url
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise SSRFError("URL must include a hostname")
+
+    try:
+        addr = ipaddress.ip_address(hostname)
+        if addr.is_private or addr.is_loopback or addr.is_reserved:
+            raise SSRFError("URLs pointing to private networks are not allowed")
+    except ValueError:
+        # hostname is a DNS name, resolve it
+        try:
+            resolved = socket.getaddrinfo(hostname, None)
+            for _, _, _, _, sockaddr in resolved:
+                addr = ipaddress.ip_address(sockaddr[0])
+                if addr.is_private or addr.is_loopback or addr.is_reserved:
+                    raise SSRFError(
+                        "URLs resolving to private networks are not allowed"
+                    )
+        except socket.gaierror:
+            pass
+
+    return url

--- a/ingestion/tests/test_job_scoping.py
+++ b/ingestion/tests/test_job_scoping.py
@@ -1,0 +1,44 @@
+"""Tests for job workspace scoping."""
+
+from src.models import Job
+from src.state import jobs
+
+
+def test_job_visible_to_owner(client):
+    job = Job(filename="test.tif")
+    job.workspace_id = "testABCD"
+    jobs[job.id] = job
+
+    resp = client.get(f"/api/jobs/{job.id}")
+    assert resp.status_code == 200
+    del jobs[job.id]
+
+
+def test_job_hidden_from_other_workspace(client, app):
+    job = Job(filename="test.tif")
+    job.workspace_id = "ownerXYZ"
+    jobs[job.id] = job
+
+    resp = client.get(f"/api/jobs/{job.id}")
+    assert resp.status_code == 404
+    del jobs[job.id]
+
+
+def test_job_without_workspace_accessible(client):
+    job = Job(filename="test.tif")
+    job.workspace_id = None
+    jobs[job.id] = job
+
+    resp = client.get(f"/api/jobs/{job.id}")
+    assert resp.status_code == 200
+    del jobs[job.id]
+
+
+def test_stream_hidden_from_other_workspace(client, app):
+    job = Job(filename="test.tif")
+    job.workspace_id = "ownerXYZ"
+    jobs[job.id] = job
+
+    resp = client.get(f"/api/jobs/{job.id}/stream")
+    assert resp.status_code == 404
+    del jobs[job.id]

--- a/ingestion/tests/test_ssrf_discover.py
+++ b/ingestion/tests/test_ssrf_discover.py
@@ -1,0 +1,52 @@
+"""SSRF protection tests for discover and connect-remote endpoints."""
+
+
+def test_discover_rejects_loopback(client):
+    resp = client.post("/api/discover", json={"url": "http://127.0.0.1/listing"})
+    assert resp.status_code == 422
+
+
+def test_discover_rejects_private_ip(client):
+    resp = client.post("/api/discover", json={"url": "http://10.0.0.1/listing"})
+    assert resp.status_code == 422
+
+
+def test_discover_rejects_metadata_endpoint(client):
+    resp = client.post(
+        "/api/discover",
+        json={"url": "http://169.254.169.254/latest/meta-data/"},
+    )
+    assert resp.status_code == 422
+
+
+def test_discover_allows_s3_scheme(client):
+    # S3 scheme should pass validation (will fail on fetch, but not on validation)
+    resp = client.post("/api/discover", json={"url": "s3://bucket/prefix/"})
+    # 400 from fetch failure, not 422 from validation
+    assert resp.status_code == 400
+
+
+def test_connect_remote_rejects_private_url(client):
+    resp = client.post(
+        "/api/connect-remote",
+        json={
+            "url": "http://10.0.0.1/listing",
+            "mode": "mosaic",
+            "files": [{"url": "https://example.com/file.tif", "filename": "file.tif"}],
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_connect_remote_rejects_private_file_url(client):
+    resp = client.post(
+        "/api/connect-remote",
+        json={
+            "url": "https://example.com/listing",
+            "mode": "mosaic",
+            "files": [
+                {"url": "http://169.254.169.254/secret", "filename": "secret.tif"}
+            ],
+        },
+    )
+    assert resp.status_code == 422

--- a/ingestion/tests/test_story_access.py
+++ b/ingestion/tests/test_story_access.py
@@ -1,7 +1,5 @@
 """Tests for story access control — unpublished stories are private."""
 
-from sqlalchemy.orm import sessionmaker
-
 
 def test_unpublished_story_visible_to_owner(client):
     resp = client.post(

--- a/ingestion/tests/test_story_access.py
+++ b/ingestion/tests/test_story_access.py
@@ -1,0 +1,73 @@
+"""Tests for story access control — unpublished stories are private."""
+
+from sqlalchemy.orm import sessionmaker
+
+
+def test_unpublished_story_visible_to_owner(client):
+    resp = client.post(
+        "/api/stories",
+        json={"title": "Draft", "chapters": [], "published": False},
+    )
+    assert resp.status_code == 201
+    story_id = resp.json()["id"]
+
+    resp = client.get(f"/api/stories/{story_id}")
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Draft"
+
+
+def test_unpublished_story_hidden_from_other_workspace(client, app):
+    resp = client.post(
+        "/api/stories",
+        json={"title": "Secret", "chapters": [], "published": False},
+    )
+    story_id = resp.json()["id"]
+
+    from starlette.testclient import TestClient
+
+    other = TestClient(app, headers={"X-Workspace-Id": "otherWS1"})
+    resp = other.get(f"/api/stories/{story_id}")
+    assert resp.status_code == 404
+
+
+def test_unpublished_story_hidden_without_workspace(client, app):
+    resp = client.post(
+        "/api/stories",
+        json={"title": "Secret", "chapters": [], "published": False},
+    )
+    story_id = resp.json()["id"]
+
+    from starlette.testclient import TestClient
+
+    anon = TestClient(app)
+    resp = anon.get(f"/api/stories/{story_id}")
+    assert resp.status_code == 404
+
+
+def test_published_story_visible_to_anyone(client, app):
+    resp = client.post(
+        "/api/stories",
+        json={"title": "Public", "chapters": [], "published": True},
+    )
+    story_id = resp.json()["id"]
+
+    from starlette.testclient import TestClient
+
+    anon = TestClient(app)
+    resp = anon.get(f"/api/stories/{story_id}")
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Public"
+
+
+def test_published_story_visible_to_other_workspace(client, app):
+    resp = client.post(
+        "/api/stories",
+        json={"title": "Shared", "chapters": [], "published": True},
+    )
+    story_id = resp.json()["id"]
+
+    from starlette.testclient import TestClient
+
+    other = TestClient(app, headers={"X-Workspace-Id": "otherWS2"})
+    resp = other.get(f"/api/stories/{story_id}")
+    assert resp.status_code == 200

--- a/ingestion/tests/test_url_validation.py
+++ b/ingestion/tests/test_url_validation.py
@@ -1,0 +1,53 @@
+import pytest
+
+from src.services.url_validation import SSRFError, validate_url_safe
+
+
+def test_rejects_file_scheme():
+    with pytest.raises(SSRFError):
+        validate_url_safe("file:///etc/passwd")
+
+
+def test_rejects_ftp_scheme():
+    with pytest.raises(SSRFError):
+        validate_url_safe("ftp://example.com/data.tif")
+
+
+def test_rejects_loopback_ip():
+    with pytest.raises(SSRFError, match="private"):
+        validate_url_safe("http://127.0.0.1:9000/bucket/file.tif")
+
+
+def test_rejects_private_ip():
+    with pytest.raises(SSRFError, match="private"):
+        validate_url_safe("http://10.0.0.1/file.tif")
+
+
+def test_rejects_link_local():
+    with pytest.raises(SSRFError, match="private"):
+        validate_url_safe("http://169.254.169.254/latest/meta-data/")
+
+
+def test_allows_public_url():
+    result = validate_url_safe("https://example.com/file.tif")
+    assert result == "https://example.com/file.tif"
+
+
+def test_rejects_no_hostname():
+    with pytest.raises(SSRFError):
+        validate_url_safe("http:///path")
+
+
+def test_s3_rejected_by_default():
+    with pytest.raises(SSRFError):
+        validate_url_safe("s3://bucket/key")
+
+
+def test_s3_allowed_when_enabled():
+    result = validate_url_safe("s3://bucket/key", allow_s3=True)
+    assert result == "s3://bucket/key"
+
+
+def test_s3_skips_ip_check():
+    result = validate_url_safe("s3://my-bucket/data.tif", allow_s3=True)
+    assert result == "s3://my-bucket/data.tif"


### PR DESCRIPTION
## Summary

- **SSRF protection**: Extracted shared `validate_url_safe()` utility from `convert-url` and applied it to `discover` and `connect-remote` endpoints — both the source URL and individual file URLs are now checked for private/loopback/reserved IPs
- **Story access control**: `GET /api/stories/{id}` now returns 404 for unpublished stories when accessed from a different workspace or without a workspace header
- **Job workspace scoping**: `GET /api/jobs/{id}` and SSE stream now enforce workspace ownership, preventing cross-workspace job status leaks

## Test plan

- [x] New tests for URL validator (`test_url_validation.py`) — 10 cases covering scheme, IP, DNS, S3
- [x] New tests for discover/connect-remote SSRF (`test_ssrf_discover.py`) — 6 cases
- [x] New tests for story access control (`test_story_access.py`) — 5 cases covering owner/other/anon x published/unpublished
- [x] New tests for job scoping (`test_job_scoping.py`) — 4 cases
- [x] Existing `test_convert_url.py` and `test_stories.py` still pass (286/287 pass, 1 pre-existing S3 infra failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs and story access are enforced per workspace; unpublished stories remain workspace-private while published ones stay public.

* **Bug Fixes / Security**
  * Centralized and strengthened URL safety checks for remote connections and uploads, including file entries, to block unsafe network targets.

* **Tests**
  * Added API and unit tests covering workspace scoping and URL/SSRF validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->