### PR TITLE
fix: prevent ingestion OOM during tif conversion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
+          memory: 4G
     ports:
       - "${INGESTION_PORT:-8086}:8000"
     environment:
@@ -147,6 +147,7 @@ services:
       S3_ENDPOINT: ${R2_ENDPOINT}
       AWS_ACCESS_KEY_ID: ${R2_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY}
+      GDAL_CACHEMAX: "512"
       STAC_API_URL: http://stac-api:8080
       RASTER_TILER_URL: http://raster-tiler:80
       VECTOR_TILER_URL: http://vector-tiler:80


### PR DESCRIPTION
## Summary
- Cap `GDAL_CACHEMAX` at 512 MB on the ingestion service
- Raise ingestion container memory limit from 2G to 4G

## Root cause
Job `765ce5bf-8d6d-4479-a0e7-beef2de5fb8f` from #208 was killed mid-conversion: `docker inspect` showed `OOMKilled=true` with `RestartCount=8`. Once ingestion restarted, the in-memory `jobs` dict was wiped, so the frontend's SSE poll to `/api/jobs/{id}/stream` returned 404 and surfaced "Connection lost."

`gdalwarp` was invoked with `-multi -wo NUM_THREADS=ALL_CPUS -of COG` with no cap on GDAL's block cache. Default `GDAL_CACHEMAX` is ~5% of host RAM (~750 MB here), plus per-thread warp buffers on 8 CPUs plus COG tile buffering — easy to blow past the 2G container limit on larger tifs.

## Follow-ups (not in this PR)
- Persist the job registry so ingestion restarts don't orphan in-flight uploads.

Fixes #208

## Test plan
- [ ] Upload a tif that previously failed and confirm conversion completes without the container restarting
- [ ] `docker stats` stays under the new 4G limit during conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for ingestion and deployment services to improve processing capacity.
  * Enhanced configuration settings for the ingestion service to optimize performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->