### PR TITLE
feat: open shared map/story views to the public

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,14 @@ Service names: `database`, `stac-api`, `raster-tiler`, `vector-tiler`, `cog-tile
 
 ## Production Deployment (Hetzner)
 
-The sandbox can be deployed to a public URL with HTTPS and basic auth using the `prod` Docker Compose profile.
+The sandbox can be deployed to a public URL with HTTPS using the `prod` Docker Compose profile. The frontend and shared `/map` / `/story` views are public; write operations and workspace listings are gated behind HTTP basic auth via Caddy.
+
+### Auth model
+
+Caddy applies basic auth selectively (see `Caddyfile`):
+
+- **Public (no auth):** frontend SPA, `/storage/*` (R2 proxy), `/cog/*`, `/raster/*`, `/vector/*`, individual resource reads like `GET /api/datasets/{id}`, `GET /api/connections/{id}`, `GET /api/stories/{id}`, `/api/proxy`, `/api/health`. This lets shared map/story URLs load for anyone without a password prompt, and lets PMTiles / DuckDB-WASM range requests succeed (they can't send basic auth).
+- **Auth required:** all non-GET/HEAD requests to `/api/*` (uploads, creates, updates, deletes) and workspace-listing reads (`GET /api/datasets`, `GET /api/connections`, `GET /api/stories`).
 
 ### Prerequisites
 
@@ -95,8 +102,8 @@ docker compose --profile prod up -d --build
 
 ### Verify
 
-- Visit `https://cngsandbox.org` — should prompt for username/password
-- After auth, the sandbox should load normally
+- Visit `https://cngsandbox.org` — the SPA should load without a password prompt
+- Attempt an authenticated action (e.g. opening the dataset library or uploading a file) — should prompt for username/password
 - Upload a file to verify CORS works end-to-end
 
 ### Notes

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,8 +1,6 @@
 {$SITE_ADDRESS} {
-
-	# Data-serving paths: proxy to R2 public URL.
-	# No auth: programmatic clients (PMTiles, DuckDB WASM) can't
-	# send Basic Auth credentials with range requests.
+	# Data-serving paths: proxy to R2 public URL. Public — range requests
+	# from PMTiles / DuckDB WASM can't carry Basic Auth credentials.
 	handle /storage/* {
 		uri strip_prefix /storage
 		reverse_proxy {$R2_PUBLIC_URL} {
@@ -25,18 +23,39 @@
 		}
 	}
 
-	# Health check — no auth so the uptime monitor can reach it
-	handle /api/health {
-		reverse_proxy ingestion:8000
+	# Tile endpoints — public. Shared /map and /story views need to fetch
+	# tiles without auth. Write operations aren't exposed here (GET-only).
+	handle /cog/* {
+		reverse_proxy cog-tiler:80 {
+			header_down Cache-Control "no-store"
+		}
 	}
 
-	# API proxy — flush_interval -1 enables SSE streaming for upload progress.
-	# Large uploads (up to 15GB, matching ingestion service limit) and
-	# long-running conversions need generous timeouts — gdalwarp reprojection
-	# of continental-scale rasters can take 10+ minutes, and the SSE stream
-	# stays open the entire time.
+	handle /raster/* {
+		uri strip_prefix /raster
+		reverse_proxy raster-tiler:80 {
+			header_down Cache-Control "no-store"
+		}
+	}
+
+	handle /vector/* {
+		uri strip_prefix /vector
+		reverse_proxy vector-tiler:80 {
+			header_down Cache-Control "no-store"
+		}
+	}
+
+	# API: auth required for writes and for workspace-listing reads.
+	# Individual resource reads (GET /api/{datasets,connections,stories}/{id})
+	# and /api/proxy, /api/health stay public so shared /map and /story URLs
+	# can load without a password prompt.
+	#
+	# flush_interval -1 enables SSE streaming (upload progress, conversion
+	# jobs). 15GB body + 30min timeouts accommodate large raster uploads
+	# and multi-minute gdalwarp reprojections.
 	handle /api/* {
-		basic_auth {
+		@apiNeedsAuth `({method} != 'GET' && {method} != 'HEAD') || {path}.matches('^/api/(datasets|connections|stories)/?$')`
+		basic_auth @apiNeedsAuth {
 			{$AUTH_USER} {$AUTH_PASSWORD_HASH}
 		}
 		request_body {
@@ -51,49 +70,14 @@
 		}
 	}
 
-	# COG tiler proxy (standalone titiler for external COGs)
-	# Note: titiler routes are already under /cog/ — do NOT strip the prefix
-	handle /cog/* {
-		basic_auth {
-			{$AUTH_USER} {$AUTH_PASSWORD_HASH}
-		}
-		reverse_proxy cog-tiler:80 {
-			header_down Cache-Control "no-store"
-		}
-	}
-
-	# Raster tile proxy
-	handle /raster/* {
-		basic_auth {
-			{$AUTH_USER} {$AUTH_PASSWORD_HASH}
-		}
-		uri strip_prefix /raster
-		reverse_proxy raster-tiler:80 {
-			header_down Cache-Control "no-store"
-		}
-	}
-
-	# Vector tile proxy
-	handle /vector/* {
-		basic_auth {
-			{$AUTH_USER} {$AUTH_PASSWORD_HASH}
-		}
-		uri strip_prefix /vector
-		reverse_proxy vector-tiler:80 {
-			header_down Cache-Control "no-store"
-		}
-	}
-
-	# Frontend: serve static files from the production build.
-	# try_files falls back to index.html for SPA client-side routing.
+	# Frontend: serve static files from the production build. Public so
+	# the SPA can load for shared map/story URLs — write actions in the UI
+	# still hit auth-gated API endpoints.
 	#
 	# Cache policy: hashed assets (/assets/*) are immutable and cached
 	# for 1 year. index.html must always be revalidated so browsers
 	# pick up new asset hashes after a deploy.
 	handle {
-		basic_auth {
-			{$AUTH_USER} {$AUTH_PASSWORD_HASH}
-		}
 		encode gzip
 		root * /srv/frontend
 

--- a/frontend/src/components/SharedHeader.tsx
+++ b/frontend/src/components/SharedHeader.tsx
@@ -1,44 +1,22 @@
 import { Flex, Text } from "@chakra-ui/react";
-import { Link } from "react-router-dom";
-import { ArrowRight } from "@phosphor-icons/react";
 
 export function SharedHeader() {
   return (
     <Flex
       as="header"
       align="center"
-      justify="space-between"
       px={6}
       py={3}
       bg="white"
       borderBottom="1px solid"
       borderColor="brand.border"
     >
-      <Link to="/" style={{ textDecoration: "none" }}>
-        <Flex align="center" gap={3}>
-          <img src="/logo.svg" alt="Development Seed" width={32} height={32} />
-          <Text as="span" color="brand.brown" fontWeight={700} fontSize="15px">
-            CNG Sandbox
-          </Text>
-        </Flex>
-      </Link>
-      <Link to="/" style={{ textDecoration: "none" }}>
-        <Flex
-          align="center"
-          gap={1.5}
-          bg="brand.orange"
-          color="white"
-          px={4}
-          py={1.5}
-          borderRadius="4px"
-          fontWeight={600}
-          fontSize="sm"
-          _hover={{ bg: "brand.orangeHover" }}
-        >
-          Make your own map
-          <ArrowRight size={14} weight="bold" />
-        </Flex>
-      </Link>
+      <Flex align="center" gap={3}>
+        <img src="/logo.svg" alt="Development Seed" width={32} height={32} />
+        <Text as="span" color="brand.brown" fontWeight={700} fontSize="15px">
+          CNG Sandbox
+        </Text>
+      </Flex>
     </Flex>
   );
 }

--- a/frontend/src/components/__tests__/SharedHeader.test.tsx
+++ b/frontend/src/components/__tests__/SharedHeader.test.tsx
@@ -11,16 +11,16 @@ function renderWithProviders(ui: React.ReactElement) {
   );
 }
 
-test("renders logo linking to homepage", () => {
+test("renders logo and title as static (non-linked) content", () => {
   renderWithProviders(<SharedHeader />);
-  const link = screen.getByRole("link", { name: /cng sandbox/i });
-  expect(link).toHaveAttribute("href", "/");
+  expect(screen.getByText(/cng sandbox/i)).toBeInTheDocument();
+  expect(screen.getByAltText(/development seed/i)).toBeInTheDocument();
+  expect(screen.queryByRole("link")).not.toBeInTheDocument();
 });
 
-test("renders Make your own map CTA linking to homepage", () => {
+test("does not render Make your own map CTA", () => {
   renderWithProviders(<SharedHeader />);
-  const cta = screen.getByRole("link", { name: /make your own map/i });
-  expect(cta).toHaveAttribute("href", "/");
+  expect(screen.queryByText(/make your own map/i)).not.toBeInTheDocument();
 });
 
 test("does not render Library link", () => {

--- a/frontend/src/pages/StoryReaderPage.tsx
+++ b/frontend/src/pages/StoryReaderPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useOptionalWorkspace } from "../hooks/useWorkspace";
 import { Box, Flex, Heading, Text } from "@chakra-ui/react";
-import { ArrowLeft, ArrowRight, SpinnerGap } from "@phosphor-icons/react";
+import { ArrowLeft, SpinnerGap } from "@phosphor-icons/react";
 import { StoryRenderer } from "../components/StoryRenderer";
 
 import { getStoryFromServer, migrateStory } from "../lib/story";
@@ -155,35 +155,12 @@ export default function StoryReaderPage({
           <Heading size="sm" fontWeight={600} color="gray.800">
             {story.title}
           </Heading>
-          {shared ? (
-            <Link to="/" style={{ textDecoration: "none", marginLeft: "auto" }}>
-              <Flex
-                align="center"
-                gap={1.5}
-                bg="brand.orange"
-                color="white"
-                px={3}
-                py={1}
-                borderRadius="4px"
-                fontWeight={600}
-                fontSize="xs"
-                _hover={{ bg: "brand.orangeHover" }}
-              >
-                Make your own map
-                <ArrowRight size={12} weight="bold" />
-              </Flex>
-            </Link>
-          ) : (
-            <>
-              <BugReportLink
-                storyId={story.id}
-                datasetIds={story.dataset_ids}
-              />
-              <Text ml="auto" fontSize="xs" color="gray.500">
-                Made with CNG Sandbox
-              </Text>
-            </>
+          {!shared && (
+            <BugReportLink storyId={story.id} datasetIds={story.dataset_ids} />
           )}
+          <Text ml="auto" fontSize="xs" color="gray.500">
+            Made with CNG Sandbox
+          </Text>
         </Flex>
       )}
 


### PR DESCRIPTION
## Summary

Makes shared `/map/:id` and `/story/:id` URLs accessible without the sandbox password, so a reader-only audience can view a map you share without hitting the basic-auth prompt. Upload and edit flows stay gated.

Three changes:

- **Q1 (CTA removed):** `SharedHeader` no longer renders the "Make your own map" button; `StoryReaderPage`'s shared-view CTA is gone too. Shared readers just see "Made with CNG Sandbox".
- **Q2 (logo/title unlinked):** `SharedHeader`'s logo+title are now static — no homepage link.
- **Q3 (auth rules relaxed):** `Caddyfile` swaps blanket basic_auth for a method/path matcher on `/api/*`. Writes (POST/PUT/PATCH/DELETE) and list endpoints (`GET /api/datasets`, `/api/connections`, `/api/stories`) still require auth. Individual resource reads (`GET /api/{datasets,connections,stories}/{id}`), `/api/proxy`, `/api/health`, tile paths (`/cog`, `/raster`, `/vector`), and frontend static files are now public.

## Security notes

- Anyone with a dataset/connection/story UUID can read it + its tiles. UUIDs are the only access barrier — fine for the "share a link" use case, risky for anything sensitive. Matches the existing model for `/api/connections/{id}/stream` and for `/storage/*` / `/pmtiles/*` (which were already unauthenticated for PMTiles range-request reasons).
- `/api/proxy` stays public; it already has SSRF protections (HTTPS-only, private-IP rejection, extension allowlist, 50MB cap) so the abuse surface is mostly bandwidth.
- Listing endpoints remain auth-gated so a random visitor can't enumerate datasets.

## Test plan

- [x] `npx vitest run` — 314 tests pass
- [x] `npx tsc --noEmit` clean
- [x] `caddy validate` on the new Caddyfile — valid
- [x] Playwright screenshot of `/map/:id` in shared mode — header renders with logo + title only, no links (accessibility snapshot confirms no link role)
- [ ] After merge + deploy: manually verify a shared map URL loads without a password prompt while `/` still prompts
- [ ] Manually verify upload still requires auth on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded public access: tiles, health/proxy endpoints, SPA/static frontend, and shared map/story reads load without authentication; workspace listings and write actions still require auth.

* **Refactor**
  * Simplified shared header and story reader header UI to show only logo/branding and fewer interactive links/CTA.

* **Documentation**
  * Deployment docs updated to explain the selective auth model and verification steps.

* **Tests**
  * Header tests adjusted to match the simplified, non-interactive header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->