### PR TITLE
feat: retry example dataset registration on transient startup failures

### DIFF
--- a/ingestion/src/app.py
+++ b/ingestion/src/app.py
@@ -37,12 +37,40 @@ async def _cleanup_scans():
 
 
 async def _register_examples(app):
-    try:
-        from src.services.example_datasets import register_example_datasets
+    """Register example datasets with bounded retry for transient startup failures.
 
-        await register_example_datasets(db_session_factory=app.state.db_session_factory)
-    except Exception:
-        logger.exception("Example dataset registration failed")
+    If upstream dependencies (database, STAC API, remote tiles) are not ready
+    when the ingestion container boots, registering any product may raise.
+    Retry a few times with backoff so a slow-starting deploy still populates
+    the gallery without requiring a manual restart.
+    """
+    from src.services.example_datasets import (
+        missing_example_products,
+        register_example_datasets,
+    )
+
+    backoffs = [0, 30, 60, 120, 240]
+    for attempt, delay in enumerate(backoffs, start=1):
+        if delay:
+            await asyncio.sleep(delay)
+        try:
+            await register_example_datasets(
+                db_session_factory=app.state.db_session_factory
+            )
+            missing = missing_example_products(app.state.db_session_factory)
+            if not missing:
+                return
+            logger.warning(
+                "Example dataset registration incomplete after attempt %d "
+                "(still missing: %s)",
+                attempt,
+                [p.slug for p in missing],
+            )
+        except Exception:
+            logger.exception("Example dataset registration attempt %d failed", attempt)
+    logger.error(
+        "Gave up registering example datasets after %d attempts", len(backoffs)
+    )
 
 
 async def _cleanup_expired(app):

--- a/ingestion/src/services/example_datasets.py
+++ b/ingestion/src/services/example_datasets.py
@@ -59,6 +59,14 @@ def ordered_products() -> list[SourceCoopProduct]:
     return fast + slow
 
 
+def missing_example_products(
+    db_session_factory: sessionmaker,
+) -> list[SourceCoopProduct]:
+    """Return curated products not yet registered as example datasets."""
+    already = _existing_example_source_urls(db_session_factory)
+    return [p for p in ordered_products() if p.listing_url not in already]
+
+
 def _existing_example_source_urls(db_session_factory: sessionmaker) -> set[str]:
     """Return the set of source.coop listing URLs already registered as examples."""
     session = db_session_factory()

--- a/ingestion/tests/services/test_example_datasets.py
+++ b/ingestion/tests/services/test_example_datasets.py
@@ -11,6 +11,7 @@ from sqlalchemy.pool import StaticPool
 from src.models.base import Base
 from src.models.dataset import DatasetRow
 from src.services.example_datasets import (
+    missing_example_products,
     ordered_products,
     register_example_datasets,
 )
@@ -141,3 +142,32 @@ def test_register_example_datasets_continues_after_product_failure():
 
     assert enum_mock.await_count == 2
     register_mock.assert_not_awaited()
+
+
+def test_missing_example_products_returns_unregistered():
+    """missing_example_products reflects which listings are not yet persisted."""
+    _, factory = _make_db()
+
+    assert len(missing_example_products(factory)) == len(ordered_products())
+
+    session = factory()
+    try:
+        session.add(
+            DatasetRow(
+                id="already",
+                filename="GEBCO 2024",
+                dataset_type="raster",
+                format_pair="geotiff-to-cog",
+                tile_url="/t",
+                metadata_json='{"source_url": "https://data.source.coop/alexgleith/gebco-2024/"}',
+                is_example=True,
+                workspace_id=None,
+                created_at=datetime.now(UTC),
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    missing_slugs = {p.slug for p in missing_example_products(factory)}
+    assert "alexgleith/gebco-2024" not in missing_slugs


### PR DESCRIPTION
Follow-up to #203. Addresses CodeRabbit's "Major" startup-race concern.

## Summary
- Ingestion lifespan now retries `register_example_datasets` up to 5 times with backoff (0, 30, 60, 120, 240s) if upstream dependencies (DB, STAC API, remote tiles) are not ready on boot.
- Adds `missing_example_products(factory)` helper so the retry loop knows when to stop.
- New unit test covers the helper.

## Test plan
- [x] `uv run pytest tests/services/test_example_datasets.py` — 5/5 pass
- [x] Existing idempotency behavior preserved (the function already skips already-registered products; the new loop just re-invokes it until everything is present or attempts exhausted)