### PR TITLE
fix(caddy): security headers + cacheable tile responses (#232 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ docker compose --profile prod up -d --build
 - `docker compose up` (without `--profile prod`) still runs local dev without Caddy
 - Backend service ports (8081-8086) are accessible on localhost via SSH tunnel but blocked externally by the Hetzner firewall
 - The `caddy_data` volume persists TLS certificates — don't delete it or you'll hit Let's Encrypt rate limits
+- Caddy applies baseline security headers to every response (HSTS, CSP, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`). The CSP allows `'wasm-unsafe-eval'` for DuckDB-WASM and is permissive on `connect-src`/`img-src` to accommodate user-supplied tile URLs and the CARTO basemap
+- Tile responses (`/cog/*`, `/raster/*`, `/vector/*`) are served with `Cache-Control: public, max-age=3600`. Tile URLs are immutable per dataset (a change to the underlying data produces a new STAC item id or query param), so a 1-hour browser cache is safe and reduces Hetzner egress
 
 ## CI/CD
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,18 @@
 {$SITE_ADDRESS} {
+	# Baseline security headers applied to every response. HSTS is safe to
+	# enable globally because Caddy auto-redirects HTTP→HTTPS. The CSP is
+	# permissive on connect-src/img-src because the app fetches user-supplied
+	# tile URLs (XYZ, COG, PMTiles, GeoParquet) and basemap styles from
+	# basemaps.cartocdn.com; it locks down script-src/object-src/frame-ancestors
+	# to defend against XSS and clickjacking. wasm-unsafe-eval is required by
+	# DuckDB-WASM (GeoParquet client renderer).
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https: blob:; worker-src 'self' blob:; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
+	}
+
 	# Data-serving paths: proxy to R2 public URL. Public — range requests
 	# from PMTiles / DuckDB WASM can't carry Basic Auth credentials.
 	handle /storage/* {
@@ -25,23 +39,26 @@
 
 	# Tile endpoints — public. Shared /map and /story views need to fetch
 	# tiles without auth. Write operations aren't exposed here (GET-only).
+	# Tiles are immutable per URL (URL changes when the underlying dataset
+	# changes via STAC item id or query params), so a 1-hour browser cache
+	# is safe and avoids burning Hetzner egress on repeat visits.
 	handle /cog/* {
 		reverse_proxy cog-tiler:80 {
-			header_down Cache-Control "no-store"
+			header_down Cache-Control "public, max-age=3600"
 		}
 	}
 
 	handle /raster/* {
 		uri strip_prefix /raster
 		reverse_proxy raster-tiler:80 {
-			header_down Cache-Control "no-store"
+			header_down Cache-Control "public, max-age=3600"
 		}
 	}
 
 	handle /vector/* {
 		uri strip_prefix /vector
 		reverse_proxy vector-tiler:80 {
-			header_down Cache-Control "no-store"
+			header_down Cache-Control "public, max-age=3600"
 		}
 	}
 


### PR DESCRIPTION
## Summary

Closes the four Low-severity findings from #232 that live in the Caddyfile:

- **Security headers**: HSTS, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, and a baseline CSP. CSP locks down `script-src`/`object-src`/`frame-ancestors` (XSS + clickjacking defence) while staying permissive on `connect-src`/`img-src`/`style-src` so user-supplied tile URLs (XYZ, COG, PMTiles, GeoParquet), CartoCDN basemaps, and Chakra UI's emotion-injected styles still work. `wasm-unsafe-eval` is included for DuckDB-WASM.
- **Tile cache**: switch `/cog/*`, `/raster/*`, `/vector/*` from `Cache-Control: no-store` to `public, max-age=3600`. Tile URLs are immutable per dataset, so browser/CDN caching is safe and saves Hetzner egress on repeat visits.

Deferred (called out in the issue as Low):

- **Rate limiting** — needs the `caddy-ratelimit` 3rd-party plugin, which means building a custom Caddy image. Low ROI for the current single-credential deployment; revisit if traffic justifies.
- **Brute-force protection on Basic Auth** — issue itself notes this is "Low risk while there's one shared credential". `fail2ban` would be a host-level change outside the compose stack.

After this lands, #232 has only the two deferred items remaining.

## Test plan

- [x] `caddy validate` passes
- [ ] Deploy to staging/prod and verify the SPA still loads (CSP can break things subtly)
- [ ] Confirm `Strict-Transport-Security` and `Content-Security-Policy` headers appear in browser DevTools
- [ ] Confirm a tile request returns `Cache-Control: public, max-age=3600`
- [ ] Verify CartoCDN basemap, /storage/* PMTiles, and /api/proxy COGs all still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Tile endpoints now utilize browser caching with a 1-hour TTL, reducing load times for repeated tile access.

* **Security Enhancements**
  * Added comprehensive security headers across all requests, including strict transport, referrer protections, and content security policies.

* **Documentation**
  * Updated deployment notes to document security headers and tile caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->