### PR TITLE
feat(frontend): tighten story editor header for narrow widths

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -6,9 +6,10 @@ import { useWorkspace } from "../hooks/useWorkspace";
 
 interface HeaderProps {
   children?: ReactNode;
+  showWorkspace?: boolean;
 }
 
-export function Header({ children }: HeaderProps) {
+export function Header({ children, showWorkspace = true }: HeaderProps) {
   const { workspaceId, workspacePath } = useWorkspace();
   const [copied, setCopied] = useState(false);
 
@@ -30,9 +31,12 @@ export function Header({ children }: HeaderProps) {
       borderBottom="1px solid"
       borderColor="brand.border"
     >
-      <Flex align="center" gap={6}>
-        <Link to={workspacePath("/")} style={{ textDecoration: "none" }}>
-          <Flex align="center" gap={3}>
+      <Flex align="center" gap={6} flexShrink={0}>
+        <Link
+          to={workspacePath("/")}
+          style={{ textDecoration: "none", flexShrink: 0 }}
+        >
+          <Flex align="center" gap={3} flexShrink={0}>
             <img
               src="/logo.svg"
               alt="Development Seed"
@@ -44,6 +48,7 @@ export function Header({ children }: HeaderProps) {
               color="brand.brown"
               fontWeight={700}
               fontSize="15px"
+              whiteSpace="nowrap"
             >
               CNG Sandbox
             </Text>
@@ -70,22 +75,35 @@ export function Header({ children }: HeaderProps) {
           </Text>
         </Link>
       </Flex>
-      <Flex
-        align="center"
-        gap={1}
-        px={2}
-        py={1}
-        borderRadius="md"
-        bg="gray.100"
-        cursor="pointer"
-        onClick={copyWorkspaceUrl}
-        title="Click to copy workspace link"
-        fontSize="xs"
-        color="gray.500"
-      >
-        <Text>{copied ? "Copied!" : `Workspace ${workspaceId}`}</Text>
-      </Flex>
-      {children && <Flex gap={2}>{children}</Flex>}
+      {showWorkspace && (
+        <Flex
+          align="center"
+          gap={1}
+          px={2}
+          py={1}
+          borderRadius="md"
+          bg="gray.100"
+          cursor="pointer"
+          onClick={copyWorkspaceUrl}
+          title="Click to copy workspace link"
+          fontSize="xs"
+          color="gray.500"
+        >
+          <Text>{copied ? "Copied!" : `Workspace ${workspaceId}`}</Text>
+        </Flex>
+      )}
+      {children && (
+        <Flex
+          gap={2}
+          align="center"
+          flex="1 1 auto"
+          minW={0}
+          justify="flex-end"
+          ml={6}
+        >
+          {children}
+        </Flex>
+      )}
     </Flex>
   );
 }

--- a/frontend/src/pages/StoryEditorPage.tsx
+++ b/frontend/src/pages/StoryEditorPage.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Input, Text, Link } from "@chakra-ui/react";
+import { Box, Button, Flex, Input, Text, Menu, Portal } from "@chakra-ui/react";
 import { useMemo, useState } from "react";
 import {
   PencilSimple,
@@ -6,6 +6,7 @@ import {
   ArrowCounterClockwise,
   Check,
   SpinnerGap,
+  CaretDown,
 } from "@phosphor-icons/react";
 import { useTooltipDismiss } from "../hooks/useTooltipDismiss";
 import { useStoryEditor } from "../hooks/useStoryEditor";
@@ -16,7 +17,6 @@ import { UploadModal } from "../components/UploadModal";
 import { ConnectionModal } from "../components/ConnectionModal";
 import { PublishDialog } from "../components/PublishDialog";
 import { Header } from "../components/Header";
-import { BugReportLink } from "../components/BugReportLink";
 import { SaveStatus } from "../components/SaveStatus";
 
 function TooltipCard({
@@ -142,8 +142,16 @@ export default function StoryEditorPage() {
 
   return (
     <Box h="100vh" display="flex" flexDirection="column">
-      <Header>
-        <Flex align="center" gap={1} role="group" position="relative">
+      <Header showWorkspace={false}>
+        <Flex
+          align="center"
+          gap={1}
+          role="group"
+          position="relative"
+          flex="1 1 auto"
+          minW={0}
+          maxW="300px"
+        >
           <Input
             value={story.title}
             onChange={(e) =>
@@ -158,7 +166,9 @@ export default function StoryEditorPage() {
             borderRadius={0}
             outline="none"
             background="transparent"
-            width="300px"
+            width="100%"
+            minW={0}
+            textOverflow="ellipsis"
             p={0}
             height="auto"
             _hover={{ borderColor: "gray.300" }}
@@ -177,52 +187,71 @@ export default function StoryEditorPage() {
           </Box>
         </Flex>
         <SaveStatus state={saveState} />
-        <Flex gap={2} align="center">
-          <BugReportLink storyId={story.id} datasetIds={story.dataset_ids} />
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() =>
-              window.open(workspacePath(`/story/${story.id}`), "_blank")
-            }
-          >
-            Preview
-          </Button>
-          {story.published ? (
-            <Flex align="center" gap={2}>
-              <Flex align="center" gap={1.5}>
-                <Box w={2} h={2} borderRadius="full" bg="green.500" />
-                <Button
-                  size="sm"
-                  bg="green.500"
-                  color="white"
-                  _hover={{ bg: "green.600" }}
-                  onClick={() => setPublishDialogOpen(true)}
-                >
-                  Published
-                </Button>
-              </Flex>
-              <Link
-                fontSize="xs"
-                color="gray.500"
-                textDecoration="underline"
-                cursor="pointer"
-                onClick={handleUnpublish}
-              >
-                Unpublish
-              </Link>
+        <Flex gap={3} align="center">
+          {story.published && (
+            <Flex align="center" gap={1.5}>
+              <Box w={2} h={2} borderRadius="full" bg="green.500" />
+              <Text fontSize="xs" color="green.700" fontWeight={500}>
+                Published
+              </Text>
             </Flex>
-          ) : (
+          )}
+          <Flex align="center">
             <Button
               size="sm"
-              bg="brand.orange"
-              color="white"
-              onClick={() => setPublishDialogOpen(true)}
-              _hover={{ bg: "brand.orangeHover" }}
+              variant="outline"
+              borderRightRadius={0}
+              borderRightWidth={0}
+              onClick={() =>
+                window.open(workspacePath(`/story/${story.id}`), "_blank")
+              }
             >
-              Publish
+              Preview
             </Button>
-          )}
+            <Menu.Root positioning={{ placement: "bottom-end" }}>
+              <Menu.Trigger asChild>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  borderLeftRadius={0}
+                  px={2}
+                  aria-label="More publish options"
+                >
+                  <CaretDown size={12} />
+                </Button>
+              </Menu.Trigger>
+              <Portal>
+                <Menu.Positioner>
+                  <Menu.Content minW="180px">
+                    {story.published ? (
+                      <>
+                        <Menu.Item
+                          value="share-settings"
+                          onSelect={() => setPublishDialogOpen(true)}
+                        >
+                          Share settings…
+                        </Menu.Item>
+                        <Menu.Item
+                          value="unpublish"
+                          color="red.600"
+                          onSelect={handleUnpublish}
+                        >
+                          Unpublish
+                        </Menu.Item>
+                      </>
+                    ) : (
+                      <Menu.Item
+                        value="publish"
+                        onSelect={() => setPublishDialogOpen(true)}
+                      >
+                        Publish…
+                      </Menu.Item>
+                    )}
+                  </Menu.Content>
+                </Menu.Positioner>
+              </Portal>
+            </Menu.Root>
+          </Flex>
         </Flex>
       </Header>
 


### PR DESCRIPTION
## Summary

- Keep `CNG Sandbox` wordmark on one line (never wraps)
- Drop workspace pill + bug-report link from the header on story pages
- Collapse `Preview` and `Publish` into a GitHub-style split button: Preview is the primary action, caret opens `Publish…` (or `Share settings…` / `Unpublish` when published)
- Truncate long story titles with ellipsis (max 300px) so they no longer overlap the nav or action buttons

Addresses header crowding on narrower screens — verified clean at 1100px, 820px, and 650px viewports.

## Test plan

- [ ] Header at wide width: logo, Library, About on left; story title in middle; Preview split button on right
- [ ] Narrow width (<900px): story title truncates with ellipsis; nothing overlaps
- [ ] Unpublished story: caret menu shows `Publish…`
- [ ] Published story: green `Published` indicator appears; caret menu shows `Share settings…` and red `Unpublish`
- [ ] Preview button opens the public story page in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Preview button to open stories in a new tab
  * Introduced dropdown menu consolidating publish, unpublish, and share settings options

* **Improvements**
  * Redesigned publish controls layout for better organization
  * Enhanced header layout with improved spacing and alignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->