### PR TITLE
feat: validate remote GeoParquet URLs before connecting

### DIFF
--- a/frontend/src/components/GeoParquetPreviewModal.tsx
+++ b/frontend/src/components/GeoParquetPreviewModal.tsx
@@ -139,25 +139,33 @@ export function GeoParquetPreviewModal({
                               <Table.Cell fontWeight="600">
                                 Min Longitude
                               </Table.Cell>
-                              <Table.Cell>{geometryInfo.bbox.minLon}</Table.Cell>
+                              <Table.Cell>
+                                {geometryInfo.bbox.minLon}
+                              </Table.Cell>
                             </Table.Row>
                             <Table.Row>
                               <Table.Cell fontWeight="600">
                                 Min Latitude
                               </Table.Cell>
-                              <Table.Cell>{geometryInfo.bbox.minLat}</Table.Cell>
+                              <Table.Cell>
+                                {geometryInfo.bbox.minLat}
+                              </Table.Cell>
                             </Table.Row>
                             <Table.Row>
                               <Table.Cell fontWeight="600">
                                 Max Longitude
                               </Table.Cell>
-                              <Table.Cell>{geometryInfo.bbox.maxLon}</Table.Cell>
+                              <Table.Cell>
+                                {geometryInfo.bbox.maxLon}
+                              </Table.Cell>
                             </Table.Row>
                             <Table.Row>
                               <Table.Cell fontWeight="600">
                                 Max Latitude
                               </Table.Cell>
-                              <Table.Cell>{geometryInfo.bbox.maxLat}</Table.Cell>
+                              <Table.Cell>
+                                {geometryInfo.bbox.maxLat}
+                              </Table.Cell>
                             </Table.Row>
                           </>
                         )}

--- a/frontend/src/components/GeoParquetPreviewModal.tsx
+++ b/frontend/src/components/GeoParquetPreviewModal.tsx
@@ -1,22 +1,19 @@
 import {
-  Button,
-  Heading,
-  Table,
-  Thead,
-  Tbody,
-  Tr,
-  Th,
-  Td,
   Box,
+  Button,
+  CloseButton,
+  DialogBackdrop,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogRoot,
+  DialogTitle,
+  Heading,
   Spinner,
+  Table,
   Text,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalCloseButton,
-  ModalBody,
-  ModalFooter,
 } from "@chakra-ui/react";
 import type { Table as ArrowTable } from "apache-arrow";
 import type { GeometryInfo } from "../hooks/useGeoParquetValidation";
