### PR TITLE
feat(frontend): render remote GeoParquet via DuckDB WASM (Ticket A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,7 @@ cd frontend && npx vitest run
 - **COG tiler proxy preserves `/cog` prefix**: Unlike `/raster` and `/vector` (which strip their prefix before forwarding), the `/cog` proxy passes the path through unchanged because titiler's COG routes are already mounted under `/cog/`.
 - **Vendored maptool utilities**: `src/lib/maptool/` contains `createCOGLayer`, `createPMTilesProtocol`, `useColorScale`, `MapLegend`, and `listColormaps` — vendored from `@maptool/core` so the sandbox has no external dependency on the library.
 - **Categorical rasters use a JSON colormap, not `colormap_name`**: When a dataset has `isCategorical: true`, tile URLs are built with `colormap=<encoded-JSON>` (a `{value: [r,g,b]}` map) and `resampling=nearest` instead of the usual `colormap_name=` parameter. Mixing them will produce incorrect or broken tiles.
+- **GeoParquet connections render client-side via DuckDB-WASM**: Remote GeoParquet connections (`connection_type: "geoparquet"`) are not tiled. The frontend hook `useGeoParquetRender` (`src/hooks/useGeoParquetRender.ts`) loads the file into DuckDB-WASM, returns an Arrow `Table`, and `useLayerBuilder` renders it via deck.gl. A 500k feature cap protects the browser from oversized files.
 
 ## Ingestion Service
 
@@ -242,7 +243,7 @@ cd ingestion && uv run pytest -v
 
 **Connections (external tile sources):**
 - `GET /api/connections` — List connections in the workspace
-- `POST /api/connections` — Register an external tile source (XYZ raster/vector, COG, PMTiles); COG connections automatically run categorical detection and persist `is_categorical` + `categories` on the connection row
+- `POST /api/connections` — Register an external tile source (XYZ raster/vector, COG, PMTiles, GeoParquet); COG connections automatically run categorical detection and persist `is_categorical` + `categories` on the connection row. GeoParquet connections are rendered client-side via DuckDB-WASM (no tiler involved).
 - `GET /api/connections/{id}` — Get a connection by ID
 - `PATCH /api/connections/{id}/categories` — Update category labels for a categorical COG connection; body is a list of `{"value": int, "label": str}` objects; returns 400 if connection is not categorical or a value doesn't exist
 - `DELETE /api/connections/{id}` — Delete a connection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,7 @@ cd ingestion && uv run pytest -v
 
 **Connections (external tile sources):**
 - `GET /api/connections` — List connections in the workspace
-- `POST /api/connections` — Register an external tile source (XYZ raster/vector, COG, PMTiles, GeoParquet); COG connections automatically run categorical detection and persist `is_categorical` + `categories` on the connection row. GeoParquet connections are rendered client-side via DuckDB-WASM (no tiler involved).
+- `POST /api/connections` — Register an external data source (XYZ raster/vector, COG, PMTiles, GeoParquet); COG connections automatically run categorical detection and persist `is_categorical` + `categories` on the connection row. GeoParquet connections are rendered client-side via DuckDB-WASM (no tiler involved).
 - `GET /api/connections/{id}` — Get a connection by ID
 - `PATCH /api/connections/{id}/categories` — Update category labels for a categorical COG connection; body is a list of `{"value": int, "label": str}` objects; returns 400 if connection is not categorical or a value doesn't exist
 - `DELETE /api/connections/{id}` — Delete a connection

--- a/frontend/src/components/ConnectionInfoCard.tsx
+++ b/frontend/src/components/ConnectionInfoCard.tsx
@@ -13,6 +13,7 @@ const TYPE_LABELS: Record<string, string> = {
   pmtiles: "PMTiles",
   xyz_raster: "XYZ Raster Tiles",
   xyz_vector: "XYZ Vector Tiles",
+  geoparquet: "Remote GeoParquet",
 };
 
 const TYPE_SHORT: Record<string, string> = {
@@ -20,6 +21,7 @@ const TYPE_SHORT: Record<string, string> = {
   pmtiles: "PMTiles",
   xyz_raster: "XYZ raster",
   xyz_vector: "XYZ vector",
+  geoparquet: "GeoParquet",
 };
 
 interface ConnectionInfoCardProps {

--- a/frontend/src/components/ConnectionModal.tsx
+++ b/frontend/src/components/ConnectionModal.tsx
@@ -20,6 +20,7 @@ const TYPE_LABELS: Record<ConnectionType, string> = {
   pmtiles: "PMTiles",
   xyz_raster: "XYZ Raster Tiles",
   xyz_vector: "XYZ Vector Tiles",
+  geoparquet: "Remote GeoParquet",
 };
 
 const ALL_TYPES: ConnectionType[] = [

--- a/frontend/src/components/InlineConnectionForm.tsx
+++ b/frontend/src/components/InlineConnectionForm.tsx
@@ -17,6 +17,7 @@ const TYPE_LABELS: Record<ConnectionType, string> = {
   pmtiles: "PMTiles",
   xyz_raster: "XYZ Raster Tiles",
   xyz_vector: "XYZ Vector Tiles",
+  geoparquet: "Remote GeoParquet",
 };
 
 const ALL_TYPES: ConnectionType[] = [

--- a/frontend/src/components/RemoteConnectFlow.tsx
+++ b/frontend/src/components/RemoteConnectFlow.tsx
@@ -16,6 +16,8 @@ import { useDuckDB } from "../hooks/useDuckDB";
 import { useGeoParquetQuery } from "../hooks/useGeoParquetQuery";
 import { workspaceFetch } from "../lib/api";
 
+const CLIENT_FEATURE_CAP = 500_000;
+
 interface RemoteConnectFlowProps {
   onDatasetReady: (datasetId: string) => void;
 }
@@ -38,6 +40,7 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
   } = useGeoParquetValidation(conn, previewUrl);
 
   const { result: queryResult } = useGeoParquetQuery(conn, previewUrl);
+  const tooLarge = queryResult.totalCount > CLIENT_FEATURE_CAP;
 
   useEffect(() => {
     if (state.phase === "idle" && state.datasetId) {
@@ -86,7 +89,7 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
   );
 
   const handleConfirmConnection = useCallback(async () => {
-    if (!valid || !previewUrl) return;
+    if (!valid || !previewUrl || tooLarge) return;
 
     setShowPreview(false);
     setConnectionError(null);
@@ -119,7 +122,7 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
       // Re-open preview modal to show error to user
       setShowPreview(true);
     }
-  }, [valid, previewUrl, onDatasetReady]);
+  }, [valid, previewUrl, tooLarge, onDatasetReady]);
 
   if (state.phase === "discovering") {
     return (
@@ -246,8 +249,14 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
         open={showPreview}
         filename={previewUrl.split("/").pop() || "data.parquet"}
         validating={validating}
-        valid={valid}
-        error={error || connectionError}
+        valid={valid && !tooLarge}
+        error={
+          error ||
+          connectionError ||
+          (tooLarge
+            ? `This file has ${queryResult.totalCount.toLocaleString()} features, which exceeds the current in-browser limit of ${CLIENT_FEATURE_CAP.toLocaleString()}. Server-side rendering is coming soon.`
+            : null)
+        }
         geometryInfo={geometryInfo}
         schema={queryResult.columnStats}
         samples={queryResult.table}

--- a/frontend/src/components/details/__tests__/stepContent.test.ts
+++ b/frontend/src/components/details/__tests__/stepContent.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { getStepContent, getStepCount, getPipelineType } from "../stepContent";
-import type { Dataset } from "../../../types";
+import { getConnectionStepContent } from "../connectionStepContent";
+import type { Dataset, Connection } from "../../../types";
 
 const rasterDataset: Partial<Dataset> = {
   id: "abc123",
@@ -165,5 +166,35 @@ describe("getStepContent", () => {
     expect(content.subtitle).toBe("cloud hosted");
     expect(content.title).toContain("cloud");
     expect(content.title).not.toContain("PostGIS");
+  });
+});
+
+const geoparquetConnection: Connection = {
+  id: "c5",
+  name: "Parcels",
+  url: "https://example.com/parcels.parquet",
+  connection_type: "geoparquet",
+  bounds: null,
+  min_zoom: null,
+  max_zoom: null,
+  tile_type: null,
+  band_count: null,
+  rescale: null,
+  workspace_id: null,
+  is_categorical: false,
+  categories: null,
+  created_at: "2026-04-15T00:00:00Z",
+};
+
+describe("getConnectionStepContent (geoparquet)", () => {
+  it("returns DuckDB-based source step for geoparquet connections", () => {
+    const step = getConnectionStepContent(geoparquetConnection, 1);
+    expect(step.title.toLowerCase()).toContain("duckdb");
+    expect(step.tools.some((t) => /duckdb/i.test(t.name))).toBe(true);
+  });
+
+  it("returns deck.gl GeoJson display step for geoparquet", () => {
+    const step = getConnectionStepContent(geoparquetConnection, 2);
+    expect(step.tools.some((t) => /deck\.gl/i.test(t.name))).toBe(true);
   });
 });

--- a/frontend/src/components/details/connectionStepContent.ts
+++ b/frontend/src/components/details/connectionStepContent.ts
@@ -279,7 +279,11 @@ function getDisplayStep(connection: Connection): StepContent {
   if (type === "geoparquet") {
     const metadata: MetadataTileData[] = [
       { label: "Renderer", value: "WebGL (deck.gl GeoJsonLayer)" },
-      { label: "Basemap", value: "Carto Positron", subValue: "OpenStreetMap data" },
+      {
+        label: "Basemap",
+        value: "Carto Positron",
+        subValue: "OpenStreetMap data",
+      },
     ];
 
     const tools: ToolCardData[] = [

--- a/frontend/src/components/details/connectionStepContent.ts
+++ b/frontend/src/components/details/connectionStepContent.ts
@@ -145,6 +145,51 @@ function getSourceStep(connection: Connection): StepContent {
     };
   }
 
+  if (type === "geoparquet") {
+    const metadata: MetadataTileData[] = [
+      { label: "Format", value: "GeoParquet" },
+      { label: "Source URL", value: connection.url, colSpan: 2 },
+      ...(connection.bounds
+        ? [
+            {
+              label: "Bounding Box",
+              value: formatBounds(connection.bounds),
+              colSpan: 2 as const,
+            },
+          ]
+        : []),
+    ];
+
+    const tools: ToolCardData[] = [
+      {
+        name: "DuckDB WASM",
+        url: "https://duckdb.org/docs/api/wasm/overview",
+        description:
+          "An in-browser analytical database that can query remote Parquet files directly over HTTP using range requests, returning results as Arrow record batches.",
+      },
+      {
+        name: "Apache Arrow",
+        url: "https://arrow.apache.org/",
+        description:
+          "A columnar memory format used to transfer query results from DuckDB WASM to the rendering layer with zero serialization overhead.",
+      },
+    ];
+
+    return {
+      label: "Source",
+      subtitle: "remote file",
+      badge: "Step 1 of 2",
+      title: "Fetch via DuckDB WASM",
+      explanation: [
+        "This connection points to a <strong>GeoParquet</strong> file hosted remotely. GeoParquet is a columnar format built on Apache Parquet with standardized geometry encoding.",
+        "The browser queries the file directly using <strong>DuckDB WASM</strong>, an in-browser analytical database. Features stream back as Arrow record batches, convert WKB → GeoJSON, and render on the map without any server round-trip.",
+      ],
+      metadata,
+      tools,
+      toolSectionTitle: "About this format",
+    };
+  }
+
   // xyz_vector
   const metadata: MetadataTileData[] = [
     { label: "Format", value: "XYZ Vector Tiles" },
@@ -224,6 +269,36 @@ function getDisplayStep(connection: Connection): StepContent {
       explanation: [
         "Vector tiles are decoded in the browser and rendered as <strong>GPU-accelerated geometry</strong> using deck.gl's MVTLayer. Each feature is individually addressable — you can hover, click, and inspect properties.",
         "Because rendering happens client-side, the same tiles support different visual styles without re-fetching. The map composites your data layer over a basemap from Carto.",
+      ],
+      metadata,
+      tools,
+      toolSectionTitle: "Open source tools used",
+    };
+  }
+
+  if (type === "geoparquet") {
+    const metadata: MetadataTileData[] = [
+      { label: "Renderer", value: "WebGL (deck.gl GeoJsonLayer)" },
+      { label: "Basemap", value: "Carto Positron", subValue: "OpenStreetMap data" },
+    ];
+
+    const tools: ToolCardData[] = [
+      {
+        name: "deck.gl",
+        url: "https://deck.gl/",
+        description:
+          "WebGL-powered visualization framework. The GeoJsonLayer renders GeoJSON features as GPU-accelerated geometry with interactive picking.",
+      },
+    ];
+
+    return {
+      label: "Display",
+      subtitle: "browser render",
+      badge: "Step 2 of 2",
+      title: "deck.gl GeoJsonLayer",
+      explanation: [
+        "Features are drawn as a single <strong>deck.gl GeoJsonLayer</strong> on the shared map canvas. No tile server is involved — all geometry was fetched directly by the browser.",
+        "Because rendering happens client-side with WebGL, each feature is individually addressable for hover and click interactions.",
       ],
       metadata,
       tools,

--- a/frontend/src/hooks/__tests__/useGeoParquetRender.test.ts
+++ b/frontend/src/hooks/__tests__/useGeoParquetRender.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useGeoParquetRender } from "../useGeoParquetRender";
 
-function makeMockConn(rows: { __geojson: string; name: string }[]) {
+interface MockGeoParquetRow {
+  __geojson: string;
+  name: string;
+}
+
+function makeMockConn(rows: MockGeoParquetRow[]) {
   const mockTable = {
     numRows: rows.length,
     get: (i: number) => rows[i],

--- a/frontend/src/hooks/__tests__/useGeoParquetRender.test.ts
+++ b/frontend/src/hooks/__tests__/useGeoParquetRender.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useGeoParquetRender } from "../useGeoParquetRender";
+
+function makeMockConn(rows: { __geojson: string; name: string }[]) {
+  const mockTable = {
+    numRows: rows.length,
+    get: (i: number) => rows[i],
+    schema: {
+      fields: [{ name: "__geojson" }, { name: "name" }],
+    },
+  };
+  const query = vi.fn(async (sql: string) => {
+    if (sql.startsWith("DESCRIBE")) {
+      return {
+        numRows: 2,
+        get: (i: number) =>
+          i === 0
+            ? { column_name: "geometry", column_type: "GEOMETRY" }
+            : { column_name: "name", column_type: "VARCHAR" },
+      };
+    }
+    if (sql.startsWith("SELECT COUNT")) {
+      return { numRows: 1, get: () => ({ cnt: rows.length }) };
+    }
+    return mockTable;
+  });
+  return { query } as unknown as import("@duckdb/duckdb-wasm").AsyncDuckDBConnection;
+}
+
+describe("useGeoParquetRender", () => {
+  it("returns an Arrow-shaped table after load()", async () => {
+    const conn = makeMockConn([
+      { __geojson: '{"type":"Point","coordinates":[0,0]}', name: "A" },
+    ]);
+    const { result } = renderHook(() =>
+      useGeoParquetRender(conn, "https://example.com/x.parquet")
+    );
+    await act(async () => {
+      await result.current.load();
+    });
+    await waitFor(() => expect(result.current.table).not.toBeNull());
+    expect(result.current.table?.numRows).toBe(1);
+    expect(result.current.featureCount).toBe(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("blocks load when feature count exceeds cap", async () => {
+    const conn = {
+      query: vi.fn(async (sql: string) => {
+        if (sql.startsWith("SELECT COUNT")) {
+          return { numRows: 1, get: () => ({ cnt: 600_000 }) };
+        }
+        return { numRows: 0, get: () => null };
+      }),
+    } as unknown as import("@duckdb/duckdb-wasm").AsyncDuckDBConnection;
+
+    const { result } = renderHook(() =>
+      useGeoParquetRender(conn, "https://example.com/big.parquet", { featureCap: 500_000 })
+    );
+    await act(async () => {
+      await result.current.load();
+    });
+    expect(result.current.table).toBeNull();
+    expect(result.current.error).toMatch(/too large/i);
+    expect(result.current.overCap).toBe(true);
+  });
+
+  it("does nothing when conn is null", async () => {
+    const { result } = renderHook(() =>
+      useGeoParquetRender(null, "https://example.com/x.parquet")
+    );
+    await act(async () => {
+      await result.current.load();
+    });
+    expect(result.current.table).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/frontend/src/hooks/__tests__/useGeoParquetRender.test.ts
+++ b/frontend/src/hooks/__tests__/useGeoParquetRender.test.ts
@@ -30,7 +30,9 @@ function makeMockConn(rows: MockGeoParquetRow[]) {
     }
     return mockTable;
   });
-  return { query } as unknown as import("@duckdb/duckdb-wasm").AsyncDuckDBConnection;
+  return {
+    query,
+  } as unknown as import("@duckdb/duckdb-wasm").AsyncDuckDBConnection;
 }
 
 describe("useGeoParquetRender", () => {
@@ -61,7 +63,9 @@ describe("useGeoParquetRender", () => {
     } as unknown as import("@duckdb/duckdb-wasm").AsyncDuckDBConnection;
 
     const { result } = renderHook(() =>
-      useGeoParquetRender(conn, "https://example.com/big.parquet", { featureCap: 500_000 })
+      useGeoParquetRender(conn, "https://example.com/big.parquet", {
+        featureCap: 500_000,
+      })
     );
     await act(async () => {
       await result.current.load();

--- a/frontend/src/hooks/__tests__/useMapData.test.ts
+++ b/frontend/src/hooks/__tests__/useMapData.test.ts
@@ -216,4 +216,20 @@ describe("useMapData", () => {
     expect(result.current.isExpired).toBe(true);
     expect(result.current.data).toBeNull();
   });
+
+  it("treats geoparquet connections as vector data", async () => {
+    mockConnectionsGet.mockResolvedValue({
+      ...MOCK_CONNECTION,
+      id: "conn-gp",
+      name: "Parcels",
+      url: "https://example.com/parcels.parquet",
+      connection_type: "geoparquet",
+      tile_type: null,
+    });
+
+    const { result } = renderHook(() => useMapData("conn-gp", true));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data!.dataType).toBe("vector");
+  });
 });

--- a/frontend/src/hooks/useGeoParquetRender.ts
+++ b/frontend/src/hooks/useGeoParquetRender.ts
@@ -34,11 +34,21 @@ export function useGeoParquetRender(
   const reqIdRef = useRef(0);
 
   const load = useCallback(async () => {
-    if (!conn || !url) return;
+    const myReq = ++reqIdRef.current;
+    if (!conn || !url) {
+      geomColRef.current = null;
+      setState({
+        table: null,
+        featureCount: 0,
+        loading: false,
+        error: null,
+        overCap: false,
+      });
+      return;
+    }
     // Reset geometry column detection for each new load so URL switches
     // don't reuse a column name that may not exist in the new file.
     geomColRef.current = null;
-    const myReq = ++reqIdRef.current;
     setState((s) => ({ ...s, loading: true, error: null, overCap: false }));
     try {
       // Escape single quotes to prevent SQL injection via URL values.
@@ -82,8 +92,9 @@ export function useGeoParquetRender(
       }
 
       const geomCol = geomColRef.current;
-      const sql = geomCol
-        ? `SELECT * EXCLUDE ("${geomCol}"), ST_AsGeoJSON("${geomCol}") as __geojson FROM read_parquet('${safeUrl}') LIMIT ${featureCap}`
+      const safeGeomCol = geomCol ? geomCol.replace(/"/g, '""') : null;
+      const sql = safeGeomCol
+        ? `SELECT * EXCLUDE ("${safeGeomCol}"), ST_AsGeoJSON("${safeGeomCol}") as __geojson FROM read_parquet('${safeUrl}') LIMIT ${featureCap}`
         : `SELECT * FROM read_parquet('${safeUrl}') LIMIT ${featureCap}`;
       const table = (await conn.query(sql)) as unknown as Table;
       if (myReq !== reqIdRef.current) return;

--- a/frontend/src/hooks/useGeoParquetRender.ts
+++ b/frontend/src/hooks/useGeoParquetRender.ts
@@ -31,14 +31,23 @@ export function useGeoParquetRender(
     overCap: false,
   });
   const geomColRef = useRef<string | null>(null);
+  const reqIdRef = useRef(0);
 
   const load = useCallback(async () => {
     if (!conn || !url) return;
+    // Reset geometry column detection for each new load so URL switches
+    // don't reuse a column name that may not exist in the new file.
+    geomColRef.current = null;
+    const myReq = ++reqIdRef.current;
     setState((s) => ({ ...s, loading: true, error: null, overCap: false }));
     try {
+      // Escape single quotes to prevent SQL injection via URL values.
+      const safeUrl = url.split("'").join("''");
+
       const countResult = await conn.query(
-        `SELECT COUNT(*) as cnt FROM read_parquet('${url}')`
+        `SELECT COUNT(*) as cnt FROM read_parquet('${safeUrl}')`
       );
+      if (myReq !== reqIdRef.current) return;
       const featureCount = Number(countResult.get(0)?.cnt ?? 0);
 
       if (featureCount > featureCap) {
@@ -54,8 +63,9 @@ export function useGeoParquetRender(
 
       if (!geomColRef.current) {
         const desc = await conn.query(
-          `DESCRIBE SELECT * FROM read_parquet('${url}') LIMIT 0`
+          `DESCRIBE SELECT * FROM read_parquet('${safeUrl}') LIMIT 0`
         );
+        if (myReq !== reqIdRef.current) return;
         for (let i = 0; i < desc.numRows; i++) {
           const row = desc.get(i);
           if (!row) continue;
@@ -73,9 +83,10 @@ export function useGeoParquetRender(
 
       const geomCol = geomColRef.current;
       const sql = geomCol
-        ? `SELECT * EXCLUDE ("${geomCol}"), ST_AsGeoJSON("${geomCol}") as __geojson FROM read_parquet('${url}') LIMIT ${featureCap}`
-        : `SELECT * FROM read_parquet('${url}') LIMIT ${featureCap}`;
+        ? `SELECT * EXCLUDE ("${geomCol}"), ST_AsGeoJSON("${geomCol}") as __geojson FROM read_parquet('${safeUrl}') LIMIT ${featureCap}`
+        : `SELECT * FROM read_parquet('${safeUrl}') LIMIT ${featureCap}`;
       const table = (await conn.query(sql)) as unknown as Table;
+      if (myReq !== reqIdRef.current) return;
 
       setState({
         table,
@@ -85,6 +96,7 @@ export function useGeoParquetRender(
         overCap: false,
       });
     } catch (e) {
+      if (myReq !== reqIdRef.current) return;
       setState({
         table: null,
         featureCount: 0,

--- a/frontend/src/hooks/useGeoParquetRender.ts
+++ b/frontend/src/hooks/useGeoParquetRender.ts
@@ -1,0 +1,99 @@
+import { useCallback, useRef, useState } from "react";
+import type { AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
+import type { Table } from "apache-arrow";
+
+const DEFAULT_FEATURE_CAP = 500_000;
+const GEOM_NAMES = ["geometry", "geom", "wkb_geometry", "the_geom"];
+
+export interface GeoParquetRenderState {
+  table: Table | null;
+  featureCount: number;
+  loading: boolean;
+  error: string | null;
+  overCap: boolean;
+}
+
+export interface UseGeoParquetRenderOptions {
+  featureCap?: number;
+}
+
+export function useGeoParquetRender(
+  conn: AsyncDuckDBConnection | null,
+  url: string,
+  options: UseGeoParquetRenderOptions = {}
+) {
+  const featureCap = options.featureCap ?? DEFAULT_FEATURE_CAP;
+  const [state, setState] = useState<GeoParquetRenderState>({
+    table: null,
+    featureCount: 0,
+    loading: false,
+    error: null,
+    overCap: false,
+  });
+  const geomColRef = useRef<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!conn || !url) return;
+    setState((s) => ({ ...s, loading: true, error: null, overCap: false }));
+    try {
+      const countResult = await conn.query(
+        `SELECT COUNT(*) as cnt FROM read_parquet('${url}')`
+      );
+      const featureCount = Number(countResult.get(0)?.cnt ?? 0);
+
+      if (featureCount > featureCap) {
+        setState({
+          table: null,
+          featureCount,
+          loading: false,
+          error: `Dataset too large for in-browser rendering (${featureCount.toLocaleString()} features > ${featureCap.toLocaleString()} cap). Server-side conversion coming soon.`,
+          overCap: true,
+        });
+        return;
+      }
+
+      if (!geomColRef.current) {
+        const desc = await conn.query(
+          `DESCRIBE SELECT * FROM read_parquet('${url}') LIMIT 0`
+        );
+        for (let i = 0; i < desc.numRows; i++) {
+          const row = desc.get(i);
+          if (!row) continue;
+          const colType = String(row.column_type);
+          const colName = String(row.column_name);
+          if (
+            colType.includes("GEOMETRY") ||
+            (colType === "BLOB" && GEOM_NAMES.includes(colName.toLowerCase()))
+          ) {
+            geomColRef.current = colName;
+            break;
+          }
+        }
+      }
+
+      const geomCol = geomColRef.current;
+      const sql = geomCol
+        ? `SELECT * EXCLUDE ("${geomCol}"), ST_AsGeoJSON("${geomCol}") as __geojson FROM read_parquet('${url}') LIMIT ${featureCap}`
+        : `SELECT * FROM read_parquet('${url}') LIMIT ${featureCap}`;
+      const table = (await conn.query(sql)) as unknown as Table;
+
+      setState({
+        table,
+        featureCount,
+        loading: false,
+        error: null,
+        overCap: false,
+      });
+    } catch (e) {
+      setState({
+        table: null,
+        featureCount: 0,
+        loading: false,
+        error: e instanceof Error ? e.message : "Query failed",
+        overCap: false,
+      });
+    }
+  }, [conn, url, featureCap]);
+
+  return { ...state, load };
+}

--- a/frontend/src/hooks/useLayerBuilder.ts
+++ b/frontend/src/hooks/useLayerBuilder.ts
@@ -208,6 +208,10 @@ export function useLayerBuilder({
         ];
       }
 
+      if (connType === "geoparquet") {
+        return buildGeoJsonLayer({ geojson });
+      }
+
       return [];
     }
 

--- a/frontend/src/hooks/useMapData.ts
+++ b/frontend/src/hooks/useMapData.ts
@@ -32,6 +32,7 @@ function datasetToMapItem(ds: Dataset): MapItem {
 
 function getConnectionDataType(conn: Connection): "raster" | "vector" {
   if (conn.connection_type === "xyz_vector") return "vector";
+  if (conn.connection_type === "geoparquet") return "vector";
   if (conn.connection_type === "pmtiles" && conn.tile_type !== "raster")
     return "vector";
   return "raster";

--- a/frontend/src/lib/connections/__tests__/tileUrl.test.ts
+++ b/frontend/src/lib/connections/__tests__/tileUrl.test.ts
@@ -63,4 +63,14 @@ describe("buildConnectionTileUrl", () => {
       "https://example.com/data.pmtiles"
     );
   });
+
+  it("returns the raw URL for geoparquet connections", () => {
+    const conn = makeConnection({
+      url: "https://example.com/parcels.parquet",
+      connection_type: "geoparquet",
+    });
+    expect(buildConnectionTileUrl(conn)).toBe(
+      "https://example.com/parcels.parquet"
+    );
+  });
 });

--- a/frontend/src/lib/connections/tileUrl.ts
+++ b/frontend/src/lib/connections/tileUrl.ts
@@ -7,6 +7,7 @@ export function buildConnectionTileUrl(connection: Connection): string {
     case "pmtiles":
     case "xyz_raster":
     case "xyz_vector":
+    case "geoparquet":
       return connection.url;
     default:
       return connection.url;

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -240,13 +240,10 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
     item.connection?.connection_type === "geoparquet";
 
   const { conn: duckConn, initialize: initializeDuckDB } = useDuckDB();
-  const {
-    table: geoParquetTable,
-    loading: _geoParquetLoading,
-    error: _geoParquetError,
-    overCap: _geoParquetOverCap,
-    load: loadGeoParquet,
-  } = useGeoParquetRender(duckConn, isGeoParquetConnection ? item.connection!.url : "");
+  const { table: geoParquetTable, load: loadGeoParquet } = useGeoParquetRender(
+    duckConn,
+    isGeoParquetConnection ? (item.connection?.url ?? "") : "",
+  );
 
   useEffect(() => {
     if (!isGeoParquetConnection) return;

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -40,6 +40,8 @@ import { useMapControls } from "../hooks/useMapControls";
 import { useRasterOverrides } from "../hooks/useRasterOverrides";
 import { useLayerBuilder } from "../hooks/useLayerBuilder";
 import { ErrorBoundary } from "../components/ErrorBoundary";
+import { useDuckDB } from "../hooks/useDuckDB";
+import { useGeoParquetRender } from "../hooks/useGeoParquetRender";
 import type { Table } from "apache-arrow";
 
 export default function MapPage({ shared = false }: { shared?: boolean }) {
@@ -232,6 +234,40 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
   const handleTableChange = useCallback((table: Table | null) => {
     setArrowTable(table);
   }, []);
+
+  const isGeoParquetConnection =
+    item?.source === "connection" &&
+    item.connection?.connection_type === "geoparquet";
+
+  const { conn: duckConn, initialize: initializeDuckDB } = useDuckDB();
+  const {
+    table: geoParquetTable,
+    loading: _geoParquetLoading,
+    error: _geoParquetError,
+    overCap: _geoParquetOverCap,
+    load: loadGeoParquet,
+  } = useGeoParquetRender(duckConn, isGeoParquetConnection ? item.connection!.url : "");
+
+  useEffect(() => {
+    if (!isGeoParquetConnection) return;
+    let cancelled = false;
+    (async () => {
+      if (!duckConn) {
+        await initializeDuckDB();
+      }
+      if (cancelled) return;
+      await loadGeoParquet();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isGeoParquetConnection, item?.id, duckConn, initializeDuckDB, loadGeoParquet]);
+
+  useEffect(() => {
+    if (isGeoParquetConnection && geoParquetTable) {
+      setArrowTable(geoParquetTable);
+    }
+  }, [isGeoParquetConnection, geoParquetTable]);
 
   // --- Popups & pixel inspector ---
   const tileCacheRef = useRef<Map<string, TileCacheEntry>>(new Map());

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -242,7 +242,7 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
   const { conn: duckConn, initialize: initializeDuckDB } = useDuckDB();
   const { table: geoParquetTable, load: loadGeoParquet } = useGeoParquetRender(
     duckConn,
-    isGeoParquetConnection ? (item.connection?.url ?? "") : "",
+    isGeoParquetConnection ? (item.connection?.url ?? "") : ""
   );
 
   useEffect(() => {
@@ -258,7 +258,13 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
     return () => {
       cancelled = true;
     };
-  }, [isGeoParquetConnection, item?.id, duckConn, initializeDuckDB, loadGeoParquet]);
+  }, [
+    isGeoParquetConnection,
+    item?.id,
+    duckConn,
+    initializeDuckDB,
+    loadGeoParquet,
+  ]);
 
   useEffect(() => {
     if (isGeoParquetConnection && geoParquetTable) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -70,7 +70,12 @@ export interface Dataset {
   expires_at: string | null;
 }
 
-export type ConnectionType = "xyz_raster" | "xyz_vector" | "cog" | "pmtiles" | "geoparquet";
+export type ConnectionType =
+  | "xyz_raster"
+  | "xyz_vector"
+  | "cog"
+  | "pmtiles"
+  | "geoparquet";
 
 export interface Connection {
   id: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -70,7 +70,7 @@ export interface Dataset {
   expires_at: string | null;
 }
 
-export type ConnectionType = "xyz_raster" | "xyz_vector" | "cog" | "pmtiles";
+export type ConnectionType = "xyz_raster" | "xyz_vector" | "cog" | "pmtiles" | "geoparquet";
 
 export interface Connection {
   id: string;

--- a/ingestion/src/models/connection.py
+++ b/ingestion/src/models/connection.py
@@ -17,7 +17,7 @@ class ConnectionRow(Base):
     url = Column(String, nullable=False)
     connection_type = Column(
         String, nullable=False
-    )  # xyz_raster, xyz_vector, cog, pmtiles
+    )  # xyz_raster, xyz_vector, cog, pmtiles, geoparquet
     bounds_json = Column(String, nullable=True)  # JSON array [w, s, e, n]
     min_zoom = Column(Integer, nullable=True)
     max_zoom = Column(Integer, nullable=True)


### PR DESCRIPTION
## Summary
- Adds `"geoparquet"` to `ConnectionType` and wires the full client-side render path.
- New `useGeoParquetRender` hook queries remote parquet via DuckDB WASM, returns an Arrow `Table`, and blocks when feature count exceeds 500k.
- `useLayerBuilder` draws features via the existing `arrowTableToGeoJSON` + `GeoJsonLayer` utilities.
- Pipeline panel shows "DuckDB WASM → deck.gl GeoJsonLayer" steps for this connection type.
- `RemoteConnectFlow` blocks the Confirm action and shows a clear cap-message when a parquet is too large for client-side rendering.

Implements Ticket A of spec `2026-04-15-remote-geoparquet-rendering-design.md`. Tickets B (server PMTiles path) and C (auto-dispatch) follow.

## Notable review fixes applied during implementation
- `useGeoParquetRender` resets the cached geometry-column ref on every `load()` so switching between connections with different geom column names works.
- URL is single-quote-escaped before SQL interpolation as defense-in-depth against malformed/hostile URLs.
- A request-counter ref drops stale state writes when the user switches connections rapidly.

## Test plan
- [x] `cd frontend && npx vitest run` — 290/290 pass
- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `cd ingestion && uv run pytest tests/test_connections.py` — 13/13 pass
- [ ] Manual smoke test (worktree stack) — small parquet renders on map; oversized parquet shows cap message. _Deferred to follow-up._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for remote GeoParquet connections with in-browser rendering (DuckDB-WASM → Arrow) and deck.gl display; UI shows "Remote GeoParquet".
  * Preview is blocked for datasets exceeding a 500k feature in-browser cap.

* **Documentation**
  * API docs updated to include GeoParquet alongside existing connection types and describe client-side behavior.

* **Tests**
  * Added tests for GeoParquet rendering, feature-cap handling, and type mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->