### PR TITLE
fix(frontend): tighten COG reprojection mesh at low zoom

### DIFF
--- a/frontend/src/lib/layers/cogLayer.ts
+++ b/frontend/src/lib/layers/cogLayer.ts
@@ -135,6 +135,7 @@ export function buildCogLayerPaletted({
         id: "direct-cog-layer-paletted",
         geotiff: url,
         opacity,
+        maxError: 0.03,
       } as any),
     ];
     /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -231,6 +232,7 @@ export function buildCogLayerPaletted({
       opacity,
       getTileData,
       renderTile,
+      maxError: 0.03,
     } as any),
   ];
   /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -348,6 +350,7 @@ export function buildCogLayerContinuous({
       opacity,
       getTileData,
       renderTile,
+      maxError: 0.03,
     } as any),
   ];
   /* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
## Summary

Hypothesis-fix for the offset seen on the UK soil types dataset at zoom 5:

- Dataset: EPSG:4326 COG, bounds [-9.35, 49.77, 2.79, 60.95], rendered via client path (`buildCogLayerPaletted` → `@developmentseed/deck.gl-geotiff` COGLayer).
- Symptom (see screenshot on the issue): raster blob noticeably offset/stretched vs the basemap at zoom 5, aligns better as you zoom in.

The library reprojects EPSG:4326 COGs into Web Mercator using a refined triangle mesh controlled by the `maxError` prop (default **0.125 px**). At UK latitudes (~55°N) Mercator stretches ~1.7× in the north-south direction, so a coarse mesh produces visible misregistration at low zoom.

This PR passes `maxError: 0.03` to every `COGLayer` we instantiate — roughly 4× more triangles → much tighter fit with a small memory/CPU cost.

## Test plan

- [ ] Pull branch locally, run `cd frontend && yarn dev --port 5285` (or use the worktree stack).
- [ ] Open the UK soil types map with client-side rendering **on** — confirm the raster is aligned to the basemap at zoom 5 (previously offset).
- [ ] Zoom in and out — alignment should hold across zooms.
- [ ] Smoke-test a temporal dataset / COG connection to confirm no regression.
- [ ] If it doesn't fix the offset, the cause is elsewhere (possible alternates: custom `getTileData` not returning `forwardTransform`/`inverseTransform`; source-file georeference; `localEpsgResolver` never wired in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced COG layer rendering with optimized error tolerance configuration across paletted and continuous layer types for improved visual quality and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->