@@ -80,135 +77,157 @@ export function GeoParquetPreviewModal({
   };
 
   const sampleRows = getSampleRows();
-  const sampleColumnNames = sampleRows.length > 0
-    ? Object.keys(sampleRows[0]).filter((col) => col !== "__geojson")
-    : [];
+  const sampleColumnNames =
+    sampleRows.length > 0
+      ? Object.keys(sampleRows[0]).filter((col) => col !== "__geojson")
+      : [];
 
   return (
-    <Modal isOpen={open} onClose={onCancel} size="2xl">
-      <ModalOverlay />
-      <ModalContent maxH="80vh" overflowY="auto">
-        <ModalHeader>
-          <Heading size="md">Preview: {filename}</Heading>
-        </ModalHeader>
-        <ModalCloseButton />
-        <ModalBody>
-
-        {validating ? (
-          <Box textAlign="center" py={12}>
-            <Spinner
-              size="lg"
-              color="brand.orange"
-              data-testid="validating-spinner"
-              mb={4}
-            />
-            <Text>Validating...</Text>
-          </Box>
-        ) : error ? (
-          <Box p={4} bg="red.50" borderRadius="md" borderLeft="4px solid" borderColor="red.500">
-            <Text color="red.700">{error}</Text>
-          </Box>
-        ) : (
-          <Box>
-            {geometryInfo && (
-              <Box mb={6}>
-                <Heading size="sm" mb={3}>
-                  Geometry Information
-                </Heading>
-                <Box overflowX="auto">
-                  <Table size="sm">
-                    <Tbody>
-                      <Tr>
-                        <Td fontWeight="600" w="25%">
-                          Type
-                        </Td>
-                        <Td>{geometryInfo.type}</Td>
-                      </Tr>
-                      {geometryInfo.bbox && (
-                        <>
-                          <Tr>
-                            <Td fontWeight="600">Min Longitude</Td>
-                            <Td>{geometryInfo.bbox.minLon}</Td>
-                          </Tr>
-                          <Tr>
-                            <Td fontWeight="600">Min Latitude</Td>
-                            <Td>{geometryInfo.bbox.minLat}</Td>
-                          </Tr>
-                          <Tr>
-                            <Td fontWeight="600">Max Longitude</Td>
-                            <Td>{geometryInfo.bbox.maxLon}</Td>
-                          </Tr>
-                          <Tr>
-                            <Td fontWeight="600">Max Latitude</Td>
-                            <Td>{geometryInfo.bbox.maxLat}</Td>
-                          </Tr>
-                        </>
-                      )}
-                    </Tbody>
-                  </Table>
+    <DialogRoot
+      open={open}
+      onOpenChange={(e) => !e.open && onCancel()}
+      size="xl"
+    >
+      <DialogBackdrop />
+      <DialogContent shadow="lg" maxH="80vh" overflowY="auto">
+        <DialogHeader>
+          <DialogTitle>Preview: {filename}</DialogTitle>
+          <DialogCloseTrigger asChild>
+            <CloseButton size="sm" />
+          </DialogCloseTrigger>
+        </DialogHeader>
+        <DialogBody>
+          {validating ? (
+            <Box textAlign="center" py={12}>
+              <Spinner
+                size="lg"
+                color="brand.orange"
+                data-testid="validating-spinner"
+                mb={4}
+              />
+              <Text>Validating...</Text>
+            </Box>
+          ) : error ? (
+            <Box
+              p={4}
+              bg="red.50"
+              borderRadius="md"
+              borderLeft="4px solid"
+              borderColor="red.500"
+            >
+              <Text color="red.700">{error}</Text>
+            </Box>
+          ) : (
+            <Box>
+              {geometryInfo && (
+                <Box mb={6}>
+                  <Heading size="sm" mb={3}>
+                    Geometry Information
+                  </Heading>
+                  <Box overflowX="auto">
+                    <Table.Root size="sm">
+                      <Table.Body>
+                        <Table.Row>
+                          <Table.Cell fontWeight="600" w="25%">
+                            Type
+                          </Table.Cell>
+                          <Table.Cell>{geometryInfo.type}</Table.Cell>
+                        </Table.Row>
+                        {geometryInfo.bbox && (
+                          <>
+                            <Table.Row>
+                              <Table.Cell fontWeight="600">
+                                Min Longitude
+                              </Table.Cell>
+                              <Table.Cell>{geometryInfo.bbox.minLon}</Table.Cell>
+                            </Table.Row>
+                            <Table.Row>
+                              <Table.Cell fontWeight="600">
+                                Min Latitude
+                              </Table.Cell>
+                              <Table.Cell>{geometryInfo.bbox.minLat}</Table.Cell>
+                            </Table.Row>
+                            <Table.Row>
+                              <Table.Cell fontWeight="600">
+                                Max Longitude
+                              </Table.Cell>
+                              <Table.Cell>{geometryInfo.bbox.maxLon}</Table.Cell>
+                            </Table.Row>
+                            <Table.Row>
+                              <Table.Cell fontWeight="600">
+                                Max Latitude
+                              </Table.Cell>
+                              <Table.Cell>{geometryInfo.bbox.maxLat}</Table.Cell>
+                            </Table.Row>
+                          </>
+                        )}
+                      </Table.Body>
+                    </Table.Root>
+                  </Box>
                 </Box>
-              </Box>
-            )}
+              )}
 
-            {schema.length > 0 && (
-              <Box mb={6}>
-                <Heading size="sm" mb={3}>
-                  Schema
-                </Heading>
-                <Box overflowX="auto">
-                  <Table size="sm">
-                    <Thead>
-                      <Tr bg="brand.bgSubtle">
-                        <Th>Column</Th>
-                        <Th>Type</Th>
-                      </Tr>
-                    </Thead>
-                    <Tbody>
-                      {schema.map((col) => (
-                        <Tr key={col.name}>
-                          <Td>{col.name}</Td>
-                          <Td>{col.type}</Td>
-                        </Tr>
-                      ))}
-                    </Tbody>
-                  </Table>
-                </Box>
-              </Box>
-            )}
-
-            {sampleRows.length > 0 && (
-              <Box mb={6}>
-                <Heading size="sm" mb={3}>
-                  Sample Rows (first {sampleRows.length})
-                </Heading>
-                <Box overflowX="auto">
-                  <Table size="sm">
-                    <Thead>
-                      <Tr bg="brand.bgSubtle">
-                        {sampleColumnNames.map((col) => (
-                          <Th key={col}>{col}</Th>
+              {schema.length > 0 && (
+                <Box mb={6}>
+                  <Heading size="sm" mb={3}>
+                    Schema
+                  </Heading>
+                  <Box overflowX="auto">
+                    <Table.Root size="sm">
+                      <Table.Header>
+                        <Table.Row bg="brand.bgSubtle">
+                          <Table.ColumnHeader>Column</Table.ColumnHeader>
+                          <Table.ColumnHeader>Type</Table.ColumnHeader>
+                        </Table.Row>
+                      </Table.Header>
+                      <Table.Body>
+                        {schema.map((col) => (
+                          <Table.Row key={col.name}>
+                            <Table.Cell>{col.name}</Table.Cell>
+                            <Table.Cell>{col.type}</Table.Cell>
+                          </Table.Row>
                         ))}
-                      </Tr>
-                    </Thead>
-                    <Tbody>
-                      {sampleRows.map((row, idx) => (
-                        <Tr key={idx}>
-                          {sampleColumnNames.map((col) => (
-                            <Td key={`${idx}-${col}`}>
-                              {truncateValue(row[col], 100)}
-                            </Td>
-                          ))}
-                        </Tr>
-                      ))}
-                    </Tbody>
-                  </Table>
+                      </Table.Body>
+                    </Table.Root>
+                  </Box>
                 </Box>
-              </Box>
-            )}
-          </Box>
-        )}
-        </ModalBody>
-        <ModalFooter gap={2}>
+              )}
+
+              {sampleRows.length > 0 && (
+                <Box mb={6}>
+                  <Heading size="sm" mb={3}>
+                    Sample Rows (first {sampleRows.length})
+                  </Heading>
+                  <Box overflowX="auto">
+                    <Table.Root size="sm">
+                      <Table.Header>
+                        <Table.Row bg="brand.bgSubtle">
+                          {sampleColumnNames.map((col) => (
+                            <Table.ColumnHeader key={col}>
+                              {col}
+                            </Table.ColumnHeader>
+                          ))}
+                        </Table.Row>
+                      </Table.Header>
+                      <Table.Body>
+                        {sampleRows.map((row, idx) => (
+                          <Table.Row key={idx}>
+                            {sampleColumnNames.map((col) => (
+                              <Table.Cell key={`${idx}-${col}`}>
+                                {truncateValue(row[col], 100)}
+                              </Table.Cell>
+                            ))}
+                          </Table.Row>
+                        ))}
+                      </Table.Body>
+                    </Table.Root>
+                  </Box>
+                </Box>
+              )}
+            </Box>
+          )}
+        </DialogBody>
+        <DialogFooter gap={2}>
           <Button variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
@@ -220,8 +239,8 @@ export function GeoParquetPreviewModal({
           >
             Confirm & Connect
           </Button>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
+        </DialogFooter>
+      </DialogContent>
+    </DialogRoot>
   );
 }

--- a/frontend/src/components/GeoParquetPreviewModal.tsx
+++ b/frontend/src/components/GeoParquetPreviewModal.tsx
@@ -1,0 +1,241 @@
+import {
+  Button,
+  Heading,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Box,
+  Spinner,
+  Text,
+} from "@chakra-ui/react";
+import type { Table as ArrowTable } from "apache-arrow";
+import type { GeometryInfo } from "../hooks/useGeoParquetValidation";
+import type { ColumnStats } from "../hooks/useGeoParquetQuery";
+
+interface GeoParquetPreviewModalProps {
+  open: boolean;
+  filename: string;
+  validating: boolean;
+  valid: boolean;
+  error: string | null;
+  geometryInfo: GeometryInfo | null;
+  schema: ColumnStats[];
+  samples: ArrowTable | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function GeoParquetPreviewModal({
+  open,
+  filename,
+  validating,
+  valid,
+  error,
+  geometryInfo,
+  schema,
+  samples,
+  onConfirm,
+  onCancel,
+}: GeoParquetPreviewModalProps) {
+  if (!open) return null;
+
+  const isConfirmDisabled = !valid || validating;
+
+  const truncateValue = (value: unknown, maxLength: number = 100): string => {
+    if (value === null || value === undefined) return "—";
+    const str = String(value);
+    return str.length > maxLength ? `${str.substring(0, maxLength)}...` : str;
+  };
+
+  const getSampleRows = (): Array<Record<string, unknown>> => {
+    if (!samples || samples.numRows === 0) return [];
+
+    const rows: Array<Record<string, unknown>> = [];
+    const limit = Math.min(10, samples.numRows);
+
+    for (let i = 0; i < limit; i++) {
+      const row = samples.get(i);
+      if (row) {
+        const record: Record<string, unknown> = {};
+        for (const col of samples.schema.fields) {
+          if (col.type.toString() !== "geometry") {
+            record[col.name] = row[col.name];
+          }
+        }
+        rows.push(record);
+      }
+    }
+
+    return rows;
+  };
+
+  const sampleRows = getSampleRows();
+  const sampleColumnNames = sampleRows.length > 0
+    ? Object.keys(sampleRows[0]).filter((col) => col !== "__geojson")
+    : [];
+
+  return (
+    <Box
+      position="fixed"
+      inset={0}
+      zIndex={1000}
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Box
+        position="absolute"
+        inset={0}
+        bg="blackAlpha.500"
+        onClick={onCancel}
+      />
+
+      <Box
+        position="relative"
+        bg="white"
+        borderRadius="md"
+        shadow="lg"
+        maxW="2xl"
+        w="90%"
+        maxH="80vh"
+        overflowY="auto"
+        p={6}
+      >
+        <Box mb={6}>
+          <Heading size="md">Preview: {filename}</Heading>
+        </Box>
+
+        {validating ? (
+          <Box textAlign="center" py={12}>
+            <Spinner
+              size="lg"
+              color="brand.orange"
+              data-testid="validating-spinner"
+              mb={4}
+            />
+            <Text>Validating...</Text>
+          </Box>
+        ) : error ? (
+          <Box p={4} bg="red.50" borderRadius="md" borderLeft="4px solid" borderColor="red.500">
+            <Text color="red.700">{error}</Text>
+          </Box>
+        ) : (
+          <Box>
+            {geometryInfo && (
+              <Box mb={6}>
+                <Heading size="sm" mb={3}>
+                  Geometry Information
+                </Heading>
+                <Box overflowX="auto">
+                  <Table size="sm">
+                    <Tbody>
+                      <Tr>
+                        <Td fontWeight="600" w="25%">
+                          Type
+                        </Td>
+                        <Td>{geometryInfo.type}</Td>
+                      </Tr>
+                      {geometryInfo.bbox && (
+                        <>
+                          <Tr>
+                            <Td fontWeight="600">Min Longitude</Td>
+                            <Td>{geometryInfo.bbox.minLon}</Td>
+                          </Tr>
+                          <Tr>
+                            <Td fontWeight="600">Min Latitude</Td>
+                            <Td>{geometryInfo.bbox.minLat}</Td>
+                          </Tr>
+                          <Tr>
+                            <Td fontWeight="600">Max Longitude</Td>
+                            <Td>{geometryInfo.bbox.maxLon}</Td>
+                          </Tr>
+                          <Tr>
+                            <Td fontWeight="600">Max Latitude</Td>
+                            <Td>{geometryInfo.bbox.maxLat}</Td>
+                          </Tr>
+                        </>
+                      )}
+                    </Tbody>
+                  </Table>
+                </Box>
+              </Box>
+            )}
+
+            {schema.length > 0 && (
+              <Box mb={6}>
+                <Heading size="sm" mb={3}>
+                  Schema
+                </Heading>
+                <Box overflowX="auto">
+                  <Table size="sm">
+                    <Thead>
+                      <Tr bg="brand.bgSubtle">
+                        <Th>Column</Th>
+                        <Th>Type</Th>
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {schema.map((col) => (
+                        <Tr key={col.name}>
+                          <Td>{col.name}</Td>
+                          <Td>{col.type}</Td>
+                        </Tr>
+                      ))}
+                    </Tbody>
+                  </Table>
+                </Box>
+              </Box>
+            )}
+
+            {sampleRows.length > 0 && (
+              <Box mb={6}>
+                <Heading size="sm" mb={3}>
+                  Sample Rows (first {sampleRows.length})
+                </Heading>
+                <Box overflowX="auto">
+                  <Table size="sm">
+                    <Thead>
+                      <Tr bg="brand.bgSubtle">
+                        {sampleColumnNames.map((col) => (
+                          <Th key={col}>{col}</Th>
+                        ))}
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {sampleRows.map((row, idx) => (
+                        <Tr key={idx}>
+                          {sampleColumnNames.map((col) => (
+                            <Td key={`${idx}-${col}`}>
+                              {truncateValue(row[col], 100)}
+                            </Td>
+                          ))}
+                        </Tr>
+                      ))}
+                    </Tbody>
+                  </Table>
+                </Box>
+              </Box>
+            )}
+          </Box>
+        )}
+
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: "8px", marginTop: "24px" }}>
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            bg="brand.orange"
+            color="white"
+            onClick={onConfirm}
+            disabled={isConfirmDisabled}
+          >
+            Confirm & Connect
+          </Button>
+        </div>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/GeoParquetPreviewModal.tsx
+++ b/frontend/src/components/GeoParquetPreviewModal.tsx
@@ -10,6 +10,13 @@ import {
   Box,
   Spinner,
   Text,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
 } from "@chakra-ui/react";
 import type { Table as ArrowTable } from "apache-arrow";
 import type { GeometryInfo } from "../hooks/useGeoParquetValidation";
@@ -78,35 +85,14 @@ export function GeoParquetPreviewModal({
     : [];
 
   return (
-    <Box
-      position="fixed"
-      inset={0}
-      zIndex={1000}
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-    >
-      <Box
-        position="absolute"
-        inset={0}
-        bg="blackAlpha.500"
-        onClick={onCancel}
-      />
-
-      <Box
-        position="relative"
-        bg="white"
-        borderRadius="md"
-        shadow="lg"
-        maxW="2xl"
-        w="90%"
-        maxH="80vh"
-        overflowY="auto"
-        p={6}
-      >
-        <Box mb={6}>
+    <Modal isOpen={open} onClose={onCancel} size="2xl">
+      <ModalOverlay />
+      <ModalContent maxH="80vh" overflowY="auto">
+        <ModalHeader>
           <Heading size="md">Preview: {filename}</Heading>
-        </Box>
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
 
         {validating ? (
           <Box textAlign="center" py={12}>
@@ -221,8 +207,8 @@ export function GeoParquetPreviewModal({
             )}
           </Box>
         )}
-
-        <div style={{ display: "flex", justifyContent: "flex-end", gap: "8px", marginTop: "24px" }}>
+        </ModalBody>
+        <ModalFooter gap={2}>
           <Button variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
@@ -234,8 +220,8 @@ export function GeoParquetPreviewModal({
           >
             Confirm & Connect
           </Button>
-        </div>
-      </Box>
-    </Box>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
   );
 }

--- a/frontend/src/components/RemoteConnectFlow.tsx
+++ b/frontend/src/components/RemoteConnectFlow.tsx
@@ -57,23 +57,26 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
     if (isGeoParquetUrl(trimmedUrl)) {
       setPreviewUrl(trimmedUrl);
       setShowPreview(true);
-      // Ensure DuckDB is initialized
-      if (!conn) {
+      // Ensure DuckDB is initialized and use the freshly-returned conn
+      // to avoid racing with React state updates.
+      let activeConn = conn;
+      if (!activeConn) {
         try {
-          await initializeDuckDB();
+          const result = await initializeDuckDB();
+          activeConn = result?.conn ?? null;
         } catch (e) {
           console.error("DuckDB initialization failed:", e);
           // Error will be displayed in modal via useGeoParquetValidation hook
           return;
         }
       }
-      await validateGeoParquet();
+      await validateGeoParquet(activeConn);
       return; // Don't proceed to discovery
     }
 
     // Otherwise, use the existing discovery flow
     discover(trimmedUrl);
-  }, [inputUrl, discover, initializeDuckDB, validateGeoParquet]);
+  }, [inputUrl, conn, discover, initializeDuckDB, validateGeoParquet]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/frontend/src/components/RemoteConnectFlow.tsx
+++ b/frontend/src/components/RemoteConnectFlow.tsx
@@ -29,6 +29,7 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
   const { db, conn, initialize: initializeDuckDB } = useDuckDB();
   const [showPreview, setShowPreview] = useState(false);
   const [previewUrl, setPreviewUrl] = useState("");
+  const [connectionError, setConnectionError] = useState<string | null>(null);
   const {
     validating,
     valid,
@@ -59,7 +60,13 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
       setShowPreview(true);
       // Ensure DuckDB is initialized
       if (!conn) {
-        await initializeDuckDB();
+        try {
+          await initializeDuckDB();
+        } catch (e) {
+          console.error("DuckDB initialization failed:", e);
+          // Error will be displayed in modal via useGeoParquetValidation hook
+          return;
+        }
       }
       await validateGeoParquet();
       return; // Don't proceed to discovery
@@ -67,7 +74,7 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
 
     // Otherwise, use the existing discovery flow
     discover(trimmedUrl);
-  }, [inputUrl, discover, conn, initializeDuckDB, validateGeoParquet]);
+  }, [inputUrl, discover, initializeDuckDB, validateGeoParquet]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -80,6 +87,7 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
     if (!valid || !previewUrl) return;
 
     setShowPreview(false);
+    setConnectionError(null);
 
     // Now make the actual connection POST request
     try {
@@ -98,10 +106,16 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
       }
 
       const data = await response.json();
+      if (!data.id) {
+        throw new Error("No dataset ID returned from connection creation");
+      }
       onDatasetReady(data.id); // Navigate to map
     } catch (e) {
-      // Show error via existing error handler
+      const errorMsg = e instanceof Error ? e.message : "Unknown error";
       console.error("Connection creation failed:", e);
+      setConnectionError(`Connection creation failed: ${errorMsg}`);
+      // Re-open preview modal to show error to user
+      setShowPreview(true);
     }
   }, [valid, previewUrl, onDatasetReady]);
 
@@ -231,12 +245,15 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
         filename={previewUrl.split("/").pop() || "data.parquet"}
         validating={validating}
         valid={valid}
-        error={error}
+        error={error || connectionError}
         geometryInfo={geometryInfo}
         schema={queryResult.columnStats}
         samples={queryResult.table}
         onConfirm={handleConfirmConnection}
-        onCancel={() => setShowPreview(false)}
+        onCancel={() => {
+          setShowPreview(false);
+          setConnectionError(null);
+        }}
       />
     </Box>
   );

--- a/frontend/src/components/RemoteConnectFlow.tsx
+++ b/frontend/src/components/RemoteConnectFlow.tsx
@@ -10,6 +10,12 @@ import {
 } from "@phosphor-icons/react";
 import { useRemoteConnect } from "../hooks/useRemoteConnect";
 import { transition } from "../lib/interactionStyles";
+import { useGeoParquetValidation } from "../hooks/useGeoParquetValidation";
+import { GeoParquetPreviewModal } from "./GeoParquetPreviewModal";
+import { useDuckDB } from "../hooks/useDuckDB";
+import { useGeoParquetQuery } from "../hooks/useGeoParquetQuery";
+import { workspaceFetch } from "../lib/api";
+import { config } from "../config";
 
 interface RemoteConnectFlowProps {
   onDatasetReady: (datasetId: string) => void;
@@ -19,16 +25,49 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
   const { state, discover, startIngestion } = useRemoteConnect();
   const [inputUrl, setInputUrl] = useState("");
 
+  // GeoParquet validation modal state
+  const { db, conn } = useDuckDB();
+  const [showPreview, setShowPreview] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState("");
+  const {
+    validating,
+    valid,
+    error,
+    geometryInfo,
+    validate: validateGeoParquet,
+  } = useGeoParquetValidation(conn, previewUrl);
+
+  const { result: queryResult } = useGeoParquetQuery(conn, previewUrl);
+
   useEffect(() => {
     if (state.phase === "idle" && state.datasetId) {
       onDatasetReady(state.datasetId);
     }
   }, [state.phase, state.datasetId, onDatasetReady]);
 
-  const handleScan = useCallback(() => {
+  const isGeoParquetUrl = (url: string): boolean => {
+    return url.toLowerCase().endsWith(".parquet");
+  };
+
+  const handleScan = useCallback(async () => {
     if (!inputUrl.trim()) return;
-    discover(inputUrl.trim());
-  }, [inputUrl, discover]);
+    const trimmedUrl = inputUrl.trim();
+
+    // If the URL points to a single GeoParquet file, validate it before connecting
+    if (isGeoParquetUrl(trimmedUrl)) {
+      setPreviewUrl(trimmedUrl);
+      setShowPreview(true);
+      // Ensure DuckDB is initialized
+      if (!conn) {
+        await db?.instantiate?.();
+      }
+      await validateGeoParquet();
+      return; // Don't proceed to discovery
+    }
+
+    // Otherwise, use the existing discovery flow
+    discover(trimmedUrl);
+  }, [inputUrl, discover, conn, db, validateGeoParquet]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -36,6 +75,35 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
     },
     [handleScan]
   );
+
+  const handleConfirmConnection = useCallback(async () => {
+    if (!valid || !previewUrl) return;
+
+    setShowPreview(false);
+
+    // Now make the actual connection POST request
+    try {
+      const response = await workspaceFetch("/api/connections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          url: previewUrl,
+          connection_type: "geoparquet",
+          name: previewUrl.split("/").pop() || "Untitled",
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to create connection");
+      }
+
+      const data = await response.json();
+      onDatasetReady(data.id); // Navigate to map
+    } catch (e) {
+      // Show error via existing error handler
+      console.error("Connection creation failed:", e);
+    }
+  }, [valid, previewUrl, onDatasetReady]);
 
   if (state.phase === "discovering") {
     return (
@@ -157,6 +225,19 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
           Scan
         </Button>
       </Flex>
+
+      <GeoParquetPreviewModal
+        open={showPreview}
+        filename={previewUrl.split("/").pop() || "data.parquet"}
+        validating={validating}
+        valid={valid}
+        error={error}
+        geometryInfo={geometryInfo}
+        schema={queryResult.columnStats}
+        samples={queryResult.table}
+        onConfirm={handleConfirmConnection}
+        onCancel={() => setShowPreview(false)}
+      />
     </Box>
   );
 }

--- a/frontend/src/components/RemoteConnectFlow.tsx
+++ b/frontend/src/components/RemoteConnectFlow.tsx
@@ -15,7 +15,6 @@ import { GeoParquetPreviewModal } from "./GeoParquetPreviewModal";
 import { useDuckDB } from "../hooks/useDuckDB";
 import { useGeoParquetQuery } from "../hooks/useGeoParquetQuery";
 import { workspaceFetch } from "../lib/api";
-import { config } from "../config";
 
 interface RemoteConnectFlowProps {
   onDatasetReady: (datasetId: string) => void;
@@ -26,7 +25,7 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
   const [inputUrl, setInputUrl] = useState("");
 
   // GeoParquet validation modal state
-  const { db, conn, initialize: initializeDuckDB } = useDuckDB();
+  const { conn, initialize: initializeDuckDB } = useDuckDB();
   const [showPreview, setShowPreview] = useState(false);
   const [previewUrl, setPreviewUrl] = useState("");
   const [connectionError, setConnectionError] = useState<string | null>(null);

--- a/frontend/src/components/RemoteConnectFlow.tsx
+++ b/frontend/src/components/RemoteConnectFlow.tsx
@@ -26,7 +26,7 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
   const [inputUrl, setInputUrl] = useState("");
 
   // GeoParquet validation modal state
-  const { db, conn } = useDuckDB();
+  const { db, conn, initialize: initializeDuckDB } = useDuckDB();
   const [showPreview, setShowPreview] = useState(false);
   const [previewUrl, setPreviewUrl] = useState("");
   const {
@@ -59,7 +59,7 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
       setShowPreview(true);
       // Ensure DuckDB is initialized
       if (!conn) {
-        await db?.instantiate?.();
+        await initializeDuckDB();
       }
       await validateGeoParquet();
       return; // Don't proceed to discovery
@@ -67,7 +67,7 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
 
     // Otherwise, use the existing discovery flow
     discover(trimmedUrl);
-  }, [inputUrl, discover, conn, db, validateGeoParquet]);
+  }, [inputUrl, discover, conn, initializeDuckDB, validateGeoParquet]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/frontend/src/components/__tests__/GeoParquetPreviewModal.test.tsx
+++ b/frontend/src/components/__tests__/GeoParquetPreviewModal.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { GeoParquetPreviewModal } from "../GeoParquetPreviewModal";
+import type { GeometryInfo } from "../../hooks/useGeoParquetValidation";
+import type { ColumnStats } from "../../hooks/useGeoParquetQuery";
+import { system } from "../../theme";
+
+function renderWithChakra(ui: React.ReactElement) {
+  return render(<ChakraProvider value={system}>{ui}</ChakraProvider>);
+}
+
+describe("GeoParquetPreviewModal", () => {
+  const mockGeometryInfo: GeometryInfo = {
+    type: "Point",
+    bbox: {
+      minLon: -120.5,
+      minLat: 30.0,
+      maxLon: -110.0,
+      maxLat: 40.0,
+    },
+  };
+
+  const mockColumnStats: ColumnStats[] = [
+    {
+      name: "name",
+      type: "categorical",
+      uniqueCount: 10,
+      topValues: [{ value: "Test", count: 5 }],
+    },
+    {
+      name: "value",
+      type: "numeric",
+      min: 0,
+      max: 100,
+      mean: 50,
+      uniqueCount: 50,
+    },
+  ];
+
+  const defaultProps = {
+    open: true,
+    filename: "test.parquet",
+    validating: false,
+    valid: false,
+    error: null,
+    geometryInfo: null,
+    schema: mockColumnStats,
+    samples: null,
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it("renders null when open is false", () => {
+    const { container } = renderWithChakra(
+      <GeoParquetPreviewModal {...defaultProps} open={false} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders loading state when validating is true", () => {
+    renderWithChakra(
+      <GeoParquetPreviewModal {...defaultProps} validating={true} />
+    );
+    expect(screen.getByText("Validating...")).toBeTruthy();
+    expect(screen.getByTestId("validating-spinner")).toBeTruthy();
+  });
+
+  it("renders error alert when error is present", () => {
+    renderWithChakra(
+      <GeoParquetPreviewModal
+        {...defaultProps}
+        error="File not found"
+        open={true}
+      />
+    );
+    expect(screen.getByText("File not found")).toBeTruthy();
+    const confirmButton = screen.getByRole("button", {
+      name: /Confirm & Connect/i,
+    });
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it("disables confirm button when valid is false", () => {
+    renderWithChakra(
+      <GeoParquetPreviewModal {...defaultProps} valid={false} open={true} />
+    );
+    const confirmButton = screen.getByRole("button", {
+      name: /Confirm & Connect/i,
+    });
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it("disables confirm button when validating is true", () => {
+    renderWithChakra(
+      <GeoParquetPreviewModal
+        {...defaultProps}
+        valid={true}
+        validating={true}
+        open={true}
+      />
+    );
+    const confirmButton = screen.getByRole("button", {
+      name: /Confirm & Connect/i,
+    });
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it("enables confirm button when valid is true and validating is false", () => {
+    renderWithChakra(
+      <GeoParquetPreviewModal
+        {...defaultProps}
+        valid={true}
+        validating={false}
+        geometryInfo={mockGeometryInfo}
+        open={true}
+      />
+    );
+    const confirmButton = screen.getByRole("button", {
+      name: /Confirm & Connect/i,
+    });
+    expect(confirmButton).not.toBeDisabled();
+  });
+
+  it("calls onConfirm when confirm button is clicked and valid is true", () => {
+    const onConfirm = vi.fn();
+    renderWithChakra(
+      <GeoParquetPreviewModal
+        {...defaultProps}
+        valid={true}
+        geometryInfo={mockGeometryInfo}
+        onConfirm={onConfirm}
+        open={true}
+      />
+    );
+    const confirmButton = screen.getByRole("button", {
+      name: /Confirm & Connect/i,
+    });
+    fireEvent.click(confirmButton);
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onCancel when cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    renderWithChakra(
+      <GeoParquetPreviewModal
+        {...defaultProps}
+        onCancel={onCancel}
+        open={true}
+      />
+    );
+    const cancelButton = screen.getByRole("button", { name: /Cancel/i });
+    fireEvent.click(cancelButton);
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("renders geometry info when valid is true", () => {
+    renderWithChakra(
+      <GeoParquetPreviewModal
+        {...defaultProps}
+        valid={true}
+        geometryInfo={mockGeometryInfo}
+        open={true}
+      />
+    );
+    expect(screen.getByText("Point")).toBeTruthy();
+    expect(screen.getByText(/-120.5/)).toBeTruthy();
+    expect(screen.getByText(/40.0/)).toBeTruthy();
+  });
+
+  it("renders schema table when valid is true", () => {
+    renderWithChakra(
+      <GeoParquetPreviewModal
+        {...defaultProps}
+        valid={true}
+        geometryInfo={mockGeometryInfo}
+        schema={mockColumnStats}
+        open={true}
+      />
+    );
+    expect(screen.getByText("name")).toBeTruthy();
+    expect(screen.getByText("value")).toBeTruthy();
+    expect(screen.getByText("categorical")).toBeTruthy();
+    expect(screen.getByText("numeric")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/__tests__/GeoParquetPreviewModal.test.tsx
+++ b/frontend/src/components/__tests__/GeoParquetPreviewModal.test.tsx
@@ -81,7 +81,7 @@ describe("GeoParquetPreviewModal", () => {
     expect(confirmButton).toBeDisabled();
   });
 
-  it.skip("disables confirm button when valid is false", () => {
+  it("disables confirm button when valid is false", () => {
     renderWithChakra(
       <GeoParquetPreviewModal {...defaultProps} valid={false} open={true} />
     );
@@ -106,7 +106,7 @@ describe("GeoParquetPreviewModal", () => {
     expect(confirmButton).toBeDisabled();
   });
 
-  it.skip("enables confirm button when valid is true and validating is false", () => {
+  it("enables confirm button when valid is true and validating is false", () => {
     renderWithChakra(
       <GeoParquetPreviewModal
         {...defaultProps}
@@ -122,7 +122,7 @@ describe("GeoParquetPreviewModal", () => {
     expect(confirmButton).not.toBeDisabled();
   });
 
-  it.skip("calls onConfirm when confirm button is clicked and valid is true", () => {
+  it("calls onConfirm when confirm button is clicked and valid is true", () => {
     const onConfirm = vi.fn();
     renderWithChakra(
       <GeoParquetPreviewModal
@@ -140,7 +140,7 @@ describe("GeoParquetPreviewModal", () => {
     expect(onConfirm).toHaveBeenCalledOnce();
   });
 
-  it.skip("calls onCancel when cancel button is clicked", () => {
+  it("calls onCancel when cancel button is clicked", () => {
     const onCancel = vi.fn();
     renderWithChakra(
       <GeoParquetPreviewModal
@@ -154,7 +154,7 @@ describe("GeoParquetPreviewModal", () => {
     expect(onCancel).toHaveBeenCalledOnce();
   });
 
-  it.skip("renders geometry info when valid is true", () => {
+  it("renders geometry info when valid is true", () => {
     renderWithChakra(
       <GeoParquetPreviewModal
         {...defaultProps}
@@ -164,11 +164,11 @@ describe("GeoParquetPreviewModal", () => {
       />
     );
     expect(screen.getByText("Point")).toBeTruthy();
-    expect(screen.getByText(/-120.5/)).toBeTruthy();
-    expect(screen.getByText(/40.0/)).toBeTruthy();
+    expect(screen.getByText(/-120\.5/)).toBeTruthy();
+    expect(screen.getByText(/-110/)).toBeTruthy();
   });
 
-  it.skip("renders schema table when valid is true", () => {
+  it("renders schema table when valid is true", () => {
     renderWithChakra(
       <GeoParquetPreviewModal
         {...defaultProps}

--- a/frontend/src/components/__tests__/GeoParquetPreviewModal.test.tsx
+++ b/frontend/src/components/__tests__/GeoParquetPreviewModal.test.tsx
@@ -81,7 +81,7 @@ describe("GeoParquetPreviewModal", () => {
     expect(confirmButton).toBeDisabled();
   });
 
-  it("disables confirm button when valid is false", () => {
+  it.skip("disables confirm button when valid is false", () => {
     renderWithChakra(
       <GeoParquetPreviewModal {...defaultProps} valid={false} open={true} />
     );
@@ -106,7 +106,7 @@ describe("GeoParquetPreviewModal", () => {
     expect(confirmButton).toBeDisabled();
   });
 
-  it("enables confirm button when valid is true and validating is false", () => {
+  it.skip("enables confirm button when valid is true and validating is false", () => {
     renderWithChakra(
       <GeoParquetPreviewModal
         {...defaultProps}
@@ -122,7 +122,7 @@ describe("GeoParquetPreviewModal", () => {
     expect(confirmButton).not.toBeDisabled();
   });
 
-  it("calls onConfirm when confirm button is clicked and valid is true", () => {
+  it.skip("calls onConfirm when confirm button is clicked and valid is true", () => {
     const onConfirm = vi.fn();
     renderWithChakra(
       <GeoParquetPreviewModal
@@ -140,7 +140,7 @@ describe("GeoParquetPreviewModal", () => {
     expect(onConfirm).toHaveBeenCalledOnce();
   });
 
-  it("calls onCancel when cancel button is clicked", () => {
+  it.skip("calls onCancel when cancel button is clicked", () => {
     const onCancel = vi.fn();
     renderWithChakra(
       <GeoParquetPreviewModal
@@ -154,7 +154,7 @@ describe("GeoParquetPreviewModal", () => {
     expect(onCancel).toHaveBeenCalledOnce();
   });
 
-  it("renders geometry info when valid is true", () => {
+  it.skip("renders geometry info when valid is true", () => {
     renderWithChakra(
       <GeoParquetPreviewModal
         {...defaultProps}
@@ -168,7 +168,7 @@ describe("GeoParquetPreviewModal", () => {
     expect(screen.getByText(/40.0/)).toBeTruthy();
   });
 
-  it("renders schema table when valid is true", () => {
+  it.skip("renders schema table when valid is true", () => {
     renderWithChakra(
       <GeoParquetPreviewModal
         {...defaultProps}

--- a/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
+++ b/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
@@ -106,7 +106,7 @@ describe("useGeoParquetValidation", () => {
     });
 
     expect(result.current.valid).toBe(false);
-    expect(result.current.error).toBe("Could not access URL");
+    expect(result.current.error).toBe("Could not access URL: file not found (404)");
     expect(result.current.geometryInfo).toBeNull();
   });
 
@@ -217,5 +217,100 @@ describe("useGeoParquetValidation", () => {
     // State should eventually be set to valid=true
     await waitFor(() => expect(result.current.validating).toBe(false));
     expect(result.current.valid).toBe(true);
+  });
+
+  it("returns error when geometry column name contains invalid characters", async () => {
+    const mockConn = { query: vi.fn() } as any;
+
+    const describeResult = {
+      numRows: 1,
+      get: () => ({
+        column_name: "geom'; DROP TABLE--",
+        column_type: "GEOMETRY",
+      }),
+    };
+
+    mockRunQuery.mockImplementation(async (sql) => {
+      if (sql.includes("DESCRIBE")) {
+        return describeResult;
+      }
+    });
+
+    const { result } = renderHook(() =>
+      useGeoParquetValidation(mockConn, "/api/test.parquet")
+    );
+
+    await act(async () => {
+      await result.current.validate();
+    });
+
+    expect(result.current.valid).toBe(false);
+    expect(result.current.error).toBe("Invalid column name");
+  });
+
+  it("does not allow concurrent validation calls", async () => {
+    const mockConn = { query: vi.fn() } as any;
+
+    let validateCallCount = 0;
+    mockRunQuery.mockImplementation(async (sql) => {
+      validateCallCount++;
+      if (sql.includes("DESCRIBE")) {
+        return {
+          numRows: 1,
+          get: () => ({ column_name: "geometry", column_type: "GEOMETRY" }),
+        };
+      }
+      if (sql.includes("ST_GeometryType")) {
+        return {
+          numRows: 1,
+          get: () => ({ geom_type: "POINT" }),
+        };
+      }
+      if (sql.includes("ST_Extent")) {
+        return {
+          numRows: 1,
+          get: () => ({
+            minx: -120,
+            miny: -45,
+            maxx: 120,
+            maxy: 45,
+          }),
+        };
+      }
+    });
+
+    const { result } = renderHook(() =>
+      useGeoParquetValidation(mockConn, "/api/test.parquet")
+    );
+
+    await act(async () => {
+      result.current.validate();
+      result.current.validate();
+    });
+
+    await waitFor(() => expect(result.current.validating).toBe(false));
+
+    expect(validateCallCount).toBe(3);
+  });
+
+  it("sanitizes error messages to avoid exposing internal details", async () => {
+    const mockConn = { query: vi.fn() } as any;
+
+    mockRunQuery.mockImplementation(async () => {
+      throw new Error("DuckDB Internal Error: GDAL Exception: Unknown format");
+    });
+
+    const { result } = renderHook(() =>
+      useGeoParquetValidation(mockConn, "/api/test.parquet")
+    );
+
+    await act(async () => {
+      await result.current.validate();
+    });
+
+    expect(result.current.valid).toBe(false);
+    expect(result.current.error).toBe("File validation failed");
+    expect(result.current.error).not.toContain("GDAL");
+    expect(result.current.error).not.toContain("DuckDB");
   });
 });

--- a/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
+++ b/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
@@ -95,7 +95,9 @@ describe("useGeoParquetValidation", () => {
     });
 
     expect(result.current.valid).toBe(false);
-    expect(result.current.error).toBe("Could not access URL: file not found (404)");
+    expect(result.current.error).toBe(
+      "Could not access URL: file not found (404)"
+    );
     expect(result.current.geometryInfo).toBeNull();
   });
 

--- a/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
+++ b/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import { useGeoParquetValidation } from "../useGeoParquetValidation";
 
 const mockRunQuery = vi.fn();
@@ -17,7 +18,7 @@ beforeEach(() => {
 
 describe("useGeoParquetValidation", () => {
   it("returns valid state with geometry info for valid GeoParquet", async () => {
-    const mockConn = { query: vi.fn() } as any;
+    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
 
     const describeResult = {
       numRows: 2,
@@ -90,7 +91,7 @@ describe("useGeoParquetValidation", () => {
   });
 
   it("returns error state for unreachable URL", async () => {
-    const mockConn = { query: vi.fn() } as any;
+    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
 
     mockRunQuery.mockImplementation(async () => {
       const error = new Error("Not found (404)");
@@ -111,7 +112,7 @@ describe("useGeoParquetValidation", () => {
   });
 
   it("returns error state when no geometry column detected", async () => {
-    const mockConn = { query: vi.fn() } as any;
+    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
 
     const describeResult = {
       numRows: 2,
@@ -162,10 +163,9 @@ describe("useGeoParquetValidation", () => {
   });
 
   it("sets validating to true while validation is in progress", async () => {
-    const mockConn = { query: vi.fn() } as any;
+    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
 
-    let describeResolved = false;
-    let resolveDescribe: any;
+    let resolveDescribe: (value: unknown) => void = () => {};
     const describePromise = new Promise((resolve) => {
       resolveDescribe = resolve;
     });
@@ -177,7 +177,6 @@ describe("useGeoParquetValidation", () => {
 
     mockRunQuery.mockImplementation(async (sql) => {
       if (sql.includes("DESCRIBE")) {
-        describeResolved = true;
         await describePromise;
         return describeResult;
       }
@@ -204,14 +203,11 @@ describe("useGeoParquetValidation", () => {
       useGeoParquetValidation(mockConn, "/api/test.parquet")
     );
 
-    let validatingDuringCall = false;
     const validatePromise = act(async () => {
-      result.current.validate().then(() => {
-        validatingDuringCall = result.current.validating;
-      });
+      result.current.validate();
     });
 
-    resolveDescribe();
+    resolveDescribe(undefined);
     await validatePromise;
 
     // State should eventually be set to valid=true
@@ -220,7 +216,7 @@ describe("useGeoParquetValidation", () => {
   });
 
   it("returns error when geometry column name contains invalid characters", async () => {
-    const mockConn = { query: vi.fn() } as any;
+    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
 
     const describeResult = {
       numRows: 1,
@@ -249,7 +245,7 @@ describe("useGeoParquetValidation", () => {
   });
 
   it("does not allow concurrent validation calls", async () => {
-    const mockConn = { query: vi.fn() } as any;
+    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
 
     let validateCallCount = 0;
     mockRunQuery.mockImplementation(async (sql) => {
@@ -294,7 +290,7 @@ describe("useGeoParquetValidation", () => {
   });
 
   it("sanitizes error messages to avoid exposing internal details", async () => {
-    const mockConn = { query: vi.fn() } as any;
+    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
 
     mockRunQuery.mockImplementation(async () => {
       throw new Error("DuckDB Internal Error: GDAL Exception: Unknown format");

--- a/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
+++ b/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
@@ -3,23 +3,20 @@ import { renderHook, waitFor, act } from "@testing-library/react";
 import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import { useGeoParquetValidation } from "../useGeoParquetValidation";
 
-const mockRunQuery = vi.fn();
-
-vi.mock("../useGeoParquetQuery", () => ({
-  useGeoParquetQuery: () => ({
-    runQuery: mockRunQuery,
-  }),
-}));
-
 beforeEach(() => {
-  mockRunQuery.mockReset();
   vi.clearAllMocks();
 });
 
+function makeConn(
+  impl: (sql: string) => Promise<unknown> | unknown
+): AsyncDuckDBConnection {
+  return {
+    query: vi.fn(async (sql: string) => impl(sql)),
+  } as unknown as AsyncDuckDBConnection;
+}
+
 describe("useGeoParquetValidation", () => {
   it("returns valid state with geometry info for valid GeoParquet", async () => {
-    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
-
     const describeResult = {
       numRows: 2,
       get: (i: number) => {
@@ -53,16 +50,10 @@ describe("useGeoParquetValidation", () => {
       }),
     };
 
-    mockRunQuery.mockImplementation(async (sql) => {
-      if (sql.includes("DESCRIBE")) {
-        return describeResult;
-      }
-      if (sql.includes("ST_GeometryType")) {
-        return geomTypeResult;
-      }
-      if (sql.includes("ST_Extent")) {
-        return bboxResult;
-      }
+    const mockConn = makeConn((sql) => {
+      if (sql.includes("DESCRIBE")) return describeResult;
+      if (sql.includes("ST_GeometryType")) return geomTypeResult;
+      if (sql.includes("ST_Extent")) return bboxResult;
     });
 
     const { result } = renderHook(() =>
@@ -91,11 +82,8 @@ describe("useGeoParquetValidation", () => {
   });
 
   it("returns error state for unreachable URL", async () => {
-    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
-
-    mockRunQuery.mockImplementation(async () => {
-      const error = new Error("Not found (404)");
-      throw error;
+    const mockConn = makeConn(() => {
+      throw new Error("Not found (404)");
     });
 
     const { result } = renderHook(() =>
@@ -112,8 +100,6 @@ describe("useGeoParquetValidation", () => {
   });
 
   it("returns error state when no geometry column detected", async () => {
-    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
-
     const describeResult = {
       numRows: 2,
       get: (i: number) => {
@@ -130,10 +116,8 @@ describe("useGeoParquetValidation", () => {
       },
     };
 
-    mockRunQuery.mockImplementation(async (sql) => {
-      if (sql.includes("DESCRIBE")) {
-        return describeResult;
-      }
+    const mockConn = makeConn((sql) => {
+      if (sql.includes("DESCRIBE")) return describeResult;
     });
 
     const { result } = renderHook(() =>
@@ -162,9 +146,37 @@ describe("useGeoParquetValidation", () => {
     expect(result.current.error).toBe("DuckDB connection not available");
   });
 
-  it("sets validating to true while validation is in progress", async () => {
-    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
+  it("uses the override conn when provided even if hook conn is null", async () => {
+    const describeResult = {
+      numRows: 1,
+      get: () => ({ column_name: "geometry", column_type: "GEOMETRY" }),
+    };
+    const overrideConn = makeConn((sql) => {
+      if (sql.includes("DESCRIBE")) return describeResult;
+      if (sql.includes("ST_GeometryType")) {
+        return { numRows: 1, get: () => ({ geom_type: "POINT" }) };
+      }
+      if (sql.includes("ST_Extent")) {
+        return {
+          numRows: 1,
+          get: () => ({ minx: -1, miny: -1, maxx: 1, maxy: 1 }),
+        };
+      }
+    });
 
+    const { result } = renderHook(() =>
+      useGeoParquetValidation(null, "/api/test.parquet")
+    );
+
+    await act(async () => {
+      await result.current.validate(overrideConn);
+    });
+
+    expect(result.current.valid).toBe(true);
+    expect(result.current.geometryInfo?.type).toBe("POINT");
+  });
+
+  it("sets validating to true while validation is in progress", async () => {
     let resolveDescribe: (value: unknown) => void = () => {};
     const describePromise = new Promise((resolve) => {
       resolveDescribe = resolve;
@@ -175,7 +187,7 @@ describe("useGeoParquetValidation", () => {
       get: () => ({ column_name: "geometry", column_type: "GEOMETRY" }),
     };
 
-    mockRunQuery.mockImplementation(async (sql) => {
+    const mockConn = makeConn(async (sql) => {
       if (sql.includes("DESCRIBE")) {
         await describePromise;
         return describeResult;
@@ -216,8 +228,6 @@ describe("useGeoParquetValidation", () => {
   });
 
   it("returns error when geometry column name contains invalid characters", async () => {
-    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
-
     const describeResult = {
       numRows: 1,
       get: () => ({
@@ -226,10 +236,8 @@ describe("useGeoParquetValidation", () => {
       }),
     };
 
-    mockRunQuery.mockImplementation(async (sql) => {
-      if (sql.includes("DESCRIBE")) {
-        return describeResult;
-      }
+    const mockConn = makeConn((sql) => {
+      if (sql.includes("DESCRIBE")) return describeResult;
     });
 
     const { result } = renderHook(() =>
@@ -245,10 +253,8 @@ describe("useGeoParquetValidation", () => {
   });
 
   it("does not allow concurrent validation calls", async () => {
-    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
-
     let validateCallCount = 0;
-    mockRunQuery.mockImplementation(async (sql) => {
+    const mockConn = makeConn(async (sql) => {
       validateCallCount++;
       if (sql.includes("DESCRIBE")) {
         return {
@@ -290,9 +296,7 @@ describe("useGeoParquetValidation", () => {
   });
 
   it("sanitizes error messages to avoid exposing internal details", async () => {
-    const mockConn = { query: vi.fn() } as unknown as AsyncDuckDBConnection;
-
-    mockRunQuery.mockImplementation(async () => {
+    const mockConn = makeConn(() => {
       throw new Error("DuckDB Internal Error: GDAL Exception: Unknown format");
     });
 
@@ -308,5 +312,44 @@ describe("useGeoParquetValidation", () => {
     expect(result.current.error).toBe("File validation failed");
     expect(result.current.error).not.toContain("GDAL");
     expect(result.current.error).not.toContain("DuckDB");
+  });
+
+  it("escapes single quotes in the URL to prevent SQL injection", async () => {
+    const queries: string[] = [];
+    const describeResult = {
+      numRows: 1,
+      get: () => ({ column_name: "geometry", column_type: "GEOMETRY" }),
+    };
+    const mockConn = {
+      query: vi.fn(async (sql: string) => {
+        queries.push(sql);
+        if (sql.includes("DESCRIBE")) return describeResult;
+        if (sql.includes("ST_GeometryType")) {
+          return { numRows: 1, get: () => ({ geom_type: "POINT" }) };
+        }
+        if (sql.includes("ST_Extent")) {
+          return {
+            numRows: 1,
+            get: () => ({ minx: 0, miny: 0, maxx: 1, maxy: 1 }),
+          };
+        }
+      }),
+    } as unknown as AsyncDuckDBConnection;
+
+    const trickyUrl = "/api/data's.parquet";
+    const { result } = renderHook(() =>
+      useGeoParquetValidation(mockConn, trickyUrl)
+    );
+
+    await act(async () => {
+      await result.current.validate();
+    });
+
+    expect(result.current.valid).toBe(true);
+    // Every SQL query should contain the escaped form, never a raw single quote breaking the literal
+    for (const q of queries) {
+      expect(q).toContain("data''s.parquet");
+      expect(q).not.toContain("data's.parquet");
+    }
   });
 });

--- a/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
+++ b/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useGeoParquetValidation } from "../useGeoParquetValidation";
+
+const mockRunQuery = vi.fn();
+
+vi.mock("../useGeoParquetQuery", () => ({
+  useGeoParquetQuery: () => ({
+    runQuery: mockRunQuery,
+  }),
+}));
+
+beforeEach(() => {
+  mockRunQuery.mockReset();
+  vi.clearAllMocks();
+});
+
+describe("useGeoParquetValidation", () => {
+  it("returns valid state with geometry info for valid GeoParquet", async () => {
+    const mockConn = { query: vi.fn() } as any;
+
+    const describeResult = {
+      numRows: 2,
+      get: (i: number) => {
+        if (i === 0) {
+          return {
+            column_name: "id",
+            column_type: "INTEGER",
+          };
+        }
+        return {
+          column_name: "geometry",
+          column_type: "GEOMETRY",
+        };
+      },
+    };
+
+    const geomTypeResult = {
+      numRows: 1,
+      get: () => ({
+        geom_type: "POINT",
+      }),
+    };
+
+    const bboxResult = {
+      numRows: 1,
+      get: () => ({
+        minx: -120,
+        miny: -45,
+        maxx: 120,
+        maxy: 45,
+      }),
+    };
+
+    mockRunQuery.mockImplementation(async (sql) => {
+      if (sql.includes("DESCRIBE")) {
+        return describeResult;
+      }
+      if (sql.includes("ST_GeometryType")) {
+        return geomTypeResult;
+      }
+      if (sql.includes("ST_Extent")) {
+        return bboxResult;
+      }
+    });
+
+    const { result } = renderHook(() =>
+      useGeoParquetValidation(mockConn, "/api/test.parquet")
+    );
+
+    expect(result.current.validating).toBe(false);
+    expect(result.current.valid).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.geometryInfo).toBeNull();
+
+    await act(async () => {
+      await result.current.validate();
+    });
+
+    expect(result.current.valid).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(result.current.geometryInfo).not.toBeNull();
+    expect(result.current.geometryInfo?.type).toBe("POINT");
+    expect(result.current.geometryInfo?.bbox).toEqual({
+      minLon: -120,
+      minLat: -45,
+      maxLon: 120,
+      maxLat: 45,
+    });
+  });
+
+  it("returns error state for unreachable URL", async () => {
+    const mockConn = { query: vi.fn() } as any;
+
+    mockRunQuery.mockImplementation(async () => {
+      const error = new Error("Not found (404)");
+      throw error;
+    });
+
+    const { result } = renderHook(() =>
+      useGeoParquetValidation(mockConn, "/api/missing.parquet")
+    );
+
+    await act(async () => {
+      await result.current.validate();
+    });
+
+    expect(result.current.valid).toBe(false);
+    expect(result.current.error).toBe("Could not access URL");
+    expect(result.current.geometryInfo).toBeNull();
+  });
+
+  it("returns error state when no geometry column detected", async () => {
+    const mockConn = { query: vi.fn() } as any;
+
+    const describeResult = {
+      numRows: 2,
+      get: (i: number) => {
+        if (i === 0) {
+          return {
+            column_name: "id",
+            column_type: "INTEGER",
+          };
+        }
+        return {
+          column_name: "name",
+          column_type: "VARCHAR",
+        };
+      },
+    };
+
+    mockRunQuery.mockImplementation(async (sql) => {
+      if (sql.includes("DESCRIBE")) {
+        return describeResult;
+      }
+    });
+
+    const { result } = renderHook(() =>
+      useGeoParquetValidation(mockConn, "/api/test.parquet")
+    );
+
+    await act(async () => {
+      await result.current.validate();
+    });
+
+    expect(result.current.valid).toBe(false);
+    expect(result.current.error).toBe("No geometry column detected");
+    expect(result.current.geometryInfo).toBeNull();
+  });
+
+  it("returns error when connection is null", async () => {
+    const { result } = renderHook(() =>
+      useGeoParquetValidation(null, "/api/test.parquet")
+    );
+
+    await act(async () => {
+      await result.current.validate();
+    });
+
+    expect(result.current.valid).toBe(false);
+    expect(result.current.error).toBe("DuckDB connection not available");
+  });
+
+  it("sets validating to true while validation is in progress", async () => {
+    const mockConn = { query: vi.fn() } as any;
+
+    let describeResolved = false;
+    let resolveDescribe: any;
+    const describePromise = new Promise((resolve) => {
+      resolveDescribe = resolve;
+    });
+
+    const describeResult = {
+      numRows: 1,
+      get: () => ({ column_name: "geometry", column_type: "GEOMETRY" }),
+    };
+
+    mockRunQuery.mockImplementation(async (sql) => {
+      if (sql.includes("DESCRIBE")) {
+        describeResolved = true;
+        await describePromise;
+        return describeResult;
+      }
+      if (sql.includes("ST_GeometryType")) {
+        return {
+          numRows: 1,
+          get: () => ({ geom_type: "POINT" }),
+        };
+      }
+      if (sql.includes("ST_Extent")) {
+        return {
+          numRows: 1,
+          get: () => ({
+            minx: -120,
+            miny: -45,
+            maxx: 120,
+            maxy: 45,
+          }),
+        };
+      }
+    });
+
+    const { result } = renderHook(() =>
+      useGeoParquetValidation(mockConn, "/api/test.parquet")
+    );
+
+    let validatingDuringCall = false;
+    const validatePromise = act(async () => {
+      result.current.validate().then(() => {
+        validatingDuringCall = result.current.validating;
+      });
+    });
+
+    resolveDescribe();
+    await validatePromise;
+
+    // State should eventually be set to valid=true
+    await waitFor(() => expect(result.current.validating).toBe(false));
+    expect(result.current.valid).toBe(true);
+  });
+});

--- a/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
+++ b/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
@@ -217,12 +217,18 @@ describe("useGeoParquetValidation", () => {
       useGeoParquetValidation(mockConn, "/api/test.parquet")
     );
 
-    const validatePromise = act(async () => {
-      result.current.validate();
+    let validatePromise: Promise<void> = Promise.resolve();
+    act(() => {
+      validatePromise = result.current.validate();
     });
 
+    // Assert mid-flight: validating should be true while DESCRIBE is pending
+    await waitFor(() => expect(result.current.validating).toBe(true));
+
     resolveDescribe(undefined);
-    await validatePromise;
+    await act(async () => {
+      await validatePromise;
+    });
 
     // State should eventually be set to valid=true
     await waitFor(() => expect(result.current.validating).toBe(false));
@@ -294,6 +300,10 @@ describe("useGeoParquetValidation", () => {
 
     await waitFor(() => expect(result.current.validating).toBe(false));
 
+    // validateCallCount counts SQL queries issued to the mock conn (3 per
+    // validation: DESCRIBE, ST_GeometryType, ST_Extent). The second
+    // validate() call is skipped due to the in-flight guard, so we expect
+    // exactly 3 queries, not 6.
     expect(validateCallCount).toBe(3);
   });
 
@@ -314,6 +324,76 @@ describe("useGeoParquetValidation", () => {
     expect(result.current.error).toBe("File validation failed");
     expect(result.current.error).not.toContain("GDAL");
     expect(result.current.error).not.toContain("DuckDB");
+  });
+
+  it("passes absolute URLs through unchanged and prefixes relative paths with window.location.origin", async () => {
+    const queries: string[] = [];
+    const describeResult = {
+      numRows: 1,
+      get: () => ({ column_name: "geometry", column_type: "GEOMETRY" }),
+    };
+    const makeQueryConn = () =>
+      ({
+        query: vi.fn(async (sql: string) => {
+          queries.push(sql);
+          if (sql.includes("DESCRIBE")) return describeResult;
+          if (sql.includes("ST_GeometryType")) {
+            return { numRows: 1, get: () => ({ geom_type: "POINT" }) };
+          }
+          if (sql.includes("ST_Extent")) {
+            return {
+              numRows: 1,
+              get: () => ({ minx: 0, miny: 0, maxx: 1, maxy: 1 }),
+            };
+          }
+        }),
+      }) as unknown as AsyncDuckDBConnection;
+
+    // Absolute URL: passed through unchanged
+    queries.length = 0;
+    const absoluteConn = makeQueryConn();
+    const absoluteUrl = "https://example.com/data.parquet";
+    const { result: absoluteResult } = renderHook(() =>
+      useGeoParquetValidation(absoluteConn, absoluteUrl)
+    );
+    await act(async () => {
+      await absoluteResult.current.validate();
+    });
+    expect(absoluteResult.current.valid).toBe(true);
+    for (const q of queries) {
+      expect(q).toContain("https://example.com/data.parquet");
+      expect(q).not.toContain(`${window.location.origin}https://`);
+    }
+
+    // Relative path: prefixed with window.location.origin
+    queries.length = 0;
+    const relativeConn = makeQueryConn();
+    const relativePath = "/api/data.parquet";
+    const { result: relativeResult } = renderHook(() =>
+      useGeoParquetValidation(relativeConn, relativePath)
+    );
+    await act(async () => {
+      await relativeResult.current.validate();
+    });
+    expect(relativeResult.current.valid).toBe(true);
+    for (const q of queries) {
+      expect(q).toContain(`${window.location.origin}/api/data.parquet`);
+    }
+
+    // Path without leading slash: still prefixed correctly with a single slash
+    queries.length = 0;
+    const bareConn = makeQueryConn();
+    const barePath = "api/data.parquet";
+    const { result: bareResult } = renderHook(() =>
+      useGeoParquetValidation(bareConn, barePath)
+    );
+    await act(async () => {
+      await bareResult.current.validate();
+    });
+    expect(bareResult.current.valid).toBe(true);
+    for (const q of queries) {
+      expect(q).toContain(`${window.location.origin}/api/data.parquet`);
+    }
   });
 
   it("escapes single quotes in the URL to prevent SQL injection", async () => {

--- a/frontend/src/hooks/useDuckDB.ts
+++ b/frontend/src/hooks/useDuckDB.ts
@@ -25,7 +25,10 @@ export function useDuckDB() {
   });
   const initializingRef = useRef(false);
 
-  const initialize = useCallback(async () => {
+  const initialize = useCallback(async (): Promise<{
+    db: duckdb.AsyncDuckDB;
+    conn: duckdb.AsyncDuckDBConnection;
+  } | null> => {
     if (dbSingleton.db && dbSingleton.conn) {
       setState({
         db: dbSingleton.db,
@@ -33,9 +36,9 @@ export function useDuckDB() {
         loading: false,
         error: null,
       });
-      return;
+      return { db: dbSingleton.db, conn: dbSingleton.conn };
     }
-    if (initializingRef.current) return;
+    if (initializingRef.current) return null;
     initializingRef.current = true;
     setState((s) => ({ ...s, loading: true, error: null }));
 
@@ -65,9 +68,11 @@ export function useDuckDB() {
       dbSingleton.db = db;
       dbSingleton.conn = conn;
       setState({ db, conn, loading: false, error: null });
+      return { db, conn };
     } catch (e) {
       const msg = e instanceof Error ? e.message : "DuckDB could not be loaded";
       setState({ db: null, conn: null, loading: false, error: msg });
+      return null;
     } finally {
       initializingRef.current = false;
     }

--- a/frontend/src/hooks/useGeoParquetValidation.ts
+++ b/frontend/src/hooks/useGeoParquetValidation.ts
@@ -45,7 +45,9 @@ export function useGeoParquetValidation(
   const validate = useCallback(
     async (overrideConn?: AsyncDuckDBConnection | null) => {
       if (validatingRef.current) {
-        console.warn("Validation already in progress, skipping concurrent call");
+        console.warn(
+          "Validation already in progress, skipping concurrent call"
+        );
         return;
       }
 

--- a/frontend/src/hooks/useGeoParquetValidation.ts
+++ b/frontend/src/hooks/useGeoParquetValidation.ts
@@ -10,7 +10,10 @@ function escapeSqlLiteral(value: string): string {
 }
 
 function resolveParquetUrl(parquetUrl: string): string {
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(parquetUrl) || parquetUrl.startsWith("//")) {
+  if (
+    /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(parquetUrl) ||
+    parquetUrl.startsWith("//")
+  ) {
     return parquetUrl;
   }
   const path = parquetUrl.startsWith("/") ? parquetUrl : `/${parquetUrl}`;

--- a/frontend/src/hooks/useGeoParquetValidation.ts
+++ b/frontend/src/hooks/useGeoParquetValidation.ts
@@ -1,6 +1,10 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import { useGeoParquetQuery } from "./useGeoParquetQuery";
+
+function isValidColumnName(name: string): boolean {
+  return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name);
+}
 
 export interface GeometryInfo {
   type: string;
@@ -33,9 +37,15 @@ export function useGeoParquetValidation(
     geometryInfo: null,
   });
 
+  const validatingRef = useRef(false);
   const { runQuery } = useGeoParquetQuery(conn, parquetUrl);
 
   const validate = useCallback(async () => {
+    if (validatingRef.current) {
+      console.warn("Validation already in progress, skipping concurrent call");
+      return;
+    }
+
     if (!conn) {
       setState({
         validating: false,
@@ -46,6 +56,7 @@ export function useGeoParquetValidation(
       return;
     }
 
+    validatingRef.current = true;
     setState((prev) => ({ ...prev, validating: true }));
 
     try {
@@ -82,6 +93,18 @@ export function useGeoParquetValidation(
           error: "No geometry column detected",
           geometryInfo: null,
         });
+        validatingRef.current = false;
+        return;
+      }
+
+      if (!isValidColumnName(geometryColumnName)) {
+        setState({
+          validating: false,
+          valid: false,
+          error: "Invalid column name",
+          geometryInfo: null,
+        });
+        validatingRef.current = false;
         return;
       }
 
@@ -143,6 +166,8 @@ export function useGeoParquetValidation(
         error: errorMessage,
         geometryInfo: null,
       });
+    } finally {
+      validatingRef.current = false;
     }
   }, [conn, parquetUrl, runQuery]);
 
@@ -154,20 +179,26 @@ export function useGeoParquetValidation(
 
 function categorizeError(error: unknown): string {
   if (error instanceof Error) {
-    const message = error.message.toLowerCase();
+    const errorMsg = error.message;
+    const lowerMsg = errorMsg.toLowerCase();
 
-    if (message.includes("not found") || message.includes("404")) {
-      return "Could not access URL";
+    if (lowerMsg.includes("404") || lowerMsg.includes("not found")) {
+      return "Could not access URL: file not found (404)";
     }
-    if (
-      message.includes("network") ||
-      message.includes("fetch") ||
-      message.includes("connection")
-    ) {
-      return "Could not access URL";
+    if (lowerMsg.includes("403")) {
+      return "Could not access URL: permission denied (403)";
+    }
+    if (lowerMsg.includes("network") || lowerMsg.includes("fetch")) {
+      return `Could not access URL: ${errorMsg}`;
+    }
+    if (lowerMsg.includes("parquet")) {
+      return "File is not a valid Parquet";
+    }
+    if (lowerMsg.includes("geometry")) {
+      return "No geometry column detected";
     }
 
-    return error.message;
+    return "File validation failed";
   }
 
   return "Validation failed";

--- a/frontend/src/hooks/useGeoParquetValidation.ts
+++ b/frontend/src/hooks/useGeoParquetValidation.ts
@@ -1,9 +1,12 @@
 import { useState, useCallback, useRef } from "react";
 import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
-import { useGeoParquetQuery } from "./useGeoParquetQuery";
 
 function isValidColumnName(name: string): boolean {
   return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name);
+}
+
+function escapeSqlLiteral(value: string): string {
+  return value.replace(/'/g, "''");
 }
 
 export interface GeometryInfo {
@@ -38,138 +41,143 @@ export function useGeoParquetValidation(
   });
 
   const validatingRef = useRef(false);
-  const { runQuery } = useGeoParquetQuery(conn, parquetUrl);
 
-  const validate = useCallback(async () => {
-    if (validatingRef.current) {
-      console.warn("Validation already in progress, skipping concurrent call");
-      return;
-    }
+  const validate = useCallback(
+    async (overrideConn?: AsyncDuckDBConnection | null) => {
+      if (validatingRef.current) {
+        console.warn("Validation already in progress, skipping concurrent call");
+        return;
+      }
 
-    if (!conn) {
-      setState({
-        validating: false,
-        valid: false,
-        error: "DuckDB connection not available",
-        geometryInfo: null,
-      });
-      return;
-    }
+      const activeConn = overrideConn ?? conn;
 
-    validatingRef.current = true;
-    setState((prev) => ({ ...prev, validating: true }));
+      if (!activeConn) {
+        setState({
+          validating: false,
+          valid: false,
+          error: "DuckDB connection not available",
+          geometryInfo: null,
+        });
+        return;
+      }
 
-    try {
-      const fullUrl = `${window.location.origin}${parquetUrl}`;
+      validatingRef.current = true;
+      setState((prev) => ({ ...prev, validating: true }));
 
-      // Step 1: Detect geometry column
-      const descResult = await runQuery(
-        `DESCRIBE SELECT * FROM read_parquet('${fullUrl}') LIMIT 0`
-      );
+      try {
+        const fullUrl = `${window.location.origin}${parquetUrl}`;
+        const escapedUrl = escapeSqlLiteral(fullUrl);
 
-      let geometryColumnName: string | null = null;
+        // Step 1: Detect geometry column
+        const descResult = await activeConn.query(
+          `DESCRIBE SELECT * FROM read_parquet('${escapedUrl}') LIMIT 0`
+        );
 
-      if (descResult && descResult.numRows) {
-        for (let i = 0; i < descResult.numRows; i++) {
-          const row = descResult.get(i);
-          if (!row) continue;
-          const colType = String(row.column_type);
-          const colName = String(row.column_name);
+        let geometryColumnName: string | null = null;
 
-          if (
-            colType.includes("GEOMETRY") ||
-            (colType === "BLOB" && GEOM_NAMES.includes(colName.toLowerCase()))
-          ) {
-            geometryColumnName = colName;
-            break;
+        if (descResult && descResult.numRows) {
+          for (let i = 0; i < descResult.numRows; i++) {
+            const row = descResult.get(i);
+            if (!row) continue;
+            const colType = String(row.column_type);
+            const colName = String(row.column_name);
+
+            if (
+              colType.includes("GEOMETRY") ||
+              (colType === "BLOB" && GEOM_NAMES.includes(colName.toLowerCase()))
+            ) {
+              geometryColumnName = colName;
+              break;
+            }
           }
         }
-      }
 
-      if (!geometryColumnName) {
+        if (!geometryColumnName) {
+          setState({
+            validating: false,
+            valid: false,
+            error: "No geometry column detected",
+            geometryInfo: null,
+          });
+          validatingRef.current = false;
+          return;
+        }
+
+        if (!isValidColumnName(geometryColumnName)) {
+          setState({
+            validating: false,
+            valid: false,
+            error: "Invalid column name",
+            geometryInfo: null,
+          });
+          validatingRef.current = false;
+          return;
+        }
+
+        // Step 2: Get geometry type
+        const geomTypeResult = await activeConn.query(
+          `SELECT DISTINCT ST_GeometryType("${geometryColumnName}") as geom_type FROM read_parquet('${escapedUrl}') WHERE "${geometryColumnName}" IS NOT NULL LIMIT 1`
+        );
+
+        let geometryType = "UNKNOWN";
+        if (geomTypeResult && geomTypeResult.numRows > 0) {
+          const row = geomTypeResult.get(0);
+          if (row && row.geom_type) {
+            geometryType = String(row.geom_type);
+          }
+        }
+
+        // Step 3: Get bounding box
+        const bboxResult = await activeConn.query(
+          `SELECT ST_MinX(ST_Extent("${geometryColumnName}")) as minx,
+                  ST_MinY(ST_Extent("${geometryColumnName}")) as miny,
+                  ST_MaxX(ST_Extent("${geometryColumnName}")) as maxx,
+                  ST_MaxY(ST_Extent("${geometryColumnName}")) as maxy
+           FROM read_parquet('${escapedUrl}') WHERE "${geometryColumnName}" IS NOT NULL`
+        );
+
+        let bbox: GeometryInfo["bbox"] = null;
+        if (bboxResult && bboxResult.numRows > 0) {
+          const row = bboxResult.get(0);
+          if (
+            row &&
+            row.minx != null &&
+            row.miny != null &&
+            row.maxx != null &&
+            row.maxy != null
+          ) {
+            bbox = {
+              minLon: Number(row.minx),
+              minLat: Number(row.miny),
+              maxLon: Number(row.maxx),
+              maxLat: Number(row.maxy),
+            };
+          }
+        }
+
+        setState({
+          validating: false,
+          valid: true,
+          error: null,
+          geometryInfo: {
+            type: geometryType,
+            bbox,
+          },
+        });
+      } catch (e) {
+        const errorMessage = categorizeError(e);
         setState({
           validating: false,
           valid: false,
-          error: "No geometry column detected",
+          error: errorMessage,
           geometryInfo: null,
         });
+      } finally {
         validatingRef.current = false;
-        return;
       }
-
-      if (!isValidColumnName(geometryColumnName)) {
-        setState({
-          validating: false,
-          valid: false,
-          error: "Invalid column name",
-          geometryInfo: null,
-        });
-        validatingRef.current = false;
-        return;
-      }
-
-      // Step 2: Get geometry type
-      const geomTypeResult = await runQuery(
-        `SELECT DISTINCT ST_GeometryType("${geometryColumnName}") as geom_type FROM read_parquet('${fullUrl}') WHERE "${geometryColumnName}" IS NOT NULL LIMIT 1`
-      );
-
-      let geometryType = "UNKNOWN";
-      if (geomTypeResult && geomTypeResult.numRows > 0) {
-        const row = geomTypeResult.get(0);
-        if (row && row.geom_type) {
-          geometryType = String(row.geom_type);
-        }
-      }
-
-      // Step 3: Get bounding box
-      const bboxResult = await runQuery(
-        `SELECT ST_MinX(ST_Extent("${geometryColumnName}")) as minx,
-                ST_MinY(ST_Extent("${geometryColumnName}")) as miny,
-                ST_MaxX(ST_Extent("${geometryColumnName}")) as maxx,
-                ST_MaxY(ST_Extent("${geometryColumnName}")) as maxy
-         FROM read_parquet('${fullUrl}') WHERE "${geometryColumnName}" IS NOT NULL`
-      );
-
-      let bbox: GeometryInfo["bbox"] = null;
-      if (bboxResult && bboxResult.numRows > 0) {
-        const row = bboxResult.get(0);
-        if (
-          row &&
-          row.minx != null &&
-          row.miny != null &&
-          row.maxx != null &&
-          row.maxy != null
-        ) {
-          bbox = {
-            minLon: Number(row.minx),
-            minLat: Number(row.miny),
-            maxLon: Number(row.maxx),
-            maxLat: Number(row.maxy),
-          };
-        }
-      }
-
-      setState({
-        validating: false,
-        valid: true,
-        error: null,
-        geometryInfo: {
-          type: geometryType,
-          bbox,
-        },
-      });
-    } catch (e) {
-      const errorMessage = categorizeError(e);
-      setState({
-        validating: false,
-        valid: false,
-        error: errorMessage,
-        geometryInfo: null,
-      });
-    } finally {
-      validatingRef.current = false;
-    }
-  }, [conn, parquetUrl, runQuery]);
+    },
+    [conn, parquetUrl]
+  );
 
   return {
     ...state,

--- a/frontend/src/hooks/useGeoParquetValidation.ts
+++ b/frontend/src/hooks/useGeoParquetValidation.ts
@@ -9,6 +9,14 @@ function escapeSqlLiteral(value: string): string {
   return value.replace(/'/g, "''");
 }
 
+function resolveParquetUrl(parquetUrl: string): string {
+  if (/^https?:\/\//i.test(parquetUrl)) {
+    return parquetUrl;
+  }
+  const path = parquetUrl.startsWith("/") ? parquetUrl : `/${parquetUrl}`;
+  return `${window.location.origin}${path}`;
+}
+
 export interface GeometryInfo {
   type: string;
   bbox: {
@@ -67,7 +75,7 @@ export function useGeoParquetValidation(
       setState((prev) => ({ ...prev, validating: true }));
 
       try {
-        const fullUrl = `${window.location.origin}${parquetUrl}`;
+        const fullUrl = resolveParquetUrl(parquetUrl);
         const escapedUrl = escapeSqlLiteral(fullUrl);
 
         // Step 1: Detect geometry column
@@ -129,13 +137,15 @@ export function useGeoParquetValidation(
           }
         }
 
-        // Step 3: Get bounding box
+        // Step 3: Get bounding box (compute ST_Extent once via CTE)
         const bboxResult = await activeConn.query(
-          `SELECT ST_MinX(ST_Extent("${geometryColumnName}")) as minx,
-                  ST_MinY(ST_Extent("${geometryColumnName}")) as miny,
-                  ST_MaxX(ST_Extent("${geometryColumnName}")) as maxx,
-                  ST_MaxY(ST_Extent("${geometryColumnName}")) as maxy
-           FROM read_parquet('${escapedUrl}') WHERE "${geometryColumnName}" IS NOT NULL`
+          `WITH extent AS (
+             SELECT ST_Extent("${geometryColumnName}") as ext
+             FROM read_parquet('${escapedUrl}') WHERE "${geometryColumnName}" IS NOT NULL
+           )
+           SELECT ST_MinX(ext) as minx, ST_MinY(ext) as miny,
+                  ST_MaxX(ext) as maxx, ST_MaxY(ext) as maxy
+           FROM extent`
         );
 
         let bbox: GeometryInfo["bbox"] = null;
@@ -204,8 +214,14 @@ function categorizeError(error: unknown): string {
     if (lowerMsg.includes("parquet")) {
       return "File is not a valid Parquet";
     }
-    if (lowerMsg.includes("geometry")) {
+    if (
+      lowerMsg.includes("no geometry") ||
+      lowerMsg.includes("geometry column not found")
+    ) {
       return "No geometry column detected";
+    }
+    if (lowerMsg.includes("geometry")) {
+      return "Geometry processing failed";
     }
 
     return "File validation failed";

--- a/frontend/src/hooks/useGeoParquetValidation.ts
+++ b/frontend/src/hooks/useGeoParquetValidation.ts
@@ -10,7 +10,7 @@ function escapeSqlLiteral(value: string): string {
 }
 
 function resolveParquetUrl(parquetUrl: string): string {
-  if (/^https?:\/\//i.test(parquetUrl)) {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(parquetUrl) || parquetUrl.startsWith("//")) {
     return parquetUrl;
   }
   const path = parquetUrl.startsWith("/") ? parquetUrl : `/${parquetUrl}`;
@@ -109,7 +109,6 @@ export function useGeoParquetValidation(
             error: "No geometry column detected",
             geometryInfo: null,
           });
-          validatingRef.current = false;
           return;
         }
 
@@ -120,7 +119,6 @@ export function useGeoParquetValidation(
             error: "Invalid column name",
             geometryInfo: null,
           });
-          validatingRef.current = false;
           return;
         }
 

--- a/frontend/src/hooks/useGeoParquetValidation.ts
+++ b/frontend/src/hooks/useGeoParquetValidation.ts
@@ -1,0 +1,174 @@
+import { useState, useCallback } from "react";
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
+import { useGeoParquetQuery } from "./useGeoParquetQuery";
+
+export interface GeometryInfo {
+  type: string;
+  bbox: {
+    minLon: number;
+    minLat: number;
+    maxLon: number;
+    maxLat: number;
+  } | null;
+  crs?: string;
+}
+
+export interface ValidationState {
+  validating: boolean;
+  valid: boolean;
+  error: string | null;
+  geometryInfo: GeometryInfo | null;
+}
+
+const GEOM_NAMES = ["geometry", "geom", "wkb_geometry", "the_geom"];
+
+export function useGeoParquetValidation(
+  conn: AsyncDuckDBConnection | null,
+  parquetUrl: string
+) {
+  const [state, setState] = useState<ValidationState>({
+    validating: false,
+    valid: false,
+    error: null,
+    geometryInfo: null,
+  });
+
+  const { runQuery } = useGeoParquetQuery(conn, parquetUrl);
+
+  const validate = useCallback(async () => {
+    if (!conn) {
+      setState({
+        validating: false,
+        valid: false,
+        error: "DuckDB connection not available",
+        geometryInfo: null,
+      });
+      return;
+    }
+
+    setState((prev) => ({ ...prev, validating: true }));
+
+    try {
+      const fullUrl = `${window.location.origin}${parquetUrl}`;
+
+      // Step 1: Detect geometry column
+      const descResult = await runQuery(
+        `DESCRIBE SELECT * FROM read_parquet('${fullUrl}') LIMIT 0`
+      );
+
+      let geometryColumnName: string | null = null;
+
+      if (descResult && descResult.numRows) {
+        for (let i = 0; i < descResult.numRows; i++) {
+          const row = descResult.get(i);
+          if (!row) continue;
+          const colType = String(row.column_type);
+          const colName = String(row.column_name);
+
+          if (
+            colType.includes("GEOMETRY") ||
+            (colType === "BLOB" && GEOM_NAMES.includes(colName.toLowerCase()))
+          ) {
+            geometryColumnName = colName;
+            break;
+          }
+        }
+      }
+
+      if (!geometryColumnName) {
+        setState({
+          validating: false,
+          valid: false,
+          error: "No geometry column detected",
+          geometryInfo: null,
+        });
+        return;
+      }
+
+      // Step 2: Get geometry type
+      const geomTypeResult = await runQuery(
+        `SELECT DISTINCT ST_GeometryType("${geometryColumnName}") as geom_type FROM read_parquet('${fullUrl}') WHERE "${geometryColumnName}" IS NOT NULL LIMIT 1`
+      );
+
+      let geometryType = "UNKNOWN";
+      if (geomTypeResult && geomTypeResult.numRows > 0) {
+        const row = geomTypeResult.get(0);
+        if (row && row.geom_type) {
+          geometryType = String(row.geom_type);
+        }
+      }
+
+      // Step 3: Get bounding box
+      const bboxResult = await runQuery(
+        `SELECT ST_MinX(ST_Extent("${geometryColumnName}")) as minx,
+                ST_MinY(ST_Extent("${geometryColumnName}")) as miny,
+                ST_MaxX(ST_Extent("${geometryColumnName}")) as maxx,
+                ST_MaxY(ST_Extent("${geometryColumnName}")) as maxy
+         FROM read_parquet('${fullUrl}') WHERE "${geometryColumnName}" IS NOT NULL`
+      );
+
+      let bbox: GeometryInfo["bbox"] = null;
+      if (bboxResult && bboxResult.numRows > 0) {
+        const row = bboxResult.get(0);
+        if (
+          row &&
+          row.minx != null &&
+          row.miny != null &&
+          row.maxx != null &&
+          row.maxy != null
+        ) {
+          bbox = {
+            minLon: Number(row.minx),
+            minLat: Number(row.miny),
+            maxLon: Number(row.maxx),
+            maxLat: Number(row.maxy),
+          };
+        }
+      }
+
+      setState({
+        validating: false,
+        valid: true,
+        error: null,
+        geometryInfo: {
+          type: geometryType,
+          bbox,
+        },
+      });
+    } catch (e) {
+      const errorMessage = categorizeError(e);
+      setState({
+        validating: false,
+        valid: false,
+        error: errorMessage,
+        geometryInfo: null,
+      });
+    }
+  }, [conn, parquetUrl, runQuery]);
+
+  return {
+    ...state,
+    validate,
+  };
+}
+
+function categorizeError(error: unknown): string {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+
+    if (message.includes("not found") || message.includes("404")) {
+      return "Could not access URL";
+    }
+    if (
+      message.includes("network") ||
+      message.includes("fetch") ||
+      message.includes("connection")
+    ) {
+      return "Could not access URL";
+    }
+
+    return error.message;
+  }
+
+  return "Validation failed";
+}

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -19,6 +19,7 @@ import {
   LinkSimple,
 } from "@phosphor-icons/react";
 import { useConversionJob } from "../hooks/useConversionJob";
+import { useDuckDB } from "../hooks/useDuckDB";
 import { workspaceFetch } from "../lib/api";
 import { config } from "../config";
 import { formatBytes } from "../utils/format";
@@ -54,6 +55,13 @@ export default function UploadPage() {
     "none" | "upload" | "connect" | "story"
   >("none");
   const [reportOpen, setReportOpen] = useState(false);
+  const { initialize: initializeDuckDB } = useDuckDB();
+
+  useEffect(() => {
+    initializeDuckDB().catch((err) => {
+      console.warn("DuckDB initialization in background failed:", err);
+    });
+  }, [initializeDuckDB]);
 
   const isProcessing =
     state.isUploading || (state.jobId !== null && state.status !== "failed");

--- a/ingestion/src/routes/connections.py
+++ b/ingestion/src/routes/connections.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api")
 
-VALID_CONNECTION_TYPES = {"xyz_raster", "xyz_vector", "cog", "pmtiles"}
+VALID_CONNECTION_TYPES = {"xyz_raster", "xyz_vector", "cog", "pmtiles", "geoparquet"}
 VALID_TILE_TYPES = {"raster", "vector", None}
 
 

--- a/ingestion/tests/test_connections.py
+++ b/ingestion/tests/test_connections.py
@@ -208,6 +208,20 @@ def test_patch_connection_categories_updates_labels(client, monkeypatch):
     assert get_resp.json()["categories"][0]["label"] == "Forest"
 
 
+def test_create_geoparquet_connection(client):
+    body = {
+        "name": "Remote GeoParquet",
+        "url": "https://example.com/data.parquet",
+        "connection_type": "geoparquet",
+    }
+    resp = client.post("/api/connections", json=body)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["connection_type"] == "geoparquet"
+    assert data["url"] == "https://example.com/data.parquet"
+    assert data["id"]
+
+
 def test_patch_connection_categories_rejects_non_categorical(client):
     body = {
         "name": "Plain",


### PR DESCRIPTION
## Summary

Add DuckDB WASM-based validation and preview for remote GeoParquet URLs in the connection workflow. When a user pastes a `.parquet` URL, a modal displays geometry info, schema, and sample rows before creating the connection.

- New `useGeoParquetValidation` hook validates remote URLs and extracts geometry metadata (type, bbox)
- New `GeoParquetPreviewModal` component displays validation results using Chakra v3 Dialog API
- `RemoteConnectFlow` now routes `.parquet` URLs through validation before connection creation
- DuckDB initializes in the background on app load for snappier first-use experience

## Test plan

- [ ] Paste a valid remote GeoParquet URL — modal shows geometry type, bbox, schema table, sample rows
- [ ] Click "Confirm & Connect" — connection is created and map opens
- [ ] Paste an unreachable URL — modal shows "Could not access URL" error, confirm button disabled
- [ ] Paste a parquet without a geometry column — modal shows "No geometry column detected"
- [ ] Paste a non-parquet URL (e.g. S3 prefix) — existing discovery flow runs unchanged
- [ ] Verify no console errors on app load (DuckDB init happens quietly in background)

Plan: [Project Docs/CNG Sandbox/plans/2026-04-14-geoparquet-remote-validation-impl](../Project%20Docs/CNG%20Sandbox/plans/2026-04-14-geoparquet-remote-validation-impl.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GeoParquet preview modal: validation status, geometry info (type + bbox), schema, and truncated sample rows with Confirm/Cancel actions.
  * GeoParquet connect flow: validate previewed .parquet URLs, create GeoParquet connections from the modal, and surface connection errors in the preview.
  * Automatic DB initialization on pages that use previews.

* **Tests**
  * UI and hook tests covering modal states, validation flows, concurrency, SQL/url handling, and connection creation.

* **Chores**
  * API accepts "geoparquet" as a valid connection type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->