### PR TITLE
fix(frontend): GeoParquet validation against remote URLs

### DIFF
--- a/frontend/src/components/RemoteConnectFlow.tsx
+++ b/frontend/src/components/RemoteConnectFlow.tsx
@@ -78,7 +78,11 @@ export function RemoteConnectFlow({ onDatasetReady }: RemoteConnectFlowProps) {
           return;
         }
       }
-      await validateGeoParquet(activeConn);
+      // Pass trimmedUrl explicitly: setPreviewUrl above is async, so
+      // validateGeoParquet's closure still holds the previous parquetUrl
+      // until React re-renders. Without this override the first validation
+      // would run against an empty URL.
+      await validateGeoParquet(activeConn, trimmedUrl);
       return; // Don't proceed to discovery
     }
 

--- a/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
+++ b/frontend/src/hooks/__tests__/useGeoParquetValidation.test.ts
@@ -53,7 +53,7 @@ describe("useGeoParquetValidation", () => {
     const mockConn = makeConn((sql) => {
       if (sql.includes("DESCRIBE")) return describeResult;
       if (sql.includes("ST_GeometryType")) return geomTypeResult;
-      if (sql.includes("ST_Extent")) return bboxResult;
+      if (sql.includes("ST_XMin")) return bboxResult;
     });
 
     const { result } = renderHook(() =>
@@ -158,7 +158,7 @@ describe("useGeoParquetValidation", () => {
       if (sql.includes("ST_GeometryType")) {
         return { numRows: 1, get: () => ({ geom_type: "POINT" }) };
       }
-      if (sql.includes("ST_Extent")) {
+      if (sql.includes("ST_XMin")) {
         return {
           numRows: 1,
           get: () => ({ minx: -1, miny: -1, maxx: 1, maxy: 1 }),
@@ -200,7 +200,7 @@ describe("useGeoParquetValidation", () => {
           get: () => ({ geom_type: "POINT" }),
         };
       }
-      if (sql.includes("ST_Extent")) {
+      if (sql.includes("ST_XMin")) {
         return {
           numRows: 1,
           get: () => ({
@@ -276,7 +276,7 @@ describe("useGeoParquetValidation", () => {
           get: () => ({ geom_type: "POINT" }),
         };
       }
-      if (sql.includes("ST_Extent")) {
+      if (sql.includes("ST_XMin")) {
         return {
           numRows: 1,
           get: () => ({
@@ -301,9 +301,10 @@ describe("useGeoParquetValidation", () => {
     await waitFor(() => expect(result.current.validating).toBe(false));
 
     // validateCallCount counts SQL queries issued to the mock conn (4 per
-    // validation: DESCRIBE, ST_GeometryType, ST_Extent, parquet_metadata for
-    // size detection). The second validate() call is skipped due to the
-    // in-flight guard, so we expect exactly 4 queries, not 8.
+    // validation: DESCRIBE, ST_GeometryType, bbox (ST_XMin/MAX aggregate),
+    // parquet_metadata for size detection). The second validate() call is
+    // skipped due to the in-flight guard, so we expect exactly 4 queries,
+    // not 8.
     expect(validateCallCount).toBe(4);
   });
 
@@ -340,7 +341,7 @@ describe("useGeoParquetValidation", () => {
           if (sql.includes("ST_GeometryType")) {
             return { numRows: 1, get: () => ({ geom_type: "POINT" }) };
           }
-          if (sql.includes("ST_Extent")) {
+          if (sql.includes("ST_XMin")) {
             return {
               numRows: 1,
               get: () => ({ minx: 0, miny: 0, maxx: 1, maxy: 1 }),
@@ -409,7 +410,7 @@ describe("useGeoParquetValidation", () => {
         if (sql.includes("ST_GeometryType")) {
           return { numRows: 1, get: () => ({ geom_type: "POINT" }) };
         }
-        if (sql.includes("ST_Extent")) {
+        if (sql.includes("ST_XMin")) {
           return {
             numRows: 1,
             get: () => ({ minx: 0, miny: 0, maxx: 1, maxy: 1 }),
@@ -454,7 +455,7 @@ describe("useGeoParquetValidation", () => {
       if (sql.includes("ST_GeometryType")) {
         return { numRows: 1, get: () => ({ geom_type: "POINT" }) };
       }
-      if (sql.includes("ST_Extent")) {
+      if (sql.includes("ST_XMin")) {
         return {
           numRows: 1,
           get: () => ({ minx: 0, miny: 0, maxx: 1, maxy: 1 }),
@@ -476,5 +477,88 @@ describe("useGeoParquetValidation", () => {
     expect(result.current.renderPath).toBe("client");
 
     vi.unstubAllGlobals();
+  });
+
+  it("uses the overrideUrl argument when provided instead of the hook's parquetUrl", async () => {
+    const queries: string[] = [];
+    const describeResult = {
+      numRows: 1,
+      get: () => ({ column_name: "geometry", column_type: "GEOMETRY" }),
+    };
+    const mockConn = {
+      query: vi.fn(async (sql: string) => {
+        queries.push(sql);
+        if (sql.includes("DESCRIBE")) return describeResult;
+        if (sql.includes("ST_GeometryType")) {
+          return { numRows: 1, get: () => ({ geom_type: "POLYGON" }) };
+        }
+        if (sql.includes("ST_XMin")) {
+          return {
+            numRows: 1,
+            get: () => ({ minx: -1, miny: -1, maxx: 1, maxy: 1 }),
+          };
+        }
+      }),
+    } as unknown as AsyncDuckDBConnection;
+
+    // Hook is created with an empty parquetUrl. Without the override, every
+    // query would run against `${window.location.origin}/` (empty URL
+    // resolving to the dev server root). This simulates the common case
+    // where the caller issues setPreviewUrl(...) and then immediately calls
+    // validate() before React has re-rendered the hook with the new URL.
+    const { result } = renderHook(() => useGeoParquetValidation(mockConn, ""));
+
+    const overrideUrl = "https://example.com/override.parquet";
+    await act(async () => {
+      await result.current.validate(undefined, overrideUrl);
+    });
+
+    expect(result.current.valid).toBe(true);
+    for (const q of queries) {
+      expect(q).toContain(overrideUrl);
+      expect(q).not.toContain(`${window.location.origin}/'`);
+    }
+  });
+
+  it("computes the bbox with aggregate MIN/MAX of ST_XMin/YMin/XMax/YMax", async () => {
+    const queries: string[] = [];
+    const mockConn = {
+      query: vi.fn(async (sql: string) => {
+        queries.push(sql);
+        if (sql.includes("DESCRIBE")) {
+          return {
+            numRows: 1,
+            get: () => ({ column_name: "geometry", column_type: "GEOMETRY" }),
+          };
+        }
+        if (sql.includes("ST_GeometryType")) {
+          return { numRows: 1, get: () => ({ geom_type: "POINT" }) };
+        }
+        if (sql.includes("ST_XMin")) {
+          return {
+            numRows: 1,
+            get: () => ({ minx: 0, miny: 0, maxx: 1, maxy: 1 }),
+          };
+        }
+      }),
+    } as unknown as AsyncDuckDBConnection;
+
+    const { result } = renderHook(() =>
+      useGeoParquetValidation(mockConn, "https://example.com/t.parquet")
+    );
+
+    await act(async () => {
+      await result.current.validate();
+    });
+
+    expect(result.current.valid).toBe(true);
+    const bboxQuery = queries.find((q) => q.includes("ST_XMin"));
+    expect(bboxQuery).toBeDefined();
+    // Aggregate form (not the broken scalar ST_MinX(ext) / ST_Extent CTE)
+    expect(bboxQuery).toContain("MIN(ST_XMin");
+    expect(bboxQuery).toContain("MIN(ST_YMin");
+    expect(bboxQuery).toContain("MAX(ST_XMax");
+    expect(bboxQuery).toContain("MAX(ST_YMax");
+    expect(bboxQuery).not.toMatch(/ST_MinX|ST_MaxX|ST_MinY|ST_MaxY/);
   });
 });

--- a/frontend/src/hooks/useGeoParquetValidation.ts
+++ b/frontend/src/hooks/useGeoParquetValidation.ts
@@ -62,7 +62,10 @@ export function useGeoParquetValidation(
   const validatingRef = useRef(false);
 
   const validate = useCallback(
-    async (overrideConn?: AsyncDuckDBConnection | null) => {
+    async (
+      overrideConn?: AsyncDuckDBConnection | null,
+      overrideUrl?: string
+    ) => {
       if (validatingRef.current) {
         console.warn(
           "Validation already in progress, skipping concurrent call"
@@ -71,6 +74,7 @@ export function useGeoParquetValidation(
       }
 
       const activeConn = overrideConn ?? conn;
+      const activeUrl = overrideUrl ?? parquetUrl;
 
       if (!activeConn) {
         setState({
@@ -89,7 +93,7 @@ export function useGeoParquetValidation(
       setState((prev) => ({ ...prev, validating: true }));
 
       try {
-        const fullUrl = resolveParquetUrl(parquetUrl);
+        const fullUrl = resolveParquetUrl(activeUrl);
         const escapedUrl = escapeSqlLiteral(fullUrl);
 
         // Step 1: Detect geometry column
@@ -155,15 +159,16 @@ export function useGeoParquetValidation(
           }
         }
 
-        // Step 3: Get bounding box (compute ST_Extent once via CTE)
+        // Step 3: Get bounding box. DuckDB spatial exposes ST_XMin/ST_YMin/
+        // ST_XMax/ST_YMax on GEOMETRY values (not BOX_2D), so aggregate the
+        // per-row coordinates with MIN/MAX to get the dataset extent.
         const bboxResult = await activeConn.query(
-          `WITH extent AS (
-             SELECT ST_Extent("${geometryColumnName}") as ext
-             FROM read_parquet('${escapedUrl}') WHERE "${geometryColumnName}" IS NOT NULL
-           )
-           SELECT ST_MinX(ext) as minx, ST_MinY(ext) as miny,
-                  ST_MaxX(ext) as maxx, ST_MaxY(ext) as maxy
-           FROM extent`
+          `SELECT MIN(ST_XMin("${geometryColumnName}")) as minx,
+                  MIN(ST_YMin("${geometryColumnName}")) as miny,
+                  MAX(ST_XMax("${geometryColumnName}")) as maxx,
+                  MAX(ST_YMax("${geometryColumnName}")) as maxy
+           FROM read_parquet('${escapedUrl}')
+           WHERE "${geometryColumnName}" IS NOT NULL`
         );
 
         let bbox: GeometryInfo["bbox"] = null;


### PR DESCRIPTION
## Summary

Two bugs surfaced while testing remote GeoParquet connections against `data.source.coop`:

- **Stale closure** — `RemoteConnectFlow` called `setPreviewUrl(trimmedUrl)` then awaited `validateGeoParquet(activeConn)` in the same handler, so the hook's captured `parquetUrl` was still `""` and queries ran against `${window.location.origin}/` (the dev-server root), giving `Invalid Input Error: No magic bytes found at end of file 'http://localhost:5185/'`. `validate()` now accepts an `overrideUrl` arg and the caller passes `trimmedUrl` directly.
- **Wrong bbox SQL** — the extent query used PostGIS names (`ST_MinX/MinY/MaxX/MaxY`) on a scalar `ST_Extent`. DuckDB spatial exposes `ST_XMin/YMin/XMax/YMax`, and they take `GEOMETRY`, not `BOX_2D`. The query now aggregates per-row `ST_XMin/YMin/XMax/YMax` with `MIN/MAX` over the whole file.

## Test plan

- [x] `useGeoParquetValidation` unit tests updated to the new SQL (`ST_XMin` matchers) and extended with two regression tests (override-URL path, aggregate bbox SQL shape) — 14/14 pass
- [x] Full frontend suite `npx vitest run` — 316/316 pass
- [x] `tsc --noEmit` clean, `prettier --check` clean
- [ ] Manually retest both source.coop URLs in the browser:
  - `https://data.source.coop/cholmes/google-open-buildings/geoparquet-by-country/country_iso=AI/AI.parquet`
  - `https://data.source.coop/cholmes/eurocrops/unprojected/geoparquet/FR_2018_EC21.parquet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved GeoParquet validation to use the correct URL during file scans, ensuring validation runs with the intended input.
  * Enhanced bounding box calculation for GeoParquet files with more precise coordinate aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->