### PR TITLE
fix: bump frontend dev container memory limit to 2G

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: 2G
     ports:
       - "${FRONTEND_PORT:-5185}:5185"
     environment:


### PR DESCRIPTION
## Summary

- Vite dev server + esbuild transform pool OOMs at 1G on first request
- Observed steady-state working set is ~1.1 GiB after module graph resolves
- 1G hits the cgroup hard limit → container killed & restarted in a loop → 500 on all requests
- 2G gives ~55% headroom, working set unchanged

Dev-only change. Prod serves static assets via Caddy and is unaffected by this limit.

## Investigation

The 1G limit was set in April ("production stability improvements"). Source tree has since grown to ~18K lines TS, and heavy deps (duckdb-wasm 148MB, phosphor 57MB, maplibre 41MB, loaders.gl 42MB) need to be transformed by esbuild at dev startup. No single PR caused this — gradual creep past the old limit.

## Test plan

- [x] `docker compose up -d frontend` with 2G succeeds
- [x] First request to `/src/main.tsx` returns 200 (was 500 at 1G)
- [x] `docker stats` shows steady-state 1.12 GiB / 2 GiB
- [x] No OOM events in `docker events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated memory resource allocations in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->