### PR TITLE
fix: force deck.gl tile refresh on temporal browse navigation

### DIFF
--- a/frontend/src/lib/layers/rasterTileLayer.ts
+++ b/frontend/src/lib/layers/rasterTileLayer.ts
@@ -41,10 +41,11 @@ export function buildRasterTileLayers({
     );
     const ts = timesteps[clampedIndex];
     const separator = tileUrl.includes("?") ? "&" : "?";
+    const fullUrl = `${tileUrl}${separator}datetime=${encodeURIComponent(ts.datetime)}`;
     return [
       createCOGLayer({
-        id,
-        tileUrl: `${tileUrl}${separator}datetime=${encodeURIComponent(ts.datetime)}`,
+        id: `${id}-ts-${clampedIndex}`,
+        tileUrl: fullUrl,
         opacity,
       }),
     ];


### PR DESCRIPTION
## Summary
- Temporal browse mode (clicking Next/Previous dates) didn't update the map tiles
- deck.gl's `TileLayer` with a stable `id` doesn't reliably refetch when only the `data` URL's query string changes (e.g. `&datetime=` parameter)
- Fix: include the timestep index in the layer `id` (`raster-layer-viridis-0-ts-42`) so each date change creates a fresh TileLayer, guaranteeing correct tiles load

## Test plan
- [ ] Open a temporal dataset (e.g. GHRSST, tmin.2025.nc)
- [ ] Click Next/Previous — map should visibly change between dates
- [ ] Drag slider to a very different date — clear visual difference
- [ ] Animation mode (play button) still works correctly
- [ ] Non-temporal datasets unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporal raster tile layers by ensuring correct URL construction with datetime parameters and proper layer identification for time-specific tiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->