### PR TITLE
feat(frontend): source.coop-styled /discover catalog demo

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,8 @@ import StoryReaderPage from "./pages/StoryReaderPage";
 import StoryEditorPage from "./pages/StoryEditorPage";
 import StoryEmbedPage from "./pages/StoryEmbedPage";
 import AboutPage from "./pages/AboutPage";
+import DiscoverPage from "./pages/DiscoverPage";
+import DiscoverDatasetPage from "./pages/DiscoverDatasetPage";
 import { WelcomeToast } from "./components/WelcomeToast";
 
 function StoryReaderRedirect() {
@@ -39,6 +41,11 @@ function WorkspaceRoutes() {
         <Route path="/story/:id" element={<StoryReaderRedirect />} />
         <Route path="/story/:id/edit" element={<StoryEditorPage />} />
         <Route path="/about" element={<AboutPage />} />
+        <Route path="/discover" element={<DiscoverPage />} />
+        <Route
+          path="/discover/:org/:name"
+          element={<DiscoverDatasetPage />}
+        />
       </Routes>
     </WorkspaceProvider>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,10 +42,7 @@ function WorkspaceRoutes() {
         <Route path="/story/:id/edit" element={<StoryEditorPage />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="/discover" element={<DiscoverPage />} />
-        <Route
-          path="/discover/:org/:name"
-          element={<DiscoverDatasetPage />}
-        />
+        <Route path="/discover/:org/:name" element={<DiscoverDatasetPage />} />
       </Routes>
     </WorkspaceProvider>
   );

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -54,6 +54,19 @@ export function Header({ children, showWorkspace = true }: HeaderProps) {
             </Text>
           </Flex>
         </Link>
+        <Link
+          to={workspacePath("/discover")}
+          style={{ textDecoration: "none" }}
+        >
+          <Text
+            fontSize="sm"
+            fontWeight={500}
+            color="gray.600"
+            _hover={{ color: "gray.800" }}
+          >
+            Discover
+          </Text>
+        </Link>
         <Link to={workspacePath("/library")} style={{ textDecoration: "none" }}>
           <Text
             fontSize="sm"

--- a/frontend/src/components/discover/DiscoverHeader.tsx
+++ b/frontend/src/components/discover/DiscoverHeader.tsx
@@ -33,7 +33,11 @@ export function DiscoverHeader() {
               letterSpacing="-0.02em"
               fontFamily="Georgia, serif"
             >
-              source<Text as="span" color="#c44a2a">.</Text>coop
+              source
+              <Text as="span" color="#c44a2a">
+                .
+              </Text>
+              coop
             </Text>
             <Text
               fontSize="11px"
@@ -58,11 +62,7 @@ export function DiscoverHeader() {
             </Text>
           </Link>
           <Link to={workspacePath("/")} style={{ textDecoration: "none" }}>
-            <Text
-              fontSize="14px"
-              color={TEXT_MUTED}
-              _hover={{ color: TEXT }}
-            >
+            <Text fontSize="14px" color={TEXT_MUTED} _hover={{ color: TEXT }}>
               Contribute
             </Text>
           </Link>
@@ -70,11 +70,7 @@ export function DiscoverHeader() {
             to={workspacePath("/library")}
             style={{ textDecoration: "none" }}
           >
-            <Text
-              fontSize="14px"
-              color={TEXT_MUTED}
-              _hover={{ color: TEXT }}
-            >
+            <Text fontSize="14px" color={TEXT_MUTED} _hover={{ color: TEXT }}>
               Your workspace
             </Text>
           </Link>

--- a/frontend/src/components/discover/DiscoverHeader.tsx
+++ b/frontend/src/components/discover/DiscoverHeader.tsx
@@ -1,0 +1,92 @@
+import { Flex, Text } from "@chakra-ui/react";
+import { Link } from "react-router-dom";
+import { useWorkspace } from "../../hooks/useWorkspace";
+
+const BORDER = "#e8e6e1";
+const TEXT = "#1a1a1a";
+const TEXT_MUTED = "#6b6b68";
+
+export function DiscoverHeader() {
+  const { workspacePath } = useWorkspace();
+
+  return (
+    <Flex
+      as="header"
+      align="center"
+      justify="space-between"
+      px={6}
+      py={3}
+      bg="white"
+      borderBottom="1px solid"
+      borderColor={BORDER}
+    >
+      <Flex align="center" gap={8}>
+        <Link
+          to={workspacePath("/discover")}
+          style={{ textDecoration: "none" }}
+        >
+          <Flex align="center" gap={2}>
+            <Text
+              fontSize="18px"
+              fontWeight={700}
+              color={TEXT}
+              letterSpacing="-0.02em"
+              fontFamily="Georgia, serif"
+            >
+              source<Text as="span" color="#c44a2a">.</Text>coop
+            </Text>
+            <Text
+              fontSize="11px"
+              color={TEXT_MUTED}
+              fontFamily="SFMono-Regular, Consolas, monospace"
+              ml={2}
+              pl={2}
+              borderLeft="1px solid"
+              borderColor={BORDER}
+            >
+              × CNG Sandbox
+            </Text>
+          </Flex>
+        </Link>
+        <Flex gap={6}>
+          <Link
+            to={workspacePath("/discover")}
+            style={{ textDecoration: "none" }}
+          >
+            <Text fontSize="14px" color={TEXT} _hover={{ color: "#c44a2a" }}>
+              Discover
+            </Text>
+          </Link>
+          <Link to={workspacePath("/")} style={{ textDecoration: "none" }}>
+            <Text
+              fontSize="14px"
+              color={TEXT_MUTED}
+              _hover={{ color: TEXT }}
+            >
+              Contribute
+            </Text>
+          </Link>
+          <Link
+            to={workspacePath("/library")}
+            style={{ textDecoration: "none" }}
+          >
+            <Text
+              fontSize="14px"
+              color={TEXT_MUTED}
+              _hover={{ color: TEXT }}
+            >
+              Your workspace
+            </Text>
+          </Link>
+        </Flex>
+      </Flex>
+      <Text
+        fontSize="11px"
+        color={TEXT_MUTED}
+        fontFamily="SFMono-Regular, Consolas, monospace"
+      >
+        demo
+      </Text>
+    </Flex>
+  );
+}

--- a/frontend/src/lib/discoverCatalog.ts
+++ b/frontend/src/lib/discoverCatalog.ts
@@ -1,0 +1,324 @@
+/**
+ * Mock source.coop catalog used by /discover demo pages.
+ *
+ * Entries with `supported: true` correspond to curated products registered on
+ * the backend (`is_example=True` datasets). The discover detail page resolves
+ * these to a real dataset id at runtime so "Visualize in sandbox" deep-links
+ * to the map page. Unsupported entries are browse-only and link out to
+ * source.coop.
+ */
+
+export interface CatalogFile {
+  path: string;
+  size: string;
+}
+
+export interface CatalogEntry {
+  slug: string;
+  org: string;
+  name: string;
+  title: string;
+  tagline: string;
+  description: string;
+  readme: string;
+  tags: string[];
+  license: string;
+  updated: string;
+  thumbnail: string;
+  supported: boolean;
+  externalUrl: string;
+  files: CatalogFile[];
+}
+
+const GHRSST_README = `## Overview
+
+The Multi-scale Ultra-high Resolution (MUR) Sea Surface Temperature (SST) analysis
+is a daily, gap-free, global 0.01° product produced by JPL PO.DAAC. Data are
+foundation-level SST derived from multiple satellite instruments and \`in-situ\`
+observations.
+
+## Contents
+
+The 2024 subset published here comprises 366 daily COGs covering the full globe,
+each accompanied by a STAC Item sidecar. Files are stored as cloud-optimized
+GeoTIFFs on Cloudflare R2 and are directly tileable from this archive.
+
+## Citation
+
+JPL MUR MEaSUREs Project. 2015. GHRSST Level 4 MUR Global Foundation Sea Surface
+Temperature Analysis. Ver. 4.1. PO.DAAC, CA, USA.`;
+
+const GEBCO_README = `## Overview
+
+The General Bathymetric Chart of the Oceans (GEBCO) is a publicly available
+global terrain model for ocean and land at 15 arc-second intervals. The 2024
+release reflects the TID-flag and source-data updates incorporated by BODC.
+
+## Contents
+
+A single global COG (~12.8 GB at native resolution) with over/underviews at
+consistent levels. Suitable for global ocean-floor visualization at web scale.
+
+## License
+
+Released under the GEBCO data policy (CC-BY equivalent attribution). See the
+GEBCO website for full terms.`;
+
+const CARBON_README = `## Overview
+
+Gross annual carbon emissions from deforestation, 2001–2023, produced by the
+WRI Land & Carbon Lab. The headline emissions raster is pinned here for the
+visualization sandbox — the source bucket contains an atlas of related layers
+(forest loss drivers, above-ground biomass, peatland carbon).
+
+## Contents
+
+A single 100-meter resolution COG covering the tropics. Values are tCO₂e /
+pixel / year, summed across the full time series.
+
+## License
+
+Creative Commons Attribution 4.0 International (CC-BY-4.0). Please cite as
+Harris et al. 2021.`;
+
+const HLS_README = `## Overview
+
+Harmonized Landsat Sentinel-2 (HLS) provides surface reflectance from Landsat
+8/9 OLI and Sentinel-2 MSI sensors, harmonized to a common spatial (30 m) and
+radiometric reference. NASA LP DAAC processes these data operationally.
+
+## Contents
+
+Daily 30 m COGs, tiled on the MGRS grid. This subset is a regional cut
+organized by year and tile, with STAC sidecars.`;
+
+const OVERTURE_README = `## Overview
+
+Overture Maps Foundation's \`places\` theme: a global point dataset of named
+places-of-interest assembled from open and member-contributed sources.
+
+## Contents
+
+Monthly GeoParquet snapshots, partitioned by H3 cell. The theme totals ~60M
+features globally.`;
+
+const FIELDS_README = `## Overview
+
+Fields2030 from fiboa is a cross-country, harmonized field-boundary dataset
+intended as a shared reference for agricultural analytics at continental scale.`;
+
+const USDA_README = `## Overview
+
+The USDA Cropland Data Layer (CDL) provides an annual 30 m raster of cultivated
+crops across the conterminous United States.`;
+
+const NASA_VIIRS_README = `## Overview
+
+Visible Infrared Imaging Radiometer Suite (VIIRS) nighttime lights: monthly
+composites of radiance-calibrated stray-light-corrected at-sensor radiance.`;
+
+const USGS_DEM_README = `## Overview
+
+USGS 3D Elevation Program (3DEP) 1/3 arc-second DEM — the canonical elevation
+product for the conterminous United States, provided as mosaicked COGs.`;
+
+export const discoverCatalog: CatalogEntry[] = [
+  {
+    slug: "ausantarctic/ghrsst-mur-v2",
+    org: "ausantarctic",
+    name: "ghrsst-mur-v2",
+    title: "GHRSST MUR v2 — Daily SST (2024)",
+    tagline: "Daily gap-free global sea surface temperature, 0.01° resolution.",
+    description:
+      "Multi-scale Ultra-high Resolution sea surface temperature analysis, daily global coverage. This subset shows the 2024 daily series (366 days) as cloud-optimized GeoTIFFs.",
+    readme: GHRSST_README,
+    tags: ["ocean", "temperature", "temporal", "cog", "stac"],
+    license: "Public domain (NASA JPL)",
+    updated: "2025-01-14",
+    thumbnail: "/thumbnails/ghrsst.jpg",
+    supported: true,
+    externalUrl: "https://source.coop/ausantarctic/ghrsst-mur-v2",
+    files: [
+      { path: "2024/001/mur_20240101_sst.tif", size: "438 MB" },
+      { path: "2024/001/mur_20240101_sst.json", size: "3.1 KB" },
+      { path: "2024/002/mur_20240102_sst.tif", size: "441 MB" },
+      { path: "…", size: "" },
+      { path: "2024/366/mur_20241231_sst.tif", size: "439 MB" },
+    ],
+  },
+  {
+    slug: "alexgleith/gebco-2024",
+    org: "alexgleith",
+    name: "gebco-2024",
+    title: "GEBCO 2024 Bathymetry",
+    tagline: "Global ocean-floor and land terrain model, 15 arc-second grid.",
+    description:
+      "Global ocean and land terrain model from the General Bathymetric Chart of the Oceans, 2024 release.",
+    readme: GEBCO_README,
+    tags: ["bathymetry", "terrain", "global", "cog"],
+    license: "CC-BY 4.0",
+    updated: "2024-07-02",
+    thumbnail: "/thumbnails/gebco.jpg",
+    supported: true,
+    externalUrl: "https://source.coop/alexgleith/gebco-2024",
+    files: [
+      { path: "gebco_2024_cog.tif", size: "12.8 GB" },
+      { path: "README.md", size: "4.2 KB" },
+    ],
+  },
+  {
+    slug: "vizzuality/lg-land-carbon-data",
+    org: "vizzuality",
+    name: "lg-land-carbon-data",
+    title: "Land & Carbon Lab: Deforestation Carbon Emissions",
+    tagline: "Gross emissions from deforestation, 100 m, 2001–2023.",
+    description:
+      "Gross carbon emissions from deforestation at 100 m resolution, produced by the WRI Land & Carbon Lab.",
+    readme: CARBON_README,
+    tags: ["carbon", "deforestation", "climate", "cog"],
+    license: "CC-BY 4.0",
+    updated: "2024-11-20",
+    thumbnail: "/thumbnails/lg-land-carbon.jpg",
+    supported: true,
+    externalUrl: "https://source.coop/vizzuality/lg-land-carbon-data",
+    files: [
+      { path: "deforest_carbon_100m_cog.tif", size: "8.4 GB" },
+      { path: "atlas/forest_loss_driver.tif", size: "2.1 GB" },
+      { path: "atlas/biomass_agb.tif", size: "5.7 GB" },
+    ],
+  },
+  {
+    slug: "nasa/hls",
+    org: "nasa",
+    name: "hls",
+    title: "HLS — Harmonized Landsat Sentinel-2",
+    tagline: "Daily 30 m surface reflectance, Landsat + Sentinel-2 harmonized.",
+    description:
+      "Harmonized Landsat Sentinel-2 surface reflectance, 30 m, tiled on the MGRS grid with STAC sidecars. Operational NASA LP DAAC product.",
+    readme: HLS_README,
+    tags: ["imagery", "optical", "temporal", "stac", "cog"],
+    license: "NASA public data",
+    updated: "2025-02-03",
+    thumbnail: "/thumbnails/ghrsst.jpg",
+    supported: false,
+    externalUrl: "https://source.coop/nasa/hls",
+    files: [
+      { path: "2024/T15TWK/HLS.S30.T15TWK.2024365.v2.0.B04.tif", size: "68 MB" },
+      { path: "2024/T15TWK/HLS.S30.T15TWK.2024365.v2.0.B08.tif", size: "68 MB" },
+      { path: "…", size: "" },
+    ],
+  },
+  {
+    slug: "overturemaps/places",
+    org: "overturemaps",
+    name: "places",
+    title: "Overture Maps — Places",
+    tagline: "60M global points of interest, monthly GeoParquet release.",
+    description:
+      "Overture Maps Foundation's places theme: a global point dataset of named POIs assembled from open and member-contributed sources. Monthly snapshots in GeoParquet.",
+    readme: OVERTURE_README,
+    tags: ["vector", "pois", "geoparquet", "global"],
+    license: "ODbL / CDLA-P 2.0",
+    updated: "2025-03-12",
+    thumbnail: "/thumbnails/gebco.jpg",
+    supported: false,
+    externalUrl: "https://source.coop/overturemaps/places",
+    files: [
+      { path: "release=2025-03-12/theme=places/type=place/part-00000.parquet", size: "412 MB" },
+      { path: "release=2025-03-12/theme=places/type=place/part-00001.parquet", size: "408 MB" },
+      { path: "…", size: "" },
+    ],
+  },
+  {
+    slug: "fiboa/fields2030",
+    org: "fiboa",
+    name: "fields2030",
+    title: "Fields2030 — Harmonized Field Boundaries",
+    tagline: "Cross-country harmonized agricultural field polygons.",
+    description:
+      "A shared reference dataset of field boundaries spanning multiple national programs, released under the fiboa schema as GeoParquet.",
+    readme: FIELDS_README,
+    tags: ["vector", "agriculture", "geoparquet"],
+    license: "CC-BY 4.0",
+    updated: "2025-01-28",
+    thumbnail: "/thumbnails/lg-land-carbon.jpg",
+    supported: false,
+    externalUrl: "https://source.coop/fiboa/fields2030",
+    files: [
+      { path: "country=us/year=2024/part-00000.parquet", size: "1.1 GB" },
+      { path: "country=fr/year=2024/part-00000.parquet", size: "620 MB" },
+      { path: "country=de/year=2024/part-00000.parquet", size: "840 MB" },
+    ],
+  },
+  {
+    slug: "usda/cdl",
+    org: "usda",
+    name: "cdl",
+    title: "USDA Cropland Data Layer",
+    tagline: "Annual 30 m CONUS crop-type raster, 1997–present.",
+    description:
+      "The Cropland Data Layer (CDL) is a raster, geo-referenced, crop-specific land-cover map for the continental United States.",
+    readme: USDA_README,
+    tags: ["agriculture", "categorical", "cog", "conus"],
+    license: "Public domain (USDA NASS)",
+    updated: "2024-02-15",
+    thumbnail: "/thumbnails/gebco.jpg",
+    supported: false,
+    externalUrl: "https://source.coop/usda/cdl",
+    files: [
+      { path: "2024/cdl_2024_conus.tif", size: "2.3 GB" },
+      { path: "2023/cdl_2023_conus.tif", size: "2.2 GB" },
+      { path: "…", size: "" },
+    ],
+  },
+  {
+    slug: "nasa/viirs-nightlights",
+    org: "nasa",
+    name: "viirs-nightlights",
+    title: "VIIRS Black Marble — Monthly Nighttime Lights",
+    tagline: "Stray-light-corrected nighttime radiance composites.",
+    description:
+      "Monthly VIIRS DNB composites, atmospherically and stray-light-corrected, provided as 500 m COGs. Useful for economic activity, conflict, and grid-resilience analysis.",
+    readme: NASA_VIIRS_README,
+    tags: ["imagery", "nighttime", "temporal", "cog"],
+    license: "NASA public data",
+    updated: "2025-03-01",
+    thumbnail: "/thumbnails/ghrsst.jpg",
+    supported: false,
+    externalUrl: "https://source.coop/nasa/viirs-nightlights",
+    files: [
+      { path: "2025/03/viirs_ntl_2025_03.tif", size: "1.4 GB" },
+      { path: "2025/02/viirs_ntl_2025_02.tif", size: "1.4 GB" },
+      { path: "…", size: "" },
+    ],
+  },
+  {
+    slug: "usgs/3dep-dem",
+    org: "usgs",
+    name: "3dep-dem",
+    title: "USGS 3DEP — 1/3 arc-second DEM",
+    tagline: "Canonical CONUS elevation, ~10 m ground sample distance.",
+    description:
+      "USGS 3DEP 1/3 arc-second digital elevation model for the conterminous United States, served as mosaicked COGs.",
+    readme: USGS_DEM_README,
+    tags: ["terrain", "elevation", "cog", "conus"],
+    license: "Public domain (USGS)",
+    updated: "2024-10-04",
+    thumbnail: "/thumbnails/lg-land-carbon.jpg",
+    supported: false,
+    externalUrl: "https://source.coop/usgs/3dep-dem",
+    files: [
+      { path: "n40w090/usgs_ned_13_n40w090.tif", size: "420 MB" },
+      { path: "n40w089/usgs_ned_13_n40w089.tif", size: "418 MB" },
+      { path: "…", size: "" },
+    ],
+  },
+];
+
+export function getCatalogEntry(slug: string): CatalogEntry | undefined {
+  return discoverCatalog.find((e) => e.slug === slug);
+}
+
+export function listingUrlForSlug(slug: string): string {
+  return `https://data.source.coop/${slug}/`;
+}

--- a/frontend/src/lib/discoverCatalog.ts
+++ b/frontend/src/lib/discoverCatalog.ts
@@ -203,8 +203,14 @@ export const discoverCatalog: CatalogEntry[] = [
     supported: false,
     externalUrl: "https://source.coop/nasa/hls",
     files: [
-      { path: "2024/T15TWK/HLS.S30.T15TWK.2024365.v2.0.B04.tif", size: "68 MB" },
-      { path: "2024/T15TWK/HLS.S30.T15TWK.2024365.v2.0.B08.tif", size: "68 MB" },
+      {
+        path: "2024/T15TWK/HLS.S30.T15TWK.2024365.v2.0.B04.tif",
+        size: "68 MB",
+      },
+      {
+        path: "2024/T15TWK/HLS.S30.T15TWK.2024365.v2.0.B08.tif",
+        size: "68 MB",
+      },
       { path: "…", size: "" },
     ],
   },
@@ -224,8 +230,14 @@ export const discoverCatalog: CatalogEntry[] = [
     supported: false,
     externalUrl: "https://source.coop/overturemaps/places",
     files: [
-      { path: "release=2025-03-12/theme=places/type=place/part-00000.parquet", size: "412 MB" },
-      { path: "release=2025-03-12/theme=places/type=place/part-00001.parquet", size: "408 MB" },
+      {
+        path: "release=2025-03-12/theme=places/type=place/part-00000.parquet",
+        size: "412 MB",
+      },
+      {
+        path: "release=2025-03-12/theme=places/type=place/part-00001.parquet",
+        size: "408 MB",
+      },
       { path: "…", size: "" },
     ],
   },

--- a/frontend/src/pages/DiscoverDatasetPage.tsx
+++ b/frontend/src/pages/DiscoverDatasetPage.tsx
@@ -1,0 +1,401 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { Box, Flex, Heading, Text } from "@chakra-ui/react";
+import { ArrowSquareOut, MapTrifold, Upload } from "@phosphor-icons/react";
+import { useWorkspace } from "../hooks/useWorkspace";
+import { workspaceFetch } from "../lib/api";
+import { config } from "../config";
+import type { Dataset } from "../types";
+import { getCatalogEntry, listingUrlForSlug } from "../lib/discoverCatalog";
+import { DiscoverHeader } from "../components/discover/DiscoverHeader";
+
+const PAGE_BG = "#fafaf8";
+const BORDER = "#e8e6e1";
+const TEXT = "#1a1a1a";
+const TEXT_MUTED = "#6b6b68";
+const ACCENT = "#1a3a5c";
+const MONO = "SFMono-Regular, Consolas, monospace";
+
+export default function DiscoverDatasetPage() {
+  const { org, name } = useParams<{ org: string; name: string }>();
+  const navigate = useNavigate();
+  const { workspacePath } = useWorkspace();
+  const slug = `${org}/${name}`;
+  const entry = useMemo(() => getCatalogEntry(slug), [slug]);
+
+  const [datasets, setDatasets] = useState<Dataset[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    workspaceFetch(`${config.apiBase}/api/datasets`)
+      .then((r) => r.json())
+      .then((data) => {
+        setDatasets(Array.isArray(data) ? data : []);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  if (!entry) {
+    return (
+      <Box minH="100vh" bg={PAGE_BG} color={TEXT}>
+        <DiscoverHeader />
+        <Box maxW="1100px" mx="auto" px={6} py={16} textAlign="center">
+          <Heading fontSize="28px" fontWeight={600} mb={2}>
+            Product not found
+          </Heading>
+          <Text color={TEXT_MUTED} mb={6}>
+            <Text as="span" fontFamily={MONO}>
+              {slug}
+            </Text>{" "}
+            isn't in the discover catalog.
+          </Text>
+          <Link
+            to={workspacePath("/discover")}
+            style={{ color: ACCENT, textDecoration: "underline" }}
+          >
+            Back to discover
+          </Link>
+        </Box>
+      </Box>
+    );
+  }
+
+  const matched = datasets.find(
+    (d) =>
+      d.is_example &&
+      (d as Dataset & { source_url?: string }).source_url ===
+        listingUrlForSlug(entry.slug)
+  );
+  const datasetId = matched?.id;
+  const ready = Boolean(datasetId);
+
+  const onVisualize = () => {
+    if (!datasetId) return;
+    navigate(workspacePath(`/map/${datasetId}`));
+  };
+
+  return (
+    <Box minH="100vh" bg={PAGE_BG} color={TEXT}>
+      <DiscoverHeader />
+
+      <Box maxW="1100px" mx="auto" px={6} pt={8} pb={20}>
+        <Text fontSize="12px" fontFamily={MONO} color={TEXT_MUTED} mb={6}>
+          <Link
+            to={workspacePath("/discover")}
+            style={{ color: TEXT_MUTED, textDecoration: "underline" }}
+          >
+            discover
+          </Link>{" "}
+          / {entry.org} /{" "}
+          <Text as="span" color={TEXT}>
+            {entry.name}
+          </Text>
+        </Text>
+
+        <Flex align="flex-start" gap={3} mb={2}>
+          <Heading
+            as="h1"
+            fontSize={{ base: "28px", md: "34px" }}
+            fontWeight={600}
+            letterSpacing="-0.02em"
+            lineHeight={1.2}
+            color={TEXT}
+            flex="1"
+          >
+            {entry.title}
+          </Heading>
+        </Flex>
+
+        <Text
+          fontSize="17px"
+          color={TEXT_MUTED}
+          lineHeight={1.55}
+          maxW="720px"
+          mb={5}
+        >
+          {entry.tagline}
+        </Text>
+
+        <Flex
+          gap={4}
+          wrap="wrap"
+          align="center"
+          pb={5}
+          mb={8}
+          borderBottom="1px solid"
+          borderColor={BORDER}
+          fontFamily={MONO}
+          fontSize="12px"
+          color={TEXT_MUTED}
+        >
+          <Text>
+            org · <Text as="span" color={TEXT}>{entry.org}</Text>
+          </Text>
+          <Text>
+            license · <Text as="span" color={TEXT}>{entry.license}</Text>
+          </Text>
+          <Text>
+            updated · <Text as="span" color={TEXT}>{entry.updated}</Text>
+          </Text>
+          <Flex gap={1.5} wrap="wrap">
+            {entry.tags.map((t) => (
+              <Text
+                key={t}
+                border="1px solid"
+                borderColor={BORDER}
+                px={1.5}
+                py={0.5}
+                borderRadius="2px"
+                color={TEXT_MUTED}
+              >
+                {t}
+              </Text>
+            ))}
+          </Flex>
+        </Flex>
+
+        <Flex gap={8} direction={{ base: "column", md: "row" }}>
+          <Box flex="1" minW={0}>
+            <ReadmeBlock content={entry.readme} />
+
+            <Box mt={10}>
+              <Text
+                fontSize="12px"
+                fontWeight={600}
+                letterSpacing="0.08em"
+                textTransform="uppercase"
+                color={TEXT_MUTED}
+                mb={3}
+                pb={2}
+                borderBottom="1px solid"
+                borderColor={BORDER}
+              >
+                Files
+              </Text>
+              {entry.files.map((f, i) => (
+                <Flex
+                  key={i}
+                  justify="space-between"
+                  py={2}
+                  borderBottom="1px solid"
+                  borderColor={BORDER}
+                  fontFamily={MONO}
+                  fontSize="13px"
+                >
+                  <Text color={f.path === "…" ? TEXT_MUTED : TEXT}>
+                    {f.path}
+                  </Text>
+                  <Text color={TEXT_MUTED}>{f.size}</Text>
+                </Flex>
+              ))}
+            </Box>
+          </Box>
+
+          <Box w={{ base: "100%", md: "300px" }} flexShrink={0}>
+            <Box
+              bg="white"
+              border="1px solid"
+              borderColor={BORDER}
+              borderRadius="4px"
+              p={4}
+              position="sticky"
+              top={4}
+            >
+              <Text
+                fontSize="11px"
+                fontWeight={600}
+                letterSpacing="0.08em"
+                textTransform="uppercase"
+                color={TEXT_MUTED}
+                mb={3}
+              >
+                Actions
+              </Text>
+
+              {entry.supported ? (
+                <Box
+                  as="button"
+                  onClick={onVisualize}
+                  disabled={!ready}
+                  w="100%"
+                  bg={ready ? TEXT : "#d0d0cc"}
+                  color="white"
+                  borderRadius="3px"
+                  py={2.5}
+                  px={3}
+                  fontSize="13px"
+                  fontWeight={600}
+                  cursor={ready ? "pointer" : "not-allowed"}
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  gap={2}
+                  mb={2}
+                  transition="background 120ms ease"
+                  _hover={ready ? { bg: ACCENT } : undefined}
+                >
+                  <MapTrifold size={16} weight="bold" />
+                  {loading
+                    ? "Loading…"
+                    : ready
+                      ? "Visualize in sandbox"
+                      : "Preparing…"}
+                </Box>
+              ) : (
+                <Box
+                  w="100%"
+                  bg="#f0ede7"
+                  color={TEXT_MUTED}
+                  borderRadius="3px"
+                  py={2.5}
+                  px={3}
+                  fontSize="12px"
+                  textAlign="center"
+                  mb={2}
+                  lineHeight={1.5}
+                >
+                  Not yet wired into the sandbox. Upload a sample to explore it
+                  here.
+                </Box>
+              )}
+
+              <Box
+                as="a"
+                href={entry.externalUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                gap={2}
+                w="100%"
+                bg="white"
+                color={TEXT}
+                border="1px solid"
+                borderColor={BORDER}
+                borderRadius="3px"
+                py={2.5}
+                px={3}
+                fontSize="13px"
+                fontWeight={500}
+                _hover={{ borderColor: TEXT }}
+                mb={3}
+                textDecoration="none"
+              >
+                <ArrowSquareOut size={14} />
+                View on source.coop
+              </Box>
+
+              <Box h="1px" bg={BORDER} my={4} />
+
+              <Text
+                fontSize="11px"
+                fontWeight={600}
+                letterSpacing="0.08em"
+                textTransform="uppercase"
+                color={TEXT_MUTED}
+                mb={2}
+              >
+                Quick facts
+              </Text>
+              <Box fontSize="12px" fontFamily={MONO} lineHeight={1.8}>
+                <FactRow label="slug" value={entry.slug} />
+                <FactRow label="files" value={String(entry.files.length)} />
+                <FactRow label="license" value={entry.license} />
+                <FactRow label="updated" value={entry.updated} />
+              </Box>
+
+              <Box h="1px" bg={BORDER} my={4} />
+
+              <Text fontSize="12px" color={TEXT_MUTED} lineHeight={1.5} mb={2}>
+                Have your own data to combine with this?
+              </Text>
+              <Link
+                to={workspacePath("/")}
+                style={{ textDecoration: "none" }}
+              >
+                <Flex
+                  align="center"
+                  gap={1.5}
+                  fontSize="12px"
+                  color={ACCENT}
+                  _hover={{ textDecoration: "underline" }}
+                >
+                  <Upload size={12} weight="bold" />
+                  Upload a file
+                </Flex>
+              </Link>
+            </Box>
+          </Box>
+        </Flex>
+      </Box>
+    </Box>
+  );
+}
+
+function FactRow({ label, value }: { label: string; value: string }) {
+  return (
+    <Flex justify="space-between" gap={3}>
+      <Text color={TEXT_MUTED}>{label}</Text>
+      <Text color={TEXT} textAlign="right" truncate>
+        {value}
+      </Text>
+    </Flex>
+  );
+}
+
+function ReadmeBlock({ content }: { content: string }) {
+  const blocks = content.trim().split(/\n\n+/);
+  return (
+    <Box fontSize="15px" lineHeight={1.65} color={TEXT}>
+      {blocks.map((block, i) => {
+        const heading = block.match(/^##\s+(.*)/);
+        if (heading) {
+          return (
+            <Heading
+              key={i}
+              as="h2"
+              fontSize="18px"
+              fontWeight={600}
+              letterSpacing="-0.01em"
+              mt={6}
+              mb={3}
+              color={TEXT}
+            >
+              {heading[1]}
+            </Heading>
+          );
+        }
+        return (
+          <Text key={i} mb={4} color={TEXT}>
+            {renderInline(block)}
+          </Text>
+        );
+      })}
+    </Box>
+  );
+}
+
+function renderInline(text: string) {
+  const parts = text.split(/(`[^`]+`)/g);
+  return parts.map((part, i) => {
+    if (part.startsWith("`") && part.endsWith("`")) {
+      return (
+        <Text
+          key={i}
+          as="code"
+          fontFamily={MONO}
+          fontSize="13px"
+          bg="#f0ede7"
+          px={1.5}
+          py={0.5}
+          borderRadius="2px"
+        >
+          {part.slice(1, -1)}
+        </Text>
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+}

--- a/frontend/src/pages/DiscoverDatasetPage.tsx
+++ b/frontend/src/pages/DiscoverDatasetPage.tsx
@@ -24,16 +24,19 @@ export default function DiscoverDatasetPage() {
   const entry = useMemo(() => getCatalogEntry(slug), [slug]);
 
   const [datasets, setDatasets] = useState<Dataset[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [fetchState, setFetchState] = useState<"loading" | "loaded" | "error">(
+    "loading"
+  );
 
   useEffect(() => {
     workspaceFetch(`${config.apiBase}/api/datasets`)
-      .then((r) => r.json())
-      .then((data) => {
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`dataset fetch failed: ${r.status}`);
+        const data = await r.json();
         setDatasets(Array.isArray(data) ? data : []);
-        setLoading(false);
+        setFetchState("loaded");
       })
-      .catch(() => setLoading(false));
+      .catch(() => setFetchState("error"));
   }, []);
 
   if (!entry) {
@@ -223,34 +226,44 @@ export default function DiscoverDatasetPage() {
               </Text>
 
               {entry.supported ? (
-                <Box
-                  as="button"
-                  onClick={onVisualize}
-                  {...({ disabled: !ready } as object)}
-                  w="100%"
-                  bg={ready ? TEXT : "#d0d0cc"}
-                  color="white"
-                  borderRadius="3px"
-                  py={2.5}
-                  px={3}
-                  fontSize="13px"
-                  fontWeight={600}
-                  cursor={ready ? "pointer" : "not-allowed"}
-                  display="flex"
-                  alignItems="center"
-                  justifyContent="center"
-                  gap={2}
-                  mb={2}
-                  transition="background 120ms ease"
-                  _hover={ready ? { bg: ACCENT } : undefined}
-                >
-                  <MapTrifold size={16} weight="bold" />
-                  {loading
-                    ? "Loading…"
-                    : ready
-                      ? "Visualize in sandbox"
-                      : "Preparing…"}
-                </Box>
+                <>
+                  <Box
+                    as="button"
+                    onClick={onVisualize}
+                    {...({ disabled: !ready } as object)}
+                    w="100%"
+                    bg={ready ? TEXT : "#d0d0cc"}
+                    color="white"
+                    borderRadius="3px"
+                    py={2.5}
+                    px={3}
+                    fontSize="13px"
+                    fontWeight={600}
+                    cursor={ready ? "pointer" : "not-allowed"}
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                    gap={2}
+                    mb={2}
+                    transition="background 120ms ease"
+                    _hover={ready ? { bg: ACCENT } : undefined}
+                  >
+                    <MapTrifold size={16} weight="bold" />
+                    {fetchState === "loading"
+                      ? "Loading…"
+                      : fetchState === "error"
+                        ? "Couldn't load dataset"
+                        : ready
+                          ? "Visualize in sandbox"
+                          : "Preparing…"}
+                  </Box>
+                  {fetchState === "error" && (
+                    <Text fontSize="11px" color={TEXT_MUTED} mb={2}>
+                      Retry by reloading the page, or continue to view the
+                      product on source.coop.
+                    </Text>
+                  )}
+                </>
               ) : (
                 <Box
                   w="100%"

--- a/frontend/src/pages/DiscoverDatasetPage.tsx
+++ b/frontend/src/pages/DiscoverDatasetPage.tsx
@@ -226,7 +226,7 @@ export default function DiscoverDatasetPage() {
                 <Box
                   as="button"
                   onClick={onVisualize}
-                  disabled={!ready}
+                  {...({ disabled: !ready } as object)}
                   w="100%"
                   bg={ready ? TEXT : "#d0d0cc"}
                   color="white"
@@ -271,9 +271,11 @@ export default function DiscoverDatasetPage() {
 
               <Box
                 as="a"
-                href={entry.externalUrl}
-                target="_blank"
-                rel="noopener noreferrer"
+                {...({
+                  href: entry.externalUrl,
+                  target: "_blank",
+                  rel: "noopener noreferrer",
+                } as object)}
                 display="flex"
                 alignItems="center"
                 justifyContent="center"

--- a/frontend/src/pages/DiscoverDatasetPage.tsx
+++ b/frontend/src/pages/DiscoverDatasetPage.tsx
@@ -130,13 +130,22 @@ export default function DiscoverDatasetPage() {
           color={TEXT_MUTED}
         >
           <Text>
-            org · <Text as="span" color={TEXT}>{entry.org}</Text>
+            org ·{" "}
+            <Text as="span" color={TEXT}>
+              {entry.org}
+            </Text>
           </Text>
           <Text>
-            license · <Text as="span" color={TEXT}>{entry.license}</Text>
+            license ·{" "}
+            <Text as="span" color={TEXT}>
+              {entry.license}
+            </Text>
           </Text>
           <Text>
-            updated · <Text as="span" color={TEXT}>{entry.updated}</Text>
+            updated ·{" "}
+            <Text as="span" color={TEXT}>
+              {entry.updated}
+            </Text>
           </Text>
           <Flex gap={1.5} wrap="wrap">
             {entry.tags.map((t) => (
@@ -311,10 +320,7 @@ export default function DiscoverDatasetPage() {
               <Text fontSize="12px" color={TEXT_MUTED} lineHeight={1.5} mb={2}>
                 Have your own data to combine with this?
               </Text>
-              <Link
-                to={workspacePath("/")}
-                style={{ textDecoration: "none" }}
-              >
+              <Link to={workspacePath("/")} style={{ textDecoration: "none" }}>
                 <Flex
                   align="center"
                   gap={1.5}

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -33,16 +33,23 @@ function findSupportedDatasetId(
   return match?.id;
 }
 
+type CatalogState = "loading" | "loaded" | "error";
+
 export default function DiscoverPage() {
   const navigate = useNavigate();
   const { workspacePath } = useWorkspace();
   const [datasets, setDatasets] = useState<Dataset[]>([]);
+  const [state, setState] = useState<CatalogState>("loading");
 
   useEffect(() => {
     workspaceFetch(`${config.apiBase}/api/datasets`)
-      .then((r) => r.json())
-      .then((data) => setDatasets(Array.isArray(data) ? data : []))
-      .catch(() => setDatasets([]));
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`dataset fetch failed: ${r.status}`);
+        const data = await r.json();
+        setDatasets(Array.isArray(data) ? data : []);
+        setState("loaded");
+      })
+      .catch(() => setState("error"));
   }, []);
 
   const onCardClick = (entry: CatalogEntry) => {
@@ -104,6 +111,22 @@ export default function DiscoverPage() {
           </Text>
         </Flex>
 
+        {state === "error" && (
+          <Box
+            mb={4}
+            px={3}
+            py={2}
+            border="1px solid"
+            borderColor={BORDER}
+            bg="#fdf6f2"
+            color={TEXT}
+            fontSize="13px"
+          >
+            Couldn't load dataset availability from the workspace. Supported
+            products may show as unavailable until the connection recovers.
+          </Box>
+        )}
+
         <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} gap={5}>
           {discoverCatalog.map((entry) => {
             const datasetId = findSupportedDatasetId(datasets, entry);
@@ -112,6 +135,7 @@ export default function DiscoverPage() {
                 key={entry.slug}
                 entry={entry}
                 ready={Boolean(datasetId)}
+                catalogState={state}
                 onClick={() => onCardClick(entry)}
               />
             );
@@ -139,10 +163,16 @@ export default function DiscoverPage() {
 interface CatalogCardProps {
   entry: CatalogEntry;
   ready: boolean;
+  catalogState: CatalogState;
   onClick: () => void;
 }
 
-function CatalogCard({ entry, ready, onClick }: CatalogCardProps) {
+function CatalogCard({
+  entry,
+  ready,
+  catalogState,
+  onClick,
+}: CatalogCardProps) {
   const [imageBroken, setImageBroken] = useState(false);
   const fallbackLetter = entry.title.charAt(0).toUpperCase();
 
@@ -270,7 +300,11 @@ function CatalogCard({ entry, ready, onClick }: CatalogCardProps) {
               textTransform="uppercase"
               letterSpacing="0.05em"
             >
-              Preparing…
+              {catalogState === "loading"
+                ? "Loading…"
+                : catalogState === "error"
+                  ? "Unavailable"
+                  : "Preparing…"}
             </Text>
           ) : (
             <Text

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -126,9 +126,9 @@ export default function DiscoverPage() {
               style={{ color: ACCENT, textDecoration: "underline" }}
             >
               Contribute to source.coop
-            </Link>
-            {" "}— upload a GeoTIFF, NetCDF, GeoJSON, Shapefile, or HDF5 and
-            we'll convert it to a cloud-native format ready for publication.
+            </Link>{" "}
+            — upload a GeoTIFF, NetCDF, GeoJSON, Shapefile, or HDF5 and we'll
+            convert it to a cloud-native format ready for publication.
           </Text>
         </Box>
       </Box>

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Box, Flex, Heading, SimpleGrid, Text } from "@chakra-ui/react";
+import { useWorkspace } from "../hooks/useWorkspace";
+import { workspaceFetch } from "../lib/api";
+import { config } from "../config";
+import type { Dataset } from "../types";
+import {
+  discoverCatalog,
+  listingUrlForSlug,
+  type CatalogEntry,
+} from "../lib/discoverCatalog";
+import { DiscoverHeader } from "../components/discover/DiscoverHeader";
+
+const PAGE_BG = "#fafaf8";
+const CARD_BG = "#ffffff";
+const BORDER = "#e8e6e1";
+const TEXT = "#1a1a1a";
+const TEXT_MUTED = "#6b6b68";
+const ACCENT = "#1a3a5c";
+
+function findSupportedDatasetId(
+  datasets: Dataset[],
+  entry: CatalogEntry
+): string | undefined {
+  if (!entry.supported) return undefined;
+  const target = listingUrlForSlug(entry.slug);
+  const match = datasets.find(
+    (d) =>
+      d.is_example &&
+      (d as Dataset & { source_url?: string }).source_url === target
+  );
+  return match?.id;
+}
+
+export default function DiscoverPage() {
+  const navigate = useNavigate();
+  const { workspacePath } = useWorkspace();
+  const [datasets, setDatasets] = useState<Dataset[]>([]);
+
+  useEffect(() => {
+    workspaceFetch(`${config.apiBase}/api/datasets`)
+      .then((r) => r.json())
+      .then((data) => setDatasets(Array.isArray(data) ? data : []))
+      .catch(() => setDatasets([]));
+  }, []);
+
+  const onCardClick = (entry: CatalogEntry) => {
+    navigate(workspacePath(`/discover/${entry.slug}`));
+  };
+
+  return (
+    <Box minH="100vh" bg={PAGE_BG} color={TEXT}>
+      <DiscoverHeader />
+
+      <Box maxW="1100px" mx="auto" px={6} pt={10} pb={6}>
+        <Heading
+          as="h1"
+          fontSize={{ base: "28px", md: "36px" }}
+          fontWeight={600}
+          letterSpacing="-0.02em"
+          mb={3}
+          color={TEXT}
+        >
+          Discover geospatial data
+        </Heading>
+        <Text
+          fontSize="17px"
+          color={TEXT_MUTED}
+          maxW="720px"
+          lineHeight={1.55}
+          mb={8}
+        >
+          Curated, cloud-native datasets ready to visualize, combine, and turn
+          into shareable map stories. Pick a dataset to preview it in the CNG
+          Sandbox.
+        </Text>
+      </Box>
+
+      <Box maxW="1100px" mx="auto" px={6} pb={20}>
+        <Flex
+          align="center"
+          justify="space-between"
+          mb={4}
+          borderBottom="1px solid"
+          borderColor={BORDER}
+          pb={2}
+        >
+          <Text
+            fontSize="12px"
+            fontWeight={600}
+            letterSpacing="0.08em"
+            textTransform="uppercase"
+            color={TEXT_MUTED}
+          >
+            Featured datasets
+          </Text>
+          <Text
+            fontSize="12px"
+            color={TEXT_MUTED}
+            fontFamily="SFMono-Regular, Consolas, monospace"
+          >
+            {discoverCatalog.length} products
+          </Text>
+        </Flex>
+
+        <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} gap={5}>
+          {discoverCatalog.map((entry) => {
+            const datasetId = findSupportedDatasetId(datasets, entry);
+            return (
+              <CatalogCard
+                key={entry.slug}
+                entry={entry}
+                ready={Boolean(datasetId)}
+                onClick={() => onCardClick(entry)}
+              />
+            );
+          })}
+        </SimpleGrid>
+
+        <Box mt={16} pt={8} borderTop="1px solid" borderColor={BORDER}>
+          <Text fontSize="14px" color={TEXT_MUTED} lineHeight={1.6}>
+            Want to publish your own dataset here?{" "}
+            <Link
+              to={workspacePath("/")}
+              style={{ color: ACCENT, textDecoration: "underline" }}
+            >
+              Contribute to source.coop
+            </Link>
+            {" "}— upload a GeoTIFF, NetCDF, GeoJSON, Shapefile, or HDF5 and
+            we'll convert it to a cloud-native format ready for publication.
+          </Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+interface CatalogCardProps {
+  entry: CatalogEntry;
+  ready: boolean;
+  onClick: () => void;
+}
+
+function CatalogCard({ entry, ready, onClick }: CatalogCardProps) {
+  const [imageBroken, setImageBroken] = useState(false);
+  const fallbackLetter = entry.title.charAt(0).toUpperCase();
+
+  return (
+    <Box
+      as="button"
+      onClick={onClick}
+      textAlign="left"
+      bg={CARD_BG}
+      border="1px solid"
+      borderColor={BORDER}
+      borderRadius="4px"
+      overflow="hidden"
+      cursor="pointer"
+      transition="border-color 120ms ease, transform 120ms ease"
+      _hover={{ borderColor: TEXT, transform: "translateY(-1px)" }}
+      _focusVisible={{
+        outline: "2px solid",
+        outlineColor: ACCENT,
+        outlineOffset: "2px",
+      }}
+      display="flex"
+      flexDirection="column"
+    >
+      <Box
+        h="140px"
+        bg="#efece6"
+        borderBottom="1px solid"
+        borderColor={BORDER}
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        overflow="hidden"
+      >
+        {imageBroken ? (
+          <Flex
+            align="center"
+            justify="center"
+            w="100%"
+            h="100%"
+            color={TEXT}
+            fontSize="56px"
+            fontWeight={300}
+            letterSpacing="-0.04em"
+            fontFamily="Georgia, serif"
+          >
+            {fallbackLetter}
+          </Flex>
+        ) : (
+          <img
+            src={entry.thumbnail}
+            alt={entry.title}
+            onError={() => setImageBroken(true)}
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+          />
+        )}
+      </Box>
+      <Box p={4} flex="1" display="flex" flexDirection="column">
+        <Text
+          fontSize="11px"
+          fontFamily="SFMono-Regular, Consolas, monospace"
+          color={TEXT_MUTED}
+          mb={1.5}
+        >
+          {entry.org}/{entry.name}
+        </Text>
+        <Text
+          fontSize="16px"
+          fontWeight={600}
+          color={TEXT}
+          mb={2}
+          letterSpacing="-0.01em"
+          lineHeight={1.3}
+        >
+          {entry.title}
+        </Text>
+        <Text
+          fontSize="13px"
+          color={TEXT_MUTED}
+          lineHeight={1.5}
+          mb={3}
+          flex="1"
+        >
+          {entry.tagline}
+        </Text>
+        <Flex gap={1.5} wrap="wrap" mb={3}>
+          {entry.tags.slice(0, 4).map((t) => (
+            <Text
+              key={t}
+              fontSize="11px"
+              fontFamily="SFMono-Regular, Consolas, monospace"
+              color={TEXT_MUTED}
+              border="1px solid"
+              borderColor={BORDER}
+              px={1.5}
+              py={0.5}
+              borderRadius="2px"
+            >
+              {t}
+            </Text>
+          ))}
+        </Flex>
+        <Flex align="center" justify="space-between">
+          <Text
+            fontSize="11px"
+            fontFamily="SFMono-Regular, Consolas, monospace"
+            color={TEXT_MUTED}
+          >
+            updated {entry.updated}
+          </Text>
+          {ready ? (
+            <Text
+              fontSize="11px"
+              fontWeight={600}
+              color={ACCENT}
+              textTransform="uppercase"
+              letterSpacing="0.05em"
+            >
+              ● Ready
+            </Text>
+          ) : entry.supported ? (
+            <Text
+              fontSize="11px"
+              color={TEXT_MUTED}
+              textTransform="uppercase"
+              letterSpacing="0.05em"
+            >
+              Preparing…
+            </Text>
+          ) : (
+            <Text
+              fontSize="11px"
+              color={TEXT_MUTED}
+              textTransform="uppercase"
+              letterSpacing="0.05em"
+            >
+              Browse
+            </Text>
+          )}
+        </Flex>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a source.coop-flavored entry point at `/discover` to demo the commercialization flow (catalog → visualize → build story) for stakeholders.

- **`/discover`** — editorial catalog grid with a distinct source.coop aesthetic (neutral palette, monospace metadata, flat bordered cards). 9 products total: the 3 curated example datasets already registered on the backend (GHRSST, GEBCO, LG Land Carbon) marked `● Ready`, plus 6 mocked entries (HLS, Overture, fields2030, CDL, VIIRS, 3DEP) that round out the catalog.
- **`/discover/:org/:name`** — product detail page with a two-column README + sidebar layout. Ready products expose a dark "Visualize in sandbox" CTA that deep-links to `/map/:id`; unsupported products point out to source.coop.
- **Chrome hand-off** — once the user leaves `/discover`, the standard sandbox `Header` takes over on `/map` and `/story`. A "Discover" link was added to the sandbox Header so the entry point stays reachable.

Demo script: land on `/discover` → click GHRSST → read detail page → "Visualize in sandbox" → explore → "Create story" from existing map CTA.

## Test plan

- [ ] Visit `/w/<workspace>/discover` — verify the grid renders and the 3 real products show "Ready"
- [ ] Click GHRSST card → detail page renders with metadata, readme, files, sidebar
- [ ] "Visualize in sandbox" → lands on `/map/<id>` with standard sandbox Header
- [ ] "View on source.coop" opens external link in new tab
- [ ] Click a mocked product (e.g. HLS) → detail page shows "Not yet wired into the sandbox" in place of the visualize button
- [ ] "Discover" nav link in the sandbox Header routes back to `/discover`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Discover section with a dedicated header and navigation link.
  * Featured/browsable catalog of curated datasets with cards (thumbnail fallback, org/name, title, tags, updated date).
  * Dataset detail pages showing metadata, license, file listings, formatted README, external links, and quick facts.
  * Sandbox visualize action that shows Loading/Preparing/Ready states and is active only for supported datasets.
  * Contribution CTA and upload-a-file action on Discover pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->