### PR TITLE
fix: avoid full-res read in categorical color table detection

### DIFF
--- a/ingestion/src/services/categorical.py
+++ b/ingestion/src/services/categorical.py
@@ -53,6 +53,23 @@ def _assign_palette_color(index: int) -> str:
     return QUALITATIVE_PALETTE[index % len(QUALITATIVE_PALETTE)]
 
 
+def _read_sample(src, band: int = 1):
+    """Read a band at its coarsest overview, or a decimated full read if no overviews."""
+    overviews = src.overviews(band)
+    if overviews:
+        level = overviews[-1]
+        height = max(1, src.height // level)
+        width = max(1, src.width // level)
+        return src.read(band, out_shape=(height, width))
+    target = 512
+    if src.height <= target and src.width <= target:
+        return src.read(band)
+    return src.read(
+        band,
+        out_shape=(min(target, src.height), min(target, src.width)),
+    )
+
+
 def detect_categories(raster_path: str) -> CategoricalResult:
     """Detect whether a raster is categorical and extract category metadata.
 
@@ -77,7 +94,7 @@ def detect_categories(raster_path: str) -> CategoricalResult:
             if non_default:
                 import numpy as np
 
-                data = src.read(1)
+                data = _read_sample(src, band=1)
                 present_values = set(int(v) for v in np.unique(data))
                 if nodata is not None:
                     present_values.discard(int(nodata))
@@ -161,15 +178,7 @@ def detect_categories(raster_path: str) -> CategoricalResult:
 
         import numpy as np
 
-        overviews = src.overviews(1)
-        if overviews:
-            overview_level = overviews[-1]
-            height = max(1, src.height // overview_level)
-            width = max(1, src.width // overview_level)
-            data = src.read(1, out_shape=(height, width))
-        else:
-            data = src.read(1)
-
+        data = _read_sample(src, band=1)
         unique_values = np.unique(data)
 
         if nodata is not None:

--- a/ingestion/tests/test_categorical.py
+++ b/ingestion/tests/test_categorical.py
@@ -195,3 +195,55 @@ def test_uint8_without_colormap_many_values_not_categorical(tmp_path):
         dst.write(data, 1)
     result = detect_categories(path)
     assert result.is_categorical is False
+
+
+@pytest.fixture
+def large_categorical_tif_with_colormap(tmp_path):
+    """10000x10000 uint8 with colormap — reading full res is ~100 MB."""
+    path = str(tmp_path / "large_landcover.tif")
+    rng = np.random.default_rng(42)
+    data = rng.integers(1, 6, size=(10000, 10000), dtype="uint8")
+    transform = from_bounds(0, 0, 1, 1, 10000, 10000)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        width=10000,
+        height=10000,
+        count=1,
+        dtype="uint8",
+        crs="EPSG:4326",
+        transform=transform,
+        tiled=True,
+        blockxsize=512,
+        blockysize=512,
+    ) as dst:
+        dst.write(data, 1)
+        dst.write_colormap(
+            1,
+            {
+                1: (255, 0, 0, 255),
+                2: (0, 255, 0, 255),
+                3: (0, 0, 255, 255),
+                4: (255, 255, 0, 255),
+                5: (128, 128, 128, 255),
+            },
+        )
+        dst.build_overviews([2, 4, 8, 16, 32], rasterio.enums.Resampling.nearest)
+    return path
+
+
+def test_colormap_tier_reads_overview_not_full_res(large_categorical_tif_with_colormap):
+    """Regression: reading full-res 10k x 10k uint8 caused ~100 MB allocation
+    and OOM for bigger tiles in production. Must use overviews."""
+    import resource
+
+    before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    result = detect_categories(large_categorical_tif_with_colormap)
+    after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    assert result.is_categorical is True
+    assert len(result.categories) == 5
+    # Full-res would be ~100 MB; overview (~313x313 at level 32) is ~100 KB.
+    # Allow 30 MB of headroom for GDAL/rasterio overhead.
+    delta_mb = (after - before) / 1024
+    assert delta_mb < 30, f"Memory grew by {delta_mb:.1f} MB (expected <30)"

--- a/ingestion/tests/test_categorical.py
+++ b/ingestion/tests/test_categorical.py
@@ -236,14 +236,17 @@ def large_categorical_tif_with_colormap(tmp_path):
 def test_colormap_tier_reads_overview_not_full_res(large_categorical_tif_with_colormap):
     """Regression: reading full-res 10k x 10k uint8 caused ~100 MB allocation
     and OOM for bigger tiles in production. Must use overviews."""
-    import resource
+    import tracemalloc
 
-    before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-    result = detect_categories(large_categorical_tif_with_colormap)
-    after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    tracemalloc.start()
+    try:
+        result = detect_categories(large_categorical_tif_with_colormap)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
     assert result.is_categorical is True
     assert len(result.categories) == 5
     # Full-res would be ~100 MB; overview (~313x313 at level 32) is ~100 KB.
-    # Allow 30 MB of headroom for GDAL/rasterio overhead.
-    delta_mb = (after - before) / 1024
-    assert delta_mb < 30, f"Memory grew by {delta_mb:.1f} MB (expected <30)"
+    # Allow 30 MB for Python/numpy overhead around the coarse read.
+    peak_mb = peak / (1024 * 1024)
+    assert peak_mb < 30, f"Peak Python allocation was {peak_mb:.1f} MB (expected <30)"


### PR DESCRIPTION
## Summary

- Tier 1 (GDAL color table) in \`detect_categories\` called \`src.read(1)\` with no \`out_shape\`, loading the full-resolution band into memory
- For ESA WorldCover 36000x36000 uint8 tiles that's ~1.3 GB, which OOM-killed the ingestion container during POST /api/connections
- Tier 3 (heuristic) already used the coarsest overview; now both tiers share a \`_read_sample\` helper
- Added regression test: 10000x10000 COG with overviews must allocate <30 MB

## How observed

User reported a 500 on POST /api/connections when connecting the ESA WorldCover N45W123 (~62 MB) tile. Watched memory during the POST:

\`\`\`
t=3s 146 MiB
t=4s 765 MiB
t=5s 1.309 GiB
→ OOM kill (exitCode=137), container restart loop
\`\`\`

## Test plan

- [x] \`uv run pytest tests/test_categorical.py -v\` — 9/9 pass
- [x] New regression test \`test_colormap_tier_reads_overview_not_full_res\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Centralized band sampling to prefer lower-resolution overviews when available, reducing memory usage and avoiding full-resolution reads for large rasters.

* **Tests**
  * Added a regression test with a large raster fixture that verifies categorical detection remains correct and peak memory usage stays low during ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->