### PR TITLE
fix(ingestion): add GDAL R2 endpoint env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,16 @@ On startup, the ingestion service runs a background task (`src/services/example_
 - Uses GDAL internally. GDAL < 3.11 requires `AWS_S3_ENDPOINT` (hostname:port without protocol) for S3 access, in addition to `AWS_ENDPOINT_URL`.
 - `AWS_VIRTUAL_HOSTING=FALSE` is required for R2 (path-style access).
 
+### GDAL + R2 env vars
+
+Any service that uses GDAL to read from R2 (the raster tiler, plus the ingestion service when reading COGs back during conversion) needs the same env-var set in `docker-compose.yml`:
+
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` — R2 credentials
+- `AWS_ENDPOINT_URL` — full R2 endpoint (`https://<account>.r2.cloudflarestorage.com`)
+- `AWS_S3_ENDPOINT` — hostname only (`<account>.r2.cloudflarestorage.com`), required by GDAL < 3.11
+- `AWS_HTTPS=YES`
+- `AWS_VIRTUAL_HOSTING=FALSE` — forces path-style URLs (required for R2)
+
 ## MCP Server
 
 A Model Context Protocol server that wraps the ingestion API, exposing datasets, stories, connections, and validation as composable tools for MCP-compatible agents (Claude Desktop, Claude Code, etc.). Source in `mcp/src/cng_mcp/`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,6 +147,10 @@ services:
       S3_ENDPOINT: ${R2_ENDPOINT}
       AWS_ACCESS_KEY_ID: ${R2_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY}
+      AWS_ENDPOINT_URL: ${R2_ENDPOINT}
+      AWS_S3_ENDPOINT: ${R2_ACCOUNT_ID}.r2.cloudflarestorage.com
+      AWS_HTTPS: "YES"
+      AWS_VIRTUAL_HOSTING: "FALSE"
       GDAL_CACHEMAX: "512"
       STAC_API_URL: http://stac-api:8080
       RASTER_TILER_URL: http://raster-tiler:80


### PR DESCRIPTION
## Summary
- Mirror the GDAL/AWS env vars from `raster-tiler` onto the `ingestion` service so rasterio can read COGs directly from R2 via `/vsis3/`.

## Problem
`POST /api/datasets/{id}/mark-categorical` returns 400 with a 403 from AWS S3 in the logs:

```
CPLE_AppDefined in HTTP response code on https://sandbox-data.s3.us-east-1.amazonaws.com/…: 403
```

The endpoint opens the raster via `/vsis3/<bucket>/<key>` to scan unique values. Without the R2 endpoint overrides, GDAL defaults to public AWS S3, which doesn't host the bucket and returns 403. `rasterio.errors.RasterioIOError` is then mapped to a 400.

## Fix
Add the same four env vars already set on `raster-tiler`:
- `AWS_ENDPOINT_URL`
- `AWS_S3_ENDPOINT`
- `AWS_HTTPS=YES`
- `AWS_VIRTUAL_HOSTING=FALSE`

## Test plan
- [ ] Rebuild + restart ingestion: `scripts/worktree-stack.sh up`
- [ ] Upload or pick an existing integer-dtype raster with <30 unique values
- [ ] Click "Mark as categorical" → expect success (categories populated), no 400
- [ ] Verify ingestion logs no longer show `sandbox-data.s3.us-east-1.amazonaws.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Cloudflare R2 configuration with GDAL, including required environment variables and version-specific settings for S3-compatible path-style access.

* **Chores**
  * Updated ingestion service configuration with additional R2/S3 environment variables for proper connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->