### PR TITLE
fix(ingestion): migrate connections columns added by server-side GeoParquet work

### DIFF
--- a/ingestion/src/app.py
+++ b/ingestion/src/app.py
@@ -100,19 +100,34 @@ def _migrate_schema(engine):
     from sqlalchemy import text
     from sqlalchemy.exc import DBAPIError
 
+    def _is_duplicate_column(exc: DBAPIError) -> bool:
+        # PostgreSQL raises SQLSTATE 42701 (duplicate_column); SQLite and
+        # other dialects don't set pgcode, so fall back to matching the
+        # canonical "duplicate column" phrase in the driver message.
+        orig = getattr(exc, "orig", None)
+        if getattr(orig, "pgcode", None) == "42701":
+            return True
+        return "duplicate column" in str(orig).lower()
+
     with engine.connect() as conn:
         for col, typ in [
             ("band_count", "INTEGER"),
             ("rescale", "TEXT"),
             ("is_categorical", "BOOLEAN NOT NULL DEFAULT FALSE"),
             ("categories_json", "TEXT"),
+            ("tile_url", "TEXT"),
+            ("render_path", "TEXT"),
+            ("conversion_status", "TEXT"),
+            ("conversion_error", "TEXT"),
+            ("feature_count", "INTEGER"),
+            ("file_size", "BIGINT"),
         ]:
             try:
                 conn.execute(text(f"ALTER TABLE connections ADD COLUMN {col} {typ}"))
                 conn.commit()
             except DBAPIError as exc:
                 conn.rollback()
-                if getattr(getattr(exc, "orig", None), "pgcode", None) == "42701":
+                if _is_duplicate_column(exc):
                     continue
                 raise
         try:
@@ -120,7 +135,7 @@ def _migrate_schema(engine):
             conn.commit()
         except DBAPIError as exc:
             conn.rollback()
-            if getattr(getattr(exc, "orig", None), "pgcode", None) != "42701":
+            if not _is_duplicate_column(exc):
                 raise
         try:
             conn.execute(
@@ -132,7 +147,7 @@ def _migrate_schema(engine):
             conn.commit()
         except DBAPIError as exc:
             conn.rollback()
-            if getattr(getattr(exc, "orig", None), "pgcode", None) != "42701":
+            if not _is_duplicate_column(exc):
                 raise
 
 

--- a/ingestion/tests/test_schema_migration.py
+++ b/ingestion/tests/test_schema_migration.py
@@ -1,0 +1,66 @@
+from sqlalchemy import create_engine, inspect, text
+
+from src.app import _migrate_schema
+
+
+def _create_pre_ticket_b_schema(engine) -> None:
+    """Recreate the ``connections`` / ``datasets`` schema as it existed before
+    the server-side GeoParquet conversion columns (Ticket B) were added. This
+    mimics the drifted state of the deployed database."""
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE connections (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    url TEXT NOT NULL,
+                    connection_type TEXT NOT NULL,
+                    bounds_json TEXT,
+                    min_zoom INTEGER,
+                    max_zoom INTEGER,
+                    tile_type TEXT,
+                    band_count INTEGER,
+                    rescale TEXT,
+                    workspace_id TEXT,
+                    is_categorical BOOLEAN NOT NULL DEFAULT 0,
+                    categories_json TEXT,
+                    created_at TIMESTAMP NOT NULL
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE datasets (
+                    id TEXT PRIMARY KEY,
+                    name TEXT
+                )
+                """
+            )
+        )
+        conn.commit()
+
+
+def test_migrate_schema_adds_all_connection_conversion_columns(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'drift.db'}")
+    _create_pre_ticket_b_schema(engine)
+
+    _migrate_schema(engine)
+
+    inspector = inspect(engine)
+    columns = {c["name"] for c in inspector.get_columns("connections")}
+    # These are the columns introduced by the server-side GeoParquet
+    # conversion work that must be present for POST /api/connections to
+    # succeed against a pre-existing DB.
+    expected = {
+        "tile_url",
+        "render_path",
+        "conversion_status",
+        "conversion_error",
+        "feature_count",
+        "file_size",
+    }
+    missing = expected - columns
+    assert not missing, f"_migrate_schema failed to add columns: {missing}"


### PR DESCRIPTION
## Summary

`POST /api/connections` was failing on any database created before the Ticket B server-side GeoParquet pipeline (PR #227) landed:

```
sqlalchemy.exc.ProgrammingError: column "tile_url" of relation "connections" does not exist
```

`Base.metadata.create_all` only creates missing tables; it never adds columns to existing ones. The idempotent `_migrate_schema` ALTER-loop was the place to register the new columns (`tile_url`, `render_path`, `conversion_status`, `conversion_error`, `feature_count`, `file_size`) — but those were never added there when they were introduced on the model. This PR registers them.

Also generalizes the duplicate-column tolerance from a PostgreSQL-only `pgcode == "42701"` check to also match `"duplicate column"` in the driver message, so migrations are safe to exercise under SQLite in tests (and any other dialect).

## Test plan

- [x] New `tests/test_schema_migration.py` builds a pre-Ticket-B `connections` schema on SQLite, runs `_migrate_schema`, and asserts every server-side GeoParquet column is present — passes
- [x] `test_connections.py` / `test_models.py` / `test_datasets.py` — 51/51 pass
- [ ] After merge, bounce the ingestion container on the deployed DB so startup applies the ALTERs; retry the AI.parquet connect flow that previously returned `Failed to create connection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for schema migration validation, ensuring all required columns are properly created during database updates.

* **Bug Fixes**
  * Improved duplicate column error detection in schema migration, providing more reliable handling of column conflicts across database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->