### PR TITLE
feat(frontend): sidebar labels and section dividers

### DIFF
--- a/frontend/src/components/MapSidePanel.tsx
+++ b/frontend/src/components/MapSidePanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { Box } from "@chakra-ui/react";
+import { Box, Text } from "@chakra-ui/react";
 import { useOptionalWorkspace } from "../hooks/useWorkspace";
 import type { MapItem, Connection } from "../types";
 import type { RenderMode } from "../hooks/useMapControls";
@@ -142,13 +142,25 @@ export function MapSidePanel({
   return (
     <Box p={4}>
       {!shared && (
-        <DataSwitcher
-          activeId={item.id}
-          activeSource={item.source}
-          onUploadClick={() => setMode("upload")}
-          onAddConnectionClick={() => setMode("add-connection")}
-          refreshKey={refreshKey}
-        />
+        <Box mb={4} pb={4} borderBottom="1px solid" borderColor="brand.border">
+          <Text
+            fontSize="11px"
+            color="brand.textSecondary"
+            fontWeight={600}
+            textTransform="uppercase"
+            letterSpacing="1px"
+            mb={2}
+          >
+            Dataset
+          </Text>
+          <DataSwitcher
+            activeId={item.id}
+            activeSource={item.source}
+            onUploadClick={() => setMode("upload")}
+            onAddConnectionClick={() => setMode("add-connection")}
+            refreshKey={refreshKey}
+          />
+        </Box>
       )}
 
       {/* Raster controls */}

--- a/frontend/src/components/RasterSidebarControls.tsx
+++ b/frontend/src/components/RasterSidebarControls.tsx
@@ -205,51 +205,61 @@ export function RasterSidebarControls(props: RasterSidebarControlsProps) {
               <Text fontSize="11px" color="brand.textSecondary" mb={1}>
                 Rescale
               </Text>
-              <Flex gap={2} align="center">
-                <input
-                  aria-label="Rescale min"
-                  type="number"
-                  step="any"
-                  value={minDraft}
-                  placeholder={datasetMin != null ? String(datasetMin) : ""}
-                  onChange={(e) => setMinDraft(e.target.value)}
-                  onBlur={() => commit(minDraft, maxDraft)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") commit(minDraft, maxDraft);
-                  }}
-                  style={{
-                    flex: 1,
-                    minWidth: 0,
-                    height: "28px",
-                    padding: "0 8px",
-                    border: "1px solid var(--chakra-colors-brand-border)",
-                    borderRadius: "6px",
-                    fontSize: "13px",
-                    background: "white",
-                  }}
-                />
-                <input
-                  aria-label="Rescale max"
-                  type="number"
-                  step="any"
-                  value={maxDraft}
-                  placeholder={datasetMax != null ? String(datasetMax) : ""}
-                  onChange={(e) => setMaxDraft(e.target.value)}
-                  onBlur={() => commit(minDraft, maxDraft)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") commit(minDraft, maxDraft);
-                  }}
-                  style={{
-                    flex: 1,
-                    minWidth: 0,
-                    height: "28px",
-                    padding: "0 8px",
-                    border: "1px solid var(--chakra-colors-brand-border)",
-                    borderRadius: "6px",
-                    fontSize: "13px",
-                    background: "white",
-                  }}
-                />
+              <Flex gap={2} align="flex-end">
+                <Box flex={1} minW={0}>
+                  <Text fontSize="10px" color="brand.textSecondary" mb={1}>
+                    Min
+                  </Text>
+                  <input
+                    aria-label="Rescale min"
+                    type="number"
+                    step="any"
+                    value={minDraft}
+                    placeholder={datasetMin != null ? String(datasetMin) : ""}
+                    onChange={(e) => setMinDraft(e.target.value)}
+                    onBlur={() => commit(minDraft, maxDraft)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") commit(minDraft, maxDraft);
+                    }}
+                    style={{
+                      width: "100%",
+                      minWidth: 0,
+                      height: "28px",
+                      padding: "0 8px",
+                      border: "1px solid var(--chakra-colors-brand-border)",
+                      borderRadius: "6px",
+                      fontSize: "13px",
+                      background: "white",
+                    }}
+                  />
+                </Box>
+                <Box flex={1} minW={0}>
+                  <Text fontSize="10px" color="brand.textSecondary" mb={1}>
+                    Max
+                  </Text>
+                  <input
+                    aria-label="Rescale max"
+                    type="number"
+                    step="any"
+                    value={maxDraft}
+                    placeholder={datasetMax != null ? String(datasetMax) : ""}
+                    onChange={(e) => setMaxDraft(e.target.value)}
+                    onBlur={() => commit(minDraft, maxDraft)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") commit(minDraft, maxDraft);
+                    }}
+                    style={{
+                      width: "100%",
+                      minWidth: 0,
+                      height: "28px",
+                      padding: "0 8px",
+                      border: "1px solid var(--chakra-colors-brand-border)",
+                      borderRadius: "6px",
+                      fontSize: "13px",
+                      background: "white",
+                    }}
+                  />
+                </Box>
                 <IconButton
                   aria-label="Reset rescale"
                   size="sm"
@@ -285,7 +295,7 @@ export function RasterSidebarControls(props: RasterSidebarControlsProps) {
         </Text>
       )}
 
-      <Box mb={3}>
+      <Box mb={3} pt={3} borderTop="1px solid" borderColor="brand.border">
         <Flex justify="space-between" mb={1}>
           <Text fontSize="11px" color="brand.textSecondary">
             Opacity
@@ -306,7 +316,7 @@ export function RasterSidebarControls(props: RasterSidebarControlsProps) {
       </Box>
 
       {canClientRender && onRenderModeChange && (
-        <Box mb={3}>
+        <Box mb={3} pt={3} borderTop="1px solid" borderColor="brand.border">
           <Flex justify="space-between" align="center">
             <Box>
               <Text fontSize="11px" color="brand.textSecondary">


### PR DESCRIPTION
## Summary

Polish the map sidebar per feedback on #52:

- Add a **DATASET** section heading above the dataset dropdown.
- Visually separate Dataset from Visualization Controls with a horizontal divider.
- Split the rescale inputs into labeled **Min** / **Max** columns.
- Add dividers above the Opacity and Client-side rendering groupings so related controls feel grouped.

Before/after: see screenshots in the conversation.

## Test plan

- [x] Visual check: open a raster dataset, confirm DATASET heading + divider, Min/Max labels, and section dividers render as expected
- [x] Tests: \`npx vitest run\` → 262/262 pass
- [x] Types: \`npx tsc --noEmit\` clean
- [x] Format: \`yarn prettier --check src\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the map side panel with clearer dataset control labeling and improved section spacing
  * Redesigned rescale controls with individual labeled min/max input fields arranged for better usability
  * Added visual dividers to opacity and rendering control sections for improved visual hierarchy and organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->