### PR TITLE
feat(mcp): MCP server for agent-driven story creation (#221)

### DIFF
--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -10,6 +10,7 @@ on:
     branches: [main]
     paths:
       - "mcp/**"
+      - ".github/workflows/test-mcp.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -1,0 +1,27 @@
+name: Test MCP Server
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mcp/**"
+      - ".github/workflows/test-mcp.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "mcp/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v2
+      - run: cd mcp && uv sync --extra dev
+      - run: cd mcp && uv run pytest tests/ -v --cov=src/cng_mcp

--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -11,6 +11,9 @@ on:
     paths:
       - "mcp/**"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,10 +21,12 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v2
+      - uses: astral-sh/setup-uv@797cf5c0a210b8b257f62fe1fbf9a46b4fc201bf # v2
       - run: cd mcp && uv sync --extra dev
       - run: cd mcp && uv run pytest tests/ -v --cov=src/cng_mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,41 @@ On startup, the ingestion service runs a background task (`src/services/example_
 - Uses GDAL internally. GDAL < 3.11 requires `AWS_S3_ENDPOINT` (hostname:port without protocol) for S3 access, in addition to `AWS_ENDPOINT_URL`.
 - `AWS_VIRTUAL_HOSTING=FALSE` is required for R2 (path-style access).
 
+## MCP Server
+
+A Model Context Protocol server that wraps the ingestion API, exposing datasets, stories, connections, and validation as composable tools for MCP-compatible agents (Claude Desktop, Claude Code, etc.). Source in `mcp/src/cng_mcp/`.
+
+### Running tests
+
+```bash
+cd mcp && uv run pytest -v
+```
+
+### Tools
+
+- `read_datasets` — List workspace datasets
+- `read_story` / `create_story` / `update_story` — Manage stories
+- `read_connections` — List external tile source connections
+- `validate_layer_config` — Pre-flight check for a chapter's layer config
+
+### Resources
+
+- `cng://datasets` — Catalog of datasets in the workspace
+- `cng://story-templates` — Pre-built story templates agents can reference
+- `cng://colormaps` — Valid colormap names
+
+### Running the server
+
+```bash
+cng-mcp --api-url http://localhost:8086    # Communicates over stdio
+```
+
+See `mcp/README.md` for client config examples and `mcp/ARCHITECTURE.md` for design notes.
+
+### Open dependency
+
+`validate_layer_config` calls `POST /api/validate-layer-config` on the ingestion service, which does not yet exist. The tool is wired up in advance of that endpoint landing.
+
 ## Agent Isolation & Worktrees
 
 All code changes happen in worktrees. The main session stays on `main` at all times.

--- a/mcp/ARCHITECTURE.md
+++ b/mcp/ARCHITECTURE.md
@@ -1,0 +1,55 @@
+# CNG MCP Server Architecture
+
+## Overview
+
+```
+MCP Client (Claude, agents, CLI)
+    ↓ MCP protocol (stdio)
+cng_mcp/server.py
+    ├─ Tool Handlers
+    ├─ Resource Handlers
+    └─ Request Router
+    ↓ HTTP (httpx)
+SandboxAPIClient
+    ↓ HTTP
+Sandbox Ingestion API (:8086)
+    ↓
+PostgreSQL, S3, Tilers
+```
+
+## Modules
+
+### server.py
+MCP server entrypoint. Registers tools/resources. CLI parsing.
+
+### client/sandbox_api.py
+Async HTTP wrapper for ingestion API endpoints.
+
+### tools/
+Tool implementations. Each takes a client, calls API, returns `TextContent`.
+
+### resources/
+Read-only catalogs (datasets, templates, colormaps) as markdown.
+
+## Decision Log
+
+### Separate Package
+Thinner boundary, independent versioning, open-source friendly.
+
+### Async/Await
+MCP clients may make concurrent requests.
+
+### Static Templates (v1)
+Database-backed templates deferred to v2.
+
+### Defer Validation to API
+API is single source of truth. MCP does presence checks only.
+
+### Name-Only Colormaps (v1)
+Agents pick from list. v2 can expose metadata.
+
+## Error Handling
+
+- Client raises `httpx.HTTPError` on API failures
+- Tools catch and format as user-friendly `TextContent`
+- Server wraps protocol-level errors

--- a/mcp/CONTRIBUTING.md
+++ b/mcp/CONTRIBUTING.md
@@ -31,7 +31,7 @@ uv sync
 
 ## Commit Messages
 
-Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`
 
 ## PRs
 

--- a/mcp/CONTRIBUTING.md
+++ b/mcp/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to CNG MCP Server
+
+## Development Setup
+
+```bash
+cd mcp
+uv sync
+```
+
+## Test-Driven Approach
+
+1. Write failing test
+2. Run to confirm failure: `uv run pytest tests/test_foo.py::test_name -v`
+3. Implement minimal code
+4. Run tests: `uv run pytest tests/ -v`
+5. Commit with conventional message
+
+## Code Style
+
+- No inline comments — code should speak for itself
+- Docstrings for public functions
+- Type hints for all signatures
+- Async/await throughout
+
+## Testing
+
+- Tests live in `tests/` with `test_` prefix
+- Use `pytest` + `pytest-asyncio`
+- Mock HTTP calls (no real API in tests)
+- Test happy path and error cases
+
+## Commit Messages
+
+Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+
+## PRs
+
+1. Push branch
+2. Open PR with clear title and description
+3. All tests must pass

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,10 @@
 # CNG MCP Server
 
-Model Context Protocol server for CNG Sandbox. Exposes datasets, stories, connections, and validation as composable tools for agents.
+Model Context Protocol (MCP) server for CNG Sandbox. Exposes datasets, stories, connections, and validation as composable tools for agents.
+
+## What is MCP?
+
+MCP is a protocol that lets applications (agents, CLI tools, SDKs) discover and interact with tools and resources in a standardized way. This server makes the CNG Sandbox accessible to any MCP-compatible client.
 
 ## Installation
 
@@ -8,27 +12,66 @@ Model Context Protocol server for CNG Sandbox. Exposes datasets, stories, connec
 pip install cng-mcp
 ```
 
-## Usage
+## Quick Start
+
+### 1. Start the Server
 
 ```bash
-cng-mcp --api-url http://localhost:8086
+# Default API URL (http://localhost:8086)
+cng-mcp
+
+# Custom API URL
+cng-mcp --api-url http://your-sandbox.com
 ```
 
-Connect with Claude or any MCP-compatible client.
+The server communicates over stdio. Connect with any MCP client.
+
+### 2. Use with Claude Desktop / Code
+
+Add to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "cng-sandbox": {
+      "command": "cng-mcp",
+      "args": ["--api-url", "http://localhost:8086"]
+    }
+  }
+}
+```
 
 ## Tools
 
-- `read_datasets` — List all datasets in workspace
-- `read_story` — Get story metadata and chapters
-- `create_story` — Create a new story
-- `update_story` — Modify existing story
-- `read_connections` — List external tile sources
-- `validate_layer_config` — Check if layer config is valid
+### read_datasets
+List all datasets in your workspace with IDs, types, and bounds.
+
+### read_story
+Get a story's metadata and chapters.
+**Input**: `story_id` (string)
+
+### create_story
+Create a new story.
+**Input**:
+- `title` (string)
+- `description` (string)
+- `chapters` (array): each with `title`, `text`, `dataset_id`, `map_state`, `layer_config`
+
+### update_story
+Modify an existing story.
+**Input**: `story_id`, `updates` (object with changed fields)
+
+### read_connections
+List external tile source connections.
+
+### validate_layer_config
+Check if a layer configuration is valid before creating a chapter.
+**Input**: `dataset_id`, `colormap`, optional `rescale_min`/`rescale_max`
 
 ## Resources
 
-- `cng://datasets` — Available data with metadata
-- `cng://story-templates` — Examples agents can reference
+- `cng://datasets` — Catalog of available datasets
+- `cng://story-templates` — Pre-built templates agents can reference
 - `cng://colormaps` — Valid colormap names
 
 ## Development
@@ -36,5 +79,21 @@ Connect with Claude or any MCP-compatible client.
 ```bash
 cd mcp
 uv sync
-pytest tests/
+uv run pytest tests/ -v
 ```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) and [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## Troubleshooting
+
+### "Connection refused" on localhost:8086
+Verify sandbox stack is running: `docker compose ps`. If not, start it: `docker compose up -d`.
+
+### "Unknown colormap" validation error
+List valid colormaps via the `cng://colormaps` resource and pick one.
+
+### Server doesn't discover tools
+Run with debug logging: `cng-mcp --log-level DEBUG`. Check for tool registration messages.
+
+### "ModuleNotFoundError: No module named 'cng_mcp'"
+Install in editable mode from the `mcp/` directory: `pip install -e mcp/`.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,40 @@
+# CNG MCP Server
+
+Model Context Protocol server for CNG Sandbox. Exposes datasets, stories, connections, and validation as composable tools for agents.
+
+## Installation
+
+```bash
+pip install cng-mcp
+```
+
+## Usage
+
+```bash
+cng-mcp --api-url http://localhost:8086
+```
+
+Connect with Claude or any MCP-compatible client.
+
+## Tools
+
+- `read_datasets` — List all datasets in workspace
+- `read_story` — Get story metadata and chapters
+- `create_story` — Create a new story
+- `update_story` — Modify existing story
+- `read_connections` — List external tile sources
+- `validate_layer_config` — Check if layer config is valid
+
+## Resources
+
+- `cng://datasets` — Available data with metadata
+- `cng://story-templates` — Examples agents can reference
+- `cng://colormaps` — Valid colormap names
+
+## Development
+
+```bash
+cd mcp
+uv sync
+pytest tests/
+```

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cng-mcp"
+version = "0.1.0"
+description = "MCP Server for CNG Sandbox: agent-driven story creation and data exploration"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{name = "Development Seed"}]
+keywords = ["mcp", "geospatial", "agent", "api"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "mcp>=0.1.0",
+    "httpx>=0.24.0",
+    "pydantic>=2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-mock>=3.0",
+    "pytest-cov>=4.0",
+]
+
+[project.scripts]
+cng-mcp = "cng_mcp.server:main_cli"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cng_mcp"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/mcp/src/cng_mcp/__init__.py
+++ b/mcp/src/cng_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""CNG MCP Server - Agent-driven story creation and data exploration."""
+
+__version__ = "0.1.0"

--- a/mcp/src/cng_mcp/client/__init__.py
+++ b/mcp/src/cng_mcp/client/__init__.py
@@ -1,0 +1,5 @@
+"""Client module for sandbox API communication."""
+
+from .sandbox_api import SandboxAPIClient
+
+__all__ = ["SandboxAPIClient"]

--- a/mcp/src/cng_mcp/client/sandbox_api.py
+++ b/mcp/src/cng_mcp/client/sandbox_api.py
@@ -1,6 +1,7 @@
 """HTTP client for CNG Sandbox API."""
 
 from typing import Any, Optional
+from urllib.parse import quote
 import httpx
 
 
@@ -19,7 +20,7 @@ class SandboxAPIClient:
 
     async def get_story(self, story_id: str) -> dict[str, Any]:
         """Get story by ID."""
-        response = await self.http_client.get(f"{self.api_url}/api/stories/{story_id}")
+        response = await self.http_client.get(f"{self.api_url}/api/stories/{quote(story_id, safe='')}")
         response.raise_for_status()
         return response.json()
 
@@ -40,7 +41,7 @@ class SandboxAPIClient:
     async def update_story(self, story_id: str, updates: dict[str, Any]) -> dict[str, Any]:
         """Update an existing story."""
         response = await self.http_client.patch(
-            f"{self.api_url}/api/stories/{story_id}",
+            f"{self.api_url}/api/stories/{quote(story_id, safe='')}",
             json=updates,
         )
         response.raise_for_status()

--- a/mcp/src/cng_mcp/client/sandbox_api.py
+++ b/mcp/src/cng_mcp/client/sandbox_api.py
@@ -1,0 +1,77 @@
+"""HTTP client for CNG Sandbox API."""
+
+from typing import Any, Optional
+import httpx
+
+
+class SandboxAPIClient:
+    """Async HTTP client for sandbox ingestion API."""
+
+    def __init__(self, api_url: str, http_client: Optional[httpx.AsyncClient] = None):
+        self.api_url = api_url.rstrip("/")
+        self.http_client = http_client or httpx.AsyncClient()
+
+    async def get_datasets(self) -> list[dict[str, Any]]:
+        """Get all datasets in workspace."""
+        response = await self.http_client.get(f"{self.api_url}/api/datasets")
+        response.raise_for_status()
+        return response.json().get("datasets", [])
+
+    async def get_story(self, story_id: str) -> dict[str, Any]:
+        """Get story by ID."""
+        response = await self.http_client.get(f"{self.api_url}/api/stories/{story_id}")
+        response.raise_for_status()
+        return response.json()
+
+    async def create_story(
+        self,
+        title: str,
+        description: str,
+        chapters: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Create a new story."""
+        response = await self.http_client.post(
+            f"{self.api_url}/api/stories",
+            json={"title": title, "description": description, "chapters": chapters},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def update_story(self, story_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        """Update an existing story."""
+        response = await self.http_client.patch(
+            f"{self.api_url}/api/stories/{story_id}",
+            json=updates,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def get_connections(self) -> list[dict[str, Any]]:
+        """Get all external tile source connections."""
+        response = await self.http_client.get(f"{self.api_url}/api/connections")
+        response.raise_for_status()
+        return response.json().get("connections", [])
+
+    async def validate_layer_config(
+        self,
+        dataset_id: str,
+        colormap: str,
+        rescale_min: Optional[float] = None,
+        rescale_max: Optional[float] = None,
+    ) -> dict[str, Any]:
+        """Validate a layer configuration before creating a chapter."""
+        payload: dict[str, Any] = {"dataset_id": dataset_id, "colormap": colormap}
+        if rescale_min is not None:
+            payload["rescale_min"] = rescale_min
+        if rescale_max is not None:
+            payload["rescale_max"] = rescale_max
+        response = await self.http_client.post(
+            f"{self.api_url}/api/validate-layer-config",
+            json=payload,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def close(self):
+        """Close HTTP client."""
+        await self.http_client.aclose()

--- a/mcp/src/cng_mcp/resources/__init__.py
+++ b/mcp/src/cng_mcp/resources/__init__.py
@@ -1,0 +1,11 @@
+"""MCP Resources for CNG Sandbox."""
+
+from .datasets import list_datasets_resource
+from .stories import list_story_templates_resource
+from .colormaps import list_colormaps_resource
+
+__all__ = [
+    "list_datasets_resource",
+    "list_story_templates_resource",
+    "list_colormaps_resource",
+]

--- a/mcp/src/cng_mcp/resources/colormaps.py
+++ b/mcp/src/cng_mcp/resources/colormaps.py
@@ -1,0 +1,33 @@
+"""Colormaps resource - valid colormap names for datasets."""
+
+
+async def list_colormaps_resource() -> str:
+    """Generate a list of available colormaps."""
+    colormaps = {
+        "viridis": "Perceptually uniform, colorblind-friendly",
+        "plasma": "High contrast, good for diverging data",
+        "inferno": "Dark background, good for heat maps",
+        "magma": "Sequential, good for low-to-high ranges",
+        "cividis": "Colorblind-friendly, optimized for visibility",
+        "twilight": "Cyclic, good for directional data",
+        "RdBu": "Diverging red-to-blue, good for anomalies",
+        "RdYlGn": "Diverging, natural for positive/negative contrasts",
+        "gray": "Grayscale",
+        "binary": "Black and white",
+    }
+
+    lines = ["# Available Colormaps\n",
+             "Use these colormap names when configuring layers in stories.\n\n",
+             "## Sequential (for ordered data like elevation, temperature)\n"]
+    for cm in ["viridis", "plasma", "inferno", "magma", "cividis"]:
+        lines.append(f"- `{cm}` — {colormaps[cm]}")
+
+    lines.append("\n## Diverging (for data with a midpoint like anomalies)\n")
+    for cm in ["RdBu", "RdYlGn", "twilight"]:
+        lines.append(f"- `{cm}` — {colormaps[cm]}")
+
+    lines.append("\n## Grayscale\n")
+    for cm in ["gray", "binary"]:
+        lines.append(f"- `{cm}` — {colormaps[cm]}")
+
+    return "\n".join(lines)

--- a/mcp/src/cng_mcp/resources/colormaps.py
+++ b/mcp/src/cng_mcp/resources/colormaps.py
@@ -23,8 +23,11 @@ async def list_colormaps_resource() -> str:
         lines.append(f"- `{cm}` — {colormaps[cm]}")
 
     lines.append("\n## Diverging (for data with a midpoint like anomalies)\n")
-    for cm in ["RdBu", "RdYlGn", "twilight"]:
+    for cm in ["RdBu", "RdYlGn"]:
         lines.append(f"- `{cm}` — {colormaps[cm]}")
+
+    lines.append("\n## Cyclic (for directional or phase data)\n")
+    lines.append(f"- `twilight` — {colormaps['twilight']}")
 
     lines.append("\n## Grayscale\n")
     for cm in ["gray", "binary"]:

--- a/mcp/src/cng_mcp/resources/datasets.py
+++ b/mcp/src/cng_mcp/resources/datasets.py
@@ -1,0 +1,29 @@
+"""Datasets catalog resource."""
+
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+
+
+async def list_datasets_resource(client: SandboxAPIClient) -> str:
+    """Generate a formatted list of available datasets."""
+    datasets = await client.get_datasets()
+    if not datasets:
+        return "No datasets available in workspace."
+
+    lines = ["# Available Datasets\n"]
+    for ds in datasets:
+        ds_id = ds.get("id", "unknown")
+        filename = ds.get("filename", "unknown")
+        ds_type = ds.get("dataset_type", "unknown")
+        is_example = ds.get("is_example", False)
+        metadata = ds.get("metadata", {})
+        bbox = metadata.get("bbox", [])
+        crs = metadata.get("crs", "")
+        example_note = " (example)" if is_example else ""
+        lines.append(f"## {filename}{example_note}\n")
+        lines.append(f"- **ID**: `{ds_id}`")
+        lines.append(f"- **Type**: {ds_type}")
+        lines.append(f"- **CRS**: {crs}")
+        if bbox:
+            lines.append(f"- **Bounds**: {bbox}")
+        lines.append("")
+    return "\n".join(lines)

--- a/mcp/src/cng_mcp/resources/datasets.py
+++ b/mcp/src/cng_mcp/resources/datasets.py
@@ -15,7 +15,9 @@ async def list_datasets_resource(client: SandboxAPIClient) -> str:
         filename = ds.get("filename", "unknown")
         ds_type = ds.get("dataset_type", "unknown")
         is_example = ds.get("is_example", False)
-        metadata = ds.get("metadata", {})
+        metadata = ds.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            metadata = {}
         bbox = metadata.get("bbox", [])
         crs = metadata.get("crs", "")
         example_note = " (example)" if is_example else ""

--- a/mcp/src/cng_mcp/resources/stories.py
+++ b/mcp/src/cng_mcp/resources/stories.py
@@ -1,0 +1,45 @@
+"""Story templates resource."""
+
+
+async def list_story_templates_resource() -> str:
+    """Generate a list of story templates agents can use."""
+    templates = [
+        {
+            "name": "Regional Comparison",
+            "description": "Compare datasets across geographic regions",
+            "structure": [
+                {"title": "Overview", "description": "Show global or continental view"},
+                {"title": "Regional Focus", "description": "Zoom into specific area"},
+                {"title": "Insights", "description": "Summary and takeaways"},
+            ],
+        },
+        {
+            "name": "Time Series Analysis",
+            "description": "Show temporal trends in data",
+            "structure": [
+                {"title": "Baseline", "description": "Initial state"},
+                {"title": "Mid-period", "description": "Transition period"},
+                {"title": "Recent", "description": "Current state"},
+                {"title": "Trends", "description": "Analysis of changes"},
+            ],
+        },
+        {
+            "name": "Data Exploration",
+            "description": "Free-form exploration of a single dataset",
+            "structure": [
+                {"title": "Overview", "description": "Full extent"},
+                {"title": "Detail", "description": "Zoomed perspective"},
+            ],
+        },
+    ]
+
+    lines = ["# Story Templates\n",
+             "Use these templates as starting points for agent-driven story creation.\n"]
+    for template in templates:
+        lines.append(f"## {template['name']}\n")
+        lines.append(f"{template['description']}\n")
+        lines.append("**Structure:**\n")
+        for i, chapter_desc in enumerate(template["structure"], 1):
+            lines.append(f"  {i}. **{chapter_desc['title']}**: {chapter_desc['description']}")
+        lines.append("")
+    return "\n".join(lines)

--- a/mcp/src/cng_mcp/server.py
+++ b/mcp/src/cng_mcp/server.py
@@ -1,28 +1,201 @@
 """MCP Server for CNG Sandbox."""
 
+import argparse
 import asyncio
 import logging
-from mcp.server import Server
+import os
+from typing import Any
 
-logging.basicConfig(level=logging.INFO)
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, Resource, TextContent
+
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+from cng_mcp.tools import (
+    read_datasets_tool,
+    read_story_tool,
+    create_story_tool,
+    update_story_tool,
+    read_connections_tool,
+    validate_layer_config_tool,
+)
+from cng_mcp.resources import (
+    list_datasets_resource,
+    list_story_templates_resource,
+    list_colormaps_resource,
+)
+
 logger = logging.getLogger(__name__)
+
+TOOL_DEFINITIONS = [
+    Tool(
+        name="read_datasets",
+        description="List all datasets in the workspace with metadata (ID, type, bounds, CRS).",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+    ),
+    Tool(
+        name="read_story",
+        description="Get story metadata and chapters by story ID.",
+        inputSchema={
+            "type": "object",
+            "properties": {"story_id": {"type": "string", "description": "Story ID"}},
+            "required": ["story_id"],
+        },
+    ),
+    Tool(
+        name="create_story",
+        description="Create a new story with a title, description, and chapters.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "description": {"type": "string"},
+                "chapters": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": "List of chapter objects with title, text, dataset_id, map_state, layer_config",
+                },
+            },
+            "required": ["title", "description", "chapters"],
+        },
+    ),
+    Tool(
+        name="update_story",
+        description="Update an existing story's title, description, or chapters.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "story_id": {"type": "string"},
+                "updates": {"type": "object", "description": "Fields to update"},
+            },
+            "required": ["story_id", "updates"],
+        },
+    ),
+    Tool(
+        name="read_connections",
+        description="List external tile source connections (COG, PMTiles, XYZ URLs).",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+    ),
+    Tool(
+        name="validate_layer_config",
+        description="Validate a layer configuration (dataset + colormap + rescale range) before creating a chapter.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "dataset_id": {"type": "string"},
+                "colormap": {"type": "string"},
+                "rescale_min": {"type": "number"},
+                "rescale_max": {"type": "number"},
+            },
+            "required": ["dataset_id", "colormap"],
+        },
+    ),
+]
+
+RESOURCE_DEFINITIONS = [
+    Resource(
+        uri="cng://datasets",
+        name="Available Datasets",
+        description="Catalog of all datasets in workspace",
+        mimeType="text/markdown",
+    ),
+    Resource(
+        uri="cng://story-templates",
+        name="Story Templates",
+        description="Pre-built story templates for agent-driven creation",
+        mimeType="text/markdown",
+    ),
+    Resource(
+        uri="cng://colormaps",
+        name="Available Colormaps",
+        description="Valid colormap names for layer configuration",
+        mimeType="text/markdown",
+    ),
+]
 
 
 def create_server(sandbox_api_url: str) -> Server:
     """Create and configure MCP server."""
-    server = Server("cng-sandbox")
+    server: Server = Server("cng-sandbox")
+    client = SandboxAPIClient(api_url=sandbox_api_url)
+
+    @server.list_tools()
+    async def handle_list_tools() -> list[Tool]:
+        return TOOL_DEFINITIONS
+
+    @server.call_tool()
+    async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        if name == "read_datasets":
+            return [await read_datasets_tool(client)]
+        if name == "read_story":
+            return [await read_story_tool(client, story_id=arguments["story_id"])]
+        if name == "create_story":
+            return [await create_story_tool(
+                client,
+                title=arguments["title"],
+                description=arguments["description"],
+                chapters=arguments["chapters"],
+            )]
+        if name == "update_story":
+            return [await update_story_tool(
+                client,
+                story_id=arguments["story_id"],
+                updates=arguments["updates"],
+            )]
+        if name == "read_connections":
+            return [await read_connections_tool(client)]
+        if name == "validate_layer_config":
+            return [await validate_layer_config_tool(
+                client,
+                dataset_id=arguments["dataset_id"],
+                colormap=arguments["colormap"],
+                rescale_min=arguments.get("rescale_min"),
+                rescale_max=arguments.get("rescale_max"),
+            )]
+        raise ValueError(f"Unknown tool: {name}")
+
+    @server.list_resources()
+    async def handle_list_resources() -> list[Resource]:
+        return RESOURCE_DEFINITIONS
+
+    @server.read_resource()
+    async def handle_read_resource(uri: str) -> str:
+        if uri == "cng://datasets":
+            return await list_datasets_resource(client)
+        if uri == "cng://story-templates":
+            return await list_story_templates_resource()
+        if uri == "cng://colormaps":
+            return await list_colormaps_resource()
+        raise ValueError(f"Unknown resource: {uri}")
+
     return server
 
 
 async def main():
-    """Run the MCP server."""
-    import os
-    sandbox_api_url = os.getenv("SANDBOX_API_URL", "http://localhost:8086")
-    server = create_server(sandbox_api_url=sandbox_api_url)
-    logger.info(f"CNG MCP Server starting (API: {sandbox_api_url})")
-    async with server:
-        logger.info("CNG MCP Server running")
-        await asyncio.sleep(float('inf'))
+    """Run the MCP server via stdio."""
+    parser = argparse.ArgumentParser(description="CNG MCP Server")
+    parser.add_argument(
+        "--api-url",
+        default=os.getenv("SANDBOX_API_URL", "http://localhost:8086"),
+        help="Sandbox API URL (default: http://localhost:8086)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    server = create_server(sandbox_api_url=args.api_url)
+    logger.info(f"CNG MCP Server starting (API: {args.api_url})")
+
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
 
 
 def main_cli():

--- a/mcp/src/cng_mcp/server.py
+++ b/mcp/src/cng_mcp/server.py
@@ -1,0 +1,34 @@
+"""MCP Server for CNG Sandbox."""
+
+import asyncio
+import logging
+from mcp.server import Server
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def create_server(sandbox_api_url: str) -> Server:
+    """Create and configure MCP server."""
+    server = Server("cng-sandbox")
+    return server
+
+
+async def main():
+    """Run the MCP server."""
+    import os
+    sandbox_api_url = os.getenv("SANDBOX_API_URL", "http://localhost:8086")
+    server = create_server(sandbox_api_url=sandbox_api_url)
+    logger.info(f"CNG MCP Server starting (API: {sandbox_api_url})")
+    async with server:
+        logger.info("CNG MCP Server running")
+        await asyncio.sleep(float('inf'))
+
+
+def main_cli():
+    """Synchronous entry point for CLI script."""
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    main_cli()

--- a/mcp/src/cng_mcp/tools/__init__.py
+++ b/mcp/src/cng_mcp/tools/__init__.py
@@ -1,0 +1,13 @@
+"""MCP Tools for CNG Sandbox."""
+
+from .datasets import read_datasets_tool
+from .stories import read_story_tool, create_story_tool, update_story_tool
+from .connections import read_connections_tool
+
+__all__ = [
+    "read_datasets_tool",
+    "read_story_tool",
+    "create_story_tool",
+    "update_story_tool",
+    "read_connections_tool",
+]

--- a/mcp/src/cng_mcp/tools/__init__.py
+++ b/mcp/src/cng_mcp/tools/__init__.py
@@ -3,6 +3,7 @@
 from .datasets import read_datasets_tool
 from .stories import read_story_tool, create_story_tool, update_story_tool
 from .connections import read_connections_tool
+from .validation import validate_layer_config_tool
 
 __all__ = [
     "read_datasets_tool",
@@ -10,4 +11,5 @@ __all__ = [
     "create_story_tool",
     "update_story_tool",
     "read_connections_tool",
+    "validate_layer_config_tool",
 ]

--- a/mcp/src/cng_mcp/tools/connections.py
+++ b/mcp/src/cng_mcp/tools/connections.py
@@ -1,0 +1,31 @@
+"""Tools for external connections (tile sources)."""
+
+from mcp.types import TextContent
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+
+
+async def read_connections_tool(client: SandboxAPIClient) -> TextContent:
+    """List all external tile source connections."""
+    connections = await client.get_connections()
+    if not connections:
+        return TextContent(type="text", text="No external connections configured.")
+
+    lines = ["# External Tile Sources\n"]
+    for conn in connections:
+        conn_id = conn.get("id", "")
+        name = conn.get("name", "")
+        url = conn.get("url", "")
+        conn_type = conn.get("connection_type", "")
+        is_cat = conn.get("is_categorical", False)
+
+        lines.append(f"## {name}")
+        lines.append(f"- **ID**: {conn_id}")
+        lines.append(f"- **Type**: {conn_type}")
+        lines.append(f"- **URL**: {url}")
+        if is_cat:
+            categories = conn.get("categories", []) or []
+            lines.append(f"- **Categorical**: Yes ({len(categories)} categories)")
+        else:
+            lines.append(f"- **Categorical**: No")
+        lines.append("")
+    return TextContent(type="text", text="\n".join(lines))

--- a/mcp/src/cng_mcp/tools/datasets.py
+++ b/mcp/src/cng_mcp/tools/datasets.py
@@ -1,0 +1,30 @@
+"""Tools for dataset operations."""
+
+from mcp.types import TextContent
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+
+
+async def read_datasets_tool(client: SandboxAPIClient) -> TextContent:
+    """List all datasets in workspace."""
+    datasets = await client.get_datasets()
+    if not datasets:
+        return TextContent(type="text", text="No datasets found in workspace.")
+
+    lines = ["# Datasets in Workspace\n"]
+    for ds in datasets:
+        ds_id = ds.get("id", "")
+        filename = ds.get("filename", "")
+        ds_type = ds.get("dataset_type", "")
+        is_example = ds.get("is_example", False)
+        metadata = ds.get("metadata", {})
+        bbox = metadata.get("bbox", [])
+
+        example_badge = " [EXAMPLE]" if is_example else ""
+        lines.append(f"## {filename}{example_badge}")
+        lines.append(f"- **ID**: {ds_id}")
+        lines.append(f"- **Type**: {ds_type}")
+        if bbox and len(bbox) == 4:
+            lines.append(f"- **Bounds**: W={bbox[0]}, S={bbox[1]}, E={bbox[2]}, N={bbox[3]}")
+        lines.append("")
+
+    return TextContent(type="text", text="\n".join(lines))

--- a/mcp/src/cng_mcp/tools/stories.py
+++ b/mcp/src/cng_mcp/tools/stories.py
@@ -9,7 +9,7 @@ async def read_story_tool(client: SandboxAPIClient, story_id: str) -> TextConten
     """Get a story by ID."""
     story = await client.get_story(story_id)
     lines = [f"# {story.get('title', 'Untitled Story')}\n",
-             f"**Description**: {story.get('description', 'No description')}\n"]
+             f"**Description**: {story.get('description') or 'No description'}\n"]
 
     chapters = story.get("chapters", [])
     if chapters:

--- a/mcp/src/cng_mcp/tools/stories.py
+++ b/mcp/src/cng_mcp/tools/stories.py
@@ -1,0 +1,62 @@
+"""Tools for story operations."""
+
+from typing import Any
+from mcp.types import TextContent
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+
+
+async def read_story_tool(client: SandboxAPIClient, story_id: str) -> TextContent:
+    """Get a story by ID."""
+    story = await client.get_story(story_id)
+    lines = [f"# {story.get('title', 'Untitled Story')}\n",
+             f"**Description**: {story.get('description', 'No description')}\n"]
+
+    chapters = story.get("chapters", [])
+    if chapters:
+        lines.append("## Chapters\n")
+        for i, ch in enumerate(chapters, 1):
+            lines.append(f"### {i}. {ch.get('title', 'Untitled Chapter')}")
+            lines.append(f"- **Dataset**: {ch.get('dataset_id', 'unknown')}")
+            lines.append(f"- **Text**: {ch.get('text', '')}\n")
+    return TextContent(type="text", text="\n".join(lines))
+
+
+async def create_story_tool(
+    client: SandboxAPIClient,
+    title: str,
+    description: str,
+    chapters: list[dict[str, Any]],
+) -> TextContent:
+    """Create a new story."""
+    if not title:
+        return TextContent(type="text", text="Error: title is required")
+
+    story = await client.create_story(title=title, description=description, chapters=chapters)
+    story_id = story.get("id", "unknown")
+    lines = [
+        f"# Story Created Successfully\n",
+        f"**Story ID**: `{story_id}`",
+        f"**Title**: {title}",
+        f"**Description**: {description}",
+        f"**Chapters**: {len(chapters)}",
+        f"\nShare with others using story ID: `{story_id}`",
+    ]
+    return TextContent(type="text", text="\n".join(lines))
+
+
+async def update_story_tool(
+    client: SandboxAPIClient,
+    story_id: str,
+    updates: dict[str, Any],
+) -> TextContent:
+    """Update an existing story."""
+    if not story_id:
+        return TextContent(type="text", text="Error: story_id is required")
+
+    await client.update_story(story_id=story_id, updates=updates)
+    lines = [
+        f"# Story Updated\n",
+        f"**Story ID**: `{story_id}`",
+        f"**Updated Fields**: {', '.join(updates.keys())}",
+    ]
+    return TextContent(type="text", text="\n".join(lines))

--- a/mcp/src/cng_mcp/tools/validation.py
+++ b/mcp/src/cng_mcp/tools/validation.py
@@ -1,0 +1,47 @@
+"""Tools for layer and configuration validation."""
+
+from typing import Optional
+from mcp.types import TextContent
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+
+
+async def validate_layer_config_tool(
+    client: SandboxAPIClient,
+    dataset_id: str,
+    colormap: str,
+    rescale_min: Optional[float] = None,
+    rescale_max: Optional[float] = None,
+) -> TextContent:
+    """Validate a layer configuration before creating a chapter."""
+    if not dataset_id:
+        return TextContent(type="text", text="Error: dataset_id is required")
+    if not colormap:
+        return TextContent(type="text", text="Error: colormap is required")
+
+    result = await client.validate_layer_config(
+        dataset_id=dataset_id,
+        colormap=colormap,
+        rescale_min=rescale_min,
+        rescale_max=rescale_max,
+    )
+
+    valid = result.get("valid", False)
+    error = result.get("error", "")
+
+    if valid:
+        lines = [
+            "# Layer Configuration Valid\n",
+            f"Dataset: `{dataset_id}`",
+            f"Colormap: `{colormap}`",
+        ]
+        if rescale_min is not None:
+            lines.append(f"Rescale: [{rescale_min}, {rescale_max}]")
+    else:
+        lines = [
+            "# Layer Configuration Invalid\n",
+            f"Dataset: `{dataset_id}`",
+            f"Colormap: `{colormap}`",
+        ]
+        if error:
+            lines.append(f"\n**Error**: {error}")
+    return TextContent(type="text", text="\n".join(lines))

--- a/mcp/src/cng_mcp/tools/validation.py
+++ b/mcp/src/cng_mcp/tools/validation.py
@@ -34,8 +34,10 @@ async def validate_layer_config_tool(
             f"Dataset: `{dataset_id}`",
             f"Colormap: `{colormap}`",
         ]
-        if rescale_min is not None:
-            lines.append(f"Rescale: [{rescale_min}, {rescale_max}]")
+        if rescale_min is not None or rescale_max is not None:
+            lo = rescale_min if rescale_min is not None else "—"
+            hi = rescale_max if rescale_max is not None else "—"
+            lines.append(f"Rescale: [{lo}, {hi}]")
     else:
         lines = [
             "# Layer Configuration Invalid\n",

--- a/mcp/tests/__init__.py
+++ b/mcp/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for CNG MCP Server."""

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -1,0 +1,63 @@
+"""Pytest fixtures for MCP server tests."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+
+@pytest.fixture
+def sandbox_api_url() -> str:
+    return "http://localhost:8086"
+
+
+@pytest.fixture
+def mock_http_client():
+    return AsyncMock()
+
+
+@pytest.fixture
+def sample_dataset():
+    return {
+        "id": "dataset_abc123",
+        "filename": "elevation.tif",
+        "created_at": "2025-01-01T00:00:00Z",
+        "dataset_type": "raster",
+        "metadata": {
+            "bbox": [-180, -90, 180, 90],
+            "crs": "EPSG:4326",
+            "bands": 1,
+        },
+        "tile_url": "/raster/tileset/dataset_abc123/tiles/{z}/{x}/{y}.png",
+        "is_example": False,
+    }
+
+
+@pytest.fixture
+def sample_story():
+    return {
+        "id": "story_xyz789",
+        "title": "Global Elevation Analysis",
+        "description": "An exploration of terrain worldwide",
+        "chapters": [
+            {
+                "id": "ch_001",
+                "title": "Overview",
+                "text": "Starting with global coverage...",
+                "dataset_id": "dataset_abc123",
+                "map_state": {"center": [0, 0], "zoom": 2},
+            }
+        ],
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:00:00Z",
+    }
+
+
+@pytest.fixture
+def sample_connection():
+    return {
+        "id": "conn_def456",
+        "name": "GEBCO Bathymetry",
+        "url": "https://example.com/gebco/{z}/{x}/{y}.tif",
+        "connection_type": "cog",
+        "is_categorical": False,
+        "categories": None,
+    }

--- a/mcp/tests/test_client_sandbox_api.py
+++ b/mcp/tests/test_client_sandbox_api.py
@@ -1,0 +1,69 @@
+"""Tests for sandbox API client."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+
+
+def _make_response(json_data):
+    response = MagicMock()
+    response.json = MagicMock(return_value=json_data)
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@pytest.mark.asyncio
+async def test_get_datasets_returns_list(sandbox_api_url, mock_http_client):
+    mock_http_client.get = AsyncMock(return_value=_make_response({
+        "datasets": [{"id": "ds_1", "filename": "data.tif", "dataset_type": "raster", "is_example": False}]
+    }))
+    client = SandboxAPIClient(api_url=sandbox_api_url, http_client=mock_http_client)
+    datasets = await client.get_datasets()
+    assert len(datasets) == 1
+    assert datasets[0]["id"] == "ds_1"
+    mock_http_client.get.assert_called_once_with("http://localhost:8086/api/datasets")
+
+
+@pytest.mark.asyncio
+async def test_get_story_by_id(sandbox_api_url, mock_http_client, sample_story):
+    mock_http_client.get = AsyncMock(return_value=_make_response(sample_story))
+    client = SandboxAPIClient(api_url=sandbox_api_url, http_client=mock_http_client)
+    story = await client.get_story(story_id="story_xyz789")
+    assert story["id"] == "story_xyz789"
+    mock_http_client.get.assert_called_once_with("http://localhost:8086/api/stories/story_xyz789")
+
+
+@pytest.mark.asyncio
+async def test_create_story(sandbox_api_url, mock_http_client):
+    mock_http_client.post = AsyncMock(return_value=_make_response({"id": "story_new", "title": "New"}))
+    client = SandboxAPIClient(api_url=sandbox_api_url, http_client=mock_http_client)
+    created = await client.create_story(title="New", description="Test", chapters=[])
+    assert created["id"] == "story_new"
+    mock_http_client.post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_story(sandbox_api_url, mock_http_client):
+    mock_http_client.patch = AsyncMock(return_value=_make_response({"id": "s1", "title": "Updated"}))
+    client = SandboxAPIClient(api_url=sandbox_api_url, http_client=mock_http_client)
+    updated = await client.update_story(story_id="s1", updates={"title": "Updated"})
+    assert updated["title"] == "Updated"
+
+
+@pytest.mark.asyncio
+async def test_get_connections(sandbox_api_url, mock_http_client):
+    mock_http_client.get = AsyncMock(return_value=_make_response({
+        "connections": [{"id": "conn_1", "name": "Test", "url": "https://ex.com/{z}/{x}/{y}.tif", "connection_type": "cog"}]
+    }))
+    client = SandboxAPIClient(api_url=sandbox_api_url, http_client=mock_http_client)
+    connections = await client.get_connections()
+    assert len(connections) == 1
+    assert connections[0]["id"] == "conn_1"
+
+
+@pytest.mark.asyncio
+async def test_validate_layer_config(sandbox_api_url, mock_http_client):
+    mock_http_client.post = AsyncMock(return_value=_make_response({"valid": True}))
+    client = SandboxAPIClient(api_url=sandbox_api_url, http_client=mock_http_client)
+    result = await client.validate_layer_config(dataset_id="ds_1", colormap="viridis", rescale_min=0, rescale_max=100)
+    assert result["valid"] is True

--- a/mcp/tests/test_e2e.py
+++ b/mcp/tests/test_e2e.py
@@ -1,0 +1,55 @@
+"""End-to-end tests for MCP server workflows."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from mcp.types import TextContent
+
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+from cng_mcp.tools.datasets import read_datasets_tool
+from cng_mcp.tools.stories import create_story_tool
+from cng_mcp.tools.validation import validate_layer_config_tool
+
+
+def _make_response(json_data):
+    response = MagicMock()
+    response.json = MagicMock(return_value=json_data)
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@pytest.mark.asyncio
+async def test_e2e_agent_discover_datasets(mock_http_client, sample_dataset):
+    """E2E: Agent discovers available datasets."""
+    mock_http_client.get = AsyncMock(return_value=_make_response({"datasets": [sample_dataset]}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    result = await read_datasets_tool(client)
+    assert isinstance(result, TextContent)
+    assert "elevation.tif" in result.text
+
+
+@pytest.mark.asyncio
+async def test_e2e_agent_validates_then_creates_story(mock_http_client):
+    """E2E: Agent validates layer config before creating a story."""
+    mock_http_client.post = AsyncMock(return_value=_make_response({"valid": True}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+
+    validation = await validate_layer_config_tool(
+        client, dataset_id="ds_1", colormap="viridis", rescale_min=0, rescale_max=100
+    )
+    assert "Valid" in validation.text
+
+    mock_http_client.post = AsyncMock(return_value=_make_response({"id": "story_agent_001"}))
+    chapters = [{
+        "title": "Overview",
+        "text": "Global view of elevation data",
+        "dataset_id": "ds_1",
+        "map_state": {"center": [0, 0], "zoom": 2},
+        "layer_config": {"colormap": "viridis", "rescale_min": 0, "rescale_max": 100},
+    }]
+    result = await create_story_tool(
+        client,
+        title="Agent-Created Story",
+        description="Automatically created by an agent",
+        chapters=chapters,
+    )
+    assert "story_agent_001" in result.text

--- a/mcp/tests/test_resources_colormaps.py
+++ b/mcp/tests/test_resources_colormaps.py
@@ -1,0 +1,13 @@
+"""Tests for colormaps resource."""
+
+import pytest
+from cng_mcp.resources.colormaps import list_colormaps_resource
+
+
+@pytest.mark.asyncio
+async def test_list_colormaps():
+    content = await list_colormaps_resource()
+    assert "Available Colormaps" in content
+    assert "viridis" in content
+    assert "Sequential" in content
+    assert "Diverging" in content

--- a/mcp/tests/test_resources_datasets.py
+++ b/mcp/tests/test_resources_datasets.py
@@ -1,0 +1,31 @@
+"""Tests for datasets resource."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from cng_mcp.resources.datasets import list_datasets_resource
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+
+
+def _make_response(json_data):
+    response = MagicMock()
+    response.json = MagicMock(return_value=json_data)
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_resource_empty(mock_http_client):
+    mock_http_client.get = AsyncMock(return_value=_make_response({"datasets": []}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    content = await list_datasets_resource(client)
+    assert "No datasets available" in content
+
+
+@pytest.mark.asyncio
+async def test_list_datasets_resource_with_data(mock_http_client, sample_dataset):
+    mock_http_client.get = AsyncMock(return_value=_make_response({"datasets": [sample_dataset]}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    content = await list_datasets_resource(client)
+    assert "Available Datasets" in content
+    assert "elevation.tif" in content
+    assert "EPSG:4326" in content

--- a/mcp/tests/test_resources_stories.py
+++ b/mcp/tests/test_resources_stories.py
@@ -1,0 +1,13 @@
+"""Tests for story templates resource."""
+
+import pytest
+from cng_mcp.resources.stories import list_story_templates_resource
+
+
+@pytest.mark.asyncio
+async def test_list_story_templates():
+    content = await list_story_templates_resource()
+    assert "Story Templates" in content
+    assert "Regional Comparison" in content
+    assert "Time Series Analysis" in content
+    assert "Data Exploration" in content

--- a/mcp/tests/test_server_integration.py
+++ b/mcp/tests/test_server_integration.py
@@ -1,0 +1,19 @@
+"""Integration tests for MCP server."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_server_creation(sandbox_api_url):
+    from cng_mcp.server import create_server
+    server = create_server(sandbox_api_url=sandbox_api_url)
+    assert server is not None
+    assert server.name == "cng-sandbox"
+
+
+@pytest.mark.asyncio
+async def test_server_lists_tools(sandbox_api_url):
+    """Verify server has registered request handlers."""
+    from cng_mcp.server import create_server
+    server = create_server(sandbox_api_url=sandbox_api_url)
+    assert len(server.request_handlers) > 0

--- a/mcp/tests/test_tools_connections.py
+++ b/mcp/tests/test_tools_connections.py
@@ -1,0 +1,32 @@
+"""Tests for connection tools."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from mcp.types import TextContent
+from cng_mcp.tools.connections import read_connections_tool
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+
+
+def _make_response(json_data):
+    response = MagicMock()
+    response.json = MagicMock(return_value=json_data)
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@pytest.mark.asyncio
+async def test_read_connections_tool(mock_http_client, sample_connection):
+    mock_http_client.get = AsyncMock(return_value=_make_response({"connections": [sample_connection]}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    result = await read_connections_tool(client)
+    assert isinstance(result, TextContent)
+    assert "GEBCO Bathymetry" in result.text
+    assert "cog" in result.text
+
+
+@pytest.mark.asyncio
+async def test_read_connections_tool_empty(mock_http_client):
+    mock_http_client.get = AsyncMock(return_value=_make_response({"connections": []}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    result = await read_connections_tool(client)
+    assert "No external connections" in result.text

--- a/mcp/tests/test_tools_datasets.py
+++ b/mcp/tests/test_tools_datasets.py
@@ -1,0 +1,32 @@
+"""Tests for dataset tools."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from mcp.types import TextContent
+from cng_mcp.tools.datasets import read_datasets_tool
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+
+
+def _make_response(json_data):
+    response = MagicMock()
+    response.json = MagicMock(return_value=json_data)
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@pytest.mark.asyncio
+async def test_read_datasets_tool_empty(mock_http_client):
+    mock_http_client.get = AsyncMock(return_value=_make_response({"datasets": []}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    result = await read_datasets_tool(client)
+    assert isinstance(result, TextContent)
+    assert "No datasets" in result.text
+
+
+@pytest.mark.asyncio
+async def test_read_datasets_tool_with_data(mock_http_client, sample_dataset):
+    mock_http_client.get = AsyncMock(return_value=_make_response({"datasets": [sample_dataset]}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    result = await read_datasets_tool(client)
+    assert "elevation.tif" in result.text
+    assert "dataset_abc123" in result.text

--- a/mcp/tests/test_tools_stories.py
+++ b/mcp/tests/test_tools_stories.py
@@ -1,0 +1,42 @@
+"""Tests for story tools."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from mcp.types import TextContent
+from cng_mcp.tools.stories import read_story_tool, create_story_tool, update_story_tool
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+
+
+def _make_response(json_data):
+    response = MagicMock()
+    response.json = MagicMock(return_value=json_data)
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@pytest.mark.asyncio
+async def test_read_story_tool(mock_http_client, sample_story):
+    mock_http_client.get = AsyncMock(return_value=_make_response(sample_story))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    result = await read_story_tool(client, story_id="story_xyz789")
+    assert isinstance(result, TextContent)
+    assert "Global Elevation Analysis" in result.text
+    assert "Overview" in result.text
+
+
+@pytest.mark.asyncio
+async def test_create_story_tool(mock_http_client):
+    mock_http_client.post = AsyncMock(return_value=_make_response({"id": "story_new_123"}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    result = await create_story_tool(client, title="Test Story", description="A test", chapters=[])
+    assert isinstance(result, TextContent)
+    assert "story_new_123" in result.text
+
+
+@pytest.mark.asyncio
+async def test_update_story_tool(mock_http_client):
+    mock_http_client.patch = AsyncMock(return_value=_make_response({"id": "s1", "title": "Updated"}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    result = await update_story_tool(client, story_id="s1", updates={"title": "Updated"})
+    assert isinstance(result, TextContent)
+    assert "s1" in result.text

--- a/mcp/tests/test_tools_validation.py
+++ b/mcp/tests/test_tools_validation.py
@@ -1,0 +1,47 @@
+"""Tests for validation tools."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from mcp.types import TextContent
+from cng_mcp.tools.validation import validate_layer_config_tool
+from cng_mcp.client.sandbox_api import SandboxAPIClient
+
+
+def _make_response(json_data):
+    response = MagicMock()
+    response.json = MagicMock(return_value=json_data)
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@pytest.mark.asyncio
+async def test_validate_layer_config_valid(mock_http_client):
+    mock_http_client.post = AsyncMock(return_value=_make_response({"valid": True}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    result = await validate_layer_config_tool(client, dataset_id="ds_1", colormap="viridis")
+    assert isinstance(result, TextContent)
+    assert "Valid" in result.text
+
+
+@pytest.mark.asyncio
+async def test_validate_layer_config_invalid(mock_http_client):
+    mock_http_client.post = AsyncMock(return_value=_make_response({
+        "valid": False,
+        "error": "Unknown colormap: 'invalid_map'"
+    }))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    result = await validate_layer_config_tool(client, dataset_id="ds_1", colormap="invalid_map")
+    assert isinstance(result, TextContent)
+    assert "Invalid" in result.text
+    assert "Unknown colormap" in result.text
+
+
+@pytest.mark.asyncio
+async def test_validate_layer_config_with_rescale(mock_http_client):
+    mock_http_client.post = AsyncMock(return_value=_make_response({"valid": True}))
+    client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
+    result = await validate_layer_config_tool(
+        client, dataset_id="ds_1", colormap="viridis", rescale_min=0, rescale_max=100
+    )
+    assert "Rescale" in result.text
+    assert "0" in result.text and "100" in result.text


### PR DESCRIPTION
## Summary

Implements the [MCP server for CNG Sandbox](https://github.com/aboydnw/cng-sandbox/issues/221) as a separate Python package at `mcp/`. Exposes sandbox capabilities (datasets, stories, connections, validation) as composable tools for agents.

## Scope

**Tools (6):**
- `read_datasets`, `read_story`, `create_story`, `update_story`, `read_connections`, `validate_layer_config`

**Resources (3):**
- `cng://datasets` (live API), `cng://story-templates` (static), `cng://colormaps` (static)

## Design Decisions

From issue #221 open questions:
1. **Story control** → Hybrid. Full control exposed on `create_story`; agents free to use template patterns.
2. **Colormap precision** → Name-only in v1. Metadata can be exposed later without breaking API.
3. **Validation** → Deferred to ingestion API. MCP only checks presence of required fields.

## Implementation

- Separate `mcp/` Python package with `uv`-managed dependencies
- Async throughout (`httpx`, `mcp` SDK, `pytest-asyncio`)
- 24 tests, all passing (unit + integration + E2E)
- CI workflow: matrix Python 3.11/3.12, path-filtered to `mcp/**`
- CLI entry point: `cng-mcp --api-url <url>`

## Open Dependency

`POST /api/validate-layer-config` endpoint does not exist on the ingestion API yet. `validate_layer_config` tool will fail at runtime until the endpoint is added in a paired ingestion PR. Non-blocking — the other 5 tools work independently.

## Test plan

- [ ] CI passes (test-mcp.yml)
- [ ] `cd mcp && uv run pytest tests/ -v` → 24 passing locally
- [ ] `cng-mcp --help` prints usage
- [ ] Register in Claude Desktop config, verify all 6 tools + 3 resources discovered
- [ ] Call each tool against a running sandbox stack (will fail for `validate_layer_config` until API endpoint exists)

Closes #221.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CNG MCP Server with a CLI (cng-mcp) enabling agents to discover datasets, list story templates, create/update stories, validate layer configs, and view external connections and colormaps.

* **Documentation**
  * Added README, architecture, contributing, and usage docs with examples, resources, and troubleshooting.

* **Tests**
  * Added comprehensive async test suite and a CI workflow to run tests on Python 3.11/3.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->