### PR TITLE
fix: pin Land & Carbon Lab example to single emissions raster

### DIFF
--- a/frontend/src/lib/sourceCoopCatalog.ts
+++ b/frontend/src/lib/sourceCoopCatalog.ts
@@ -33,11 +33,11 @@ export const sourceCoopCatalog: SourceCoopProduct[] = [
   },
   {
     slug: "vizzuality/lg-land-carbon-data",
-    name: "Land & Carbon Lab Carbon Data",
+    name: "Land & Carbon Lab: Deforestation Carbon Emissions",
     description:
-      "Land carbon flux and stock rasters produced by the WRI Land & Carbon Lab.",
+      "Gross carbon emissions from deforestation at 100 m resolution, produced by the WRI Land & Carbon Lab.",
     thumbnail: "/thumbnails/lg-land-carbon.jpg",
-    tags: ["carbon", "land", "climate"],
+    tags: ["carbon", "deforestation", "climate"],
     isTemporal: false,
   },
 ];

--- a/ingestion/src/services/enumerators/path_listing.py
+++ b/ingestion/src/services/enumerators/path_listing.py
@@ -32,7 +32,7 @@ async def enumerate_path_listing(
             greedy mosaic would stitch incompatible layers.
     """
     _common, keys = await _list_one_level(listing_url, prefix="")
-    allow = set(filenames) if filenames else None
+    allow = set(filenames) if filenames is not None else None
     items: list[RemoteItem] = []
     for key in keys:
         if not key.lower().endswith(_RASTER_EXTENSIONS):

--- a/ingestion/src/services/enumerators/path_listing.py
+++ b/ingestion/src/services/enumerators/path_listing.py
@@ -19,17 +19,27 @@ from src.services.enumerators.stac_sidecars import _list_one_level
 _RASTER_EXTENSIONS = (".tif", ".tiff", ".nc", ".nc4", ".h5", ".hdf5")
 
 
-async def enumerate_path_listing(listing_url: str) -> list[RemoteItem]:
+async def enumerate_path_listing(
+    listing_url: str, filenames: list[str] | None = None
+) -> list[RemoteItem]:
     """Enumerate raster files from a flat S3 prefix.
 
     Args:
         listing_url: URL of the S3 prefix (e.g. ``https://host/bucket/prefix/``).
+        filenames: Optional allowlist of exact filenames to include. When set,
+            only keys matching one of these names are returned. Use this for
+            buckets that hold an "atlas" of heterogeneous rasters where a
+            greedy mosaic would stitch incompatible layers.
     """
     _common, keys = await _list_one_level(listing_url, prefix="")
+    allow = set(filenames) if filenames else None
     items: list[RemoteItem] = []
     for key in keys:
-        if key.lower().endswith(_RASTER_EXTENSIONS):
-            items.append(
-                RemoteItem(href=urljoin(listing_url, key), datetime=None, bbox=None)
-            )
+        if not key.lower().endswith(_RASTER_EXTENSIONS):
+            continue
+        if allow is not None and key not in allow:
+            continue
+        items.append(
+            RemoteItem(href=urljoin(listing_url, key), datetime=None, bbox=None)
+        )
     return items

--- a/ingestion/src/services/example_datasets.py
+++ b/ingestion/src/services/example_datasets.py
@@ -36,7 +36,10 @@ logger = logging.getLogger(__name__)
 async def run_enumerator(product: SourceCoopProduct) -> list[RemoteItem]:
     """Dispatch to the enumerator named in the product config."""
     if product.enumerator == "path_listing":
-        return await enumerate_path_listing(listing_url=product.listing_url)
+        return await enumerate_path_listing(
+            listing_url=product.listing_url,
+            filenames=product.enumerator_args.get("filenames"),
+        )
     if product.enumerator == "stac_sidecars":
         return await enumerate_stac_sidecars(
             listing_url=product.listing_url,

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -50,13 +50,16 @@ _PRODUCTS: dict[str, SourceCoopProduct] = {
     ),
     "vizzuality/lg-land-carbon-data": SourceCoopProduct(
         slug="vizzuality/lg-land-carbon-data",
-        name="Land & Carbon Lab Carbon Data",
+        name="Land & Carbon Lab: Deforestation Carbon Emissions",
         description=(
-            "Land carbon flux and stock rasters produced by the WRI Land & Carbon Lab."
+            "Gross carbon emissions from deforestation at 100 m resolution, "
+            "produced by the WRI Land & Carbon Lab. The source bucket holds an "
+            "atlas of related layers; this example pins the headline emissions "
+            "raster so the mosaic stays coherent."
         ),
         listing_url="https://data.source.coop/vizzuality/lg-land-carbon-data/",
         enumerator="path_listing",
-        enumerator_args={},
+        enumerator_args={"filenames": ["deforest_carbon_100m_cog.tif"]},
         is_temporal=False,
     ),
 }

--- a/ingestion/tests/services/enumerators/test_path_listing.py
+++ b/ingestion/tests/services/enumerators/test_path_listing.py
@@ -43,6 +43,18 @@ async def test_path_listing_returns_empty_when_no_files_found():
 
 
 @pytest.mark.asyncio
+async def test_path_listing_empty_filenames_allowlist_returns_nothing():
+    with patch(
+        "src.services.enumerators.path_listing._list_one_level",
+        new=AsyncMock(return_value=([], ["a.tif", "b.tif"])),
+    ):
+        items = await enumerate_path_listing(
+            listing_url="https://example.com/x/", filenames=[]
+        )
+    assert items == []
+
+
+@pytest.mark.asyncio
 async def test_path_listing_filenames_allowlist_excludes_other_rasters():
     fake_keys = [
         "deforest_100m_cog.tif",

--- a/ingestion/tests/services/enumerators/test_path_listing.py
+++ b/ingestion/tests/services/enumerators/test_path_listing.py
@@ -40,3 +40,24 @@ async def test_path_listing_returns_empty_when_no_files_found():
     ):
         items = await enumerate_path_listing(listing_url="https://example.com/empty/")
     assert items == []
+
+
+@pytest.mark.asyncio
+async def test_path_listing_filenames_allowlist_excludes_other_rasters():
+    fake_keys = [
+        "deforest_100m_cog.tif",
+        "deforest_carbon_100m_cog.tif",
+        "natcrop_bii_100m_cog.tif",
+        "README.md",
+    ]
+    with patch(
+        "src.services.enumerators.path_listing._list_one_level",
+        new=AsyncMock(return_value=([], fake_keys)),
+    ):
+        items = await enumerate_path_listing(
+            listing_url="https://data.source.coop/vizzuality/lg-land-carbon-data/",
+            filenames=["deforest_carbon_100m_cog.tif"],
+        )
+
+    assert len(items) == 1
+    assert items[0].href.endswith("/deforest_carbon_100m_cog.tif")

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -46,3 +46,8 @@ def test_gebco_uses_path_listing():
 def test_lg_land_uses_path_listing():
     p = get_product("vizzuality/lg-land-carbon-data")
     assert p.enumerator == "path_listing"
+
+
+def test_lg_land_pins_single_deforestation_emissions_raster():
+    p = get_product("vizzuality/lg-land-carbon-data")
+    assert p.enumerator_args.get("filenames") == ["deforest_carbon_100m_cog.tif"]


### PR DESCRIPTION
## Summary

- The \`vizzuality/lg-land-carbon-data\` bucket holds 11 heterogeneous rasters (deforestation area, carbon emissions, BII loss, forest integrity, net conversion, …) at two resolutions. The \`path_listing\` enumerator greedily registered all of them into a single pgSTAC mosaic, so titiler-pgstac blended incompatible layers and the raster min/max was auto-detected from whichever file probed first.
- Extend \`path_listing\` with an optional \`filenames\` allowlist, wire it through \`example_datasets.run_enumerator\`, and pin the Land & Carbon Lab example to \`deforest_carbon_100m_cog.tif\` (the headline gross-deforestation-emissions raster).
- Rename the example to "Land & Carbon Lab: Deforestation Carbon Emissions" so the gallery label matches what's actually shown.

### Before / after

- Before: \`item_count=11\`, \`raster_min=0.0\`, \`raster_max=0.54\` (range wrong for most of the 11 layers)
- After: \`item_count=1\`, \`raster_min=0.0\`, \`raster_max≈4.97\` (correct range for the pinned raster)

Verified locally by running the worktree stack and confirming registration produces a single pgSTAC item pointing at \`deforest_carbon_100m_cog.tif\`.

## Test plan

- [x] \`uv run pytest tests/services/enumerators/test_path_listing.py tests/services/test_source_coop_config.py tests/services/test_example_datasets.py\` (15 tests pass)
- [x] \`npx vitest run src/lib/__tests__/sourceCoopCatalog.test.ts\` (6 tests pass)
- [x] Worktree stack boot — new example registers with exactly one item and sensible range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Renamed Land & Carbon Lab product to "Land & Carbon Lab: Deforestation Carbon Emissions" and updated description to emphasize gross carbon emissions from deforestation at 100 m resolution.

* **New Features**
  * File listing now supports an allowlist to pin/select a specific featured raster for the product, narrowing which remote files are considered.

* **Tests**
  * Added tests covering the new file-selection behavior and the updated product configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->