### PR TITLE
fix(ingestion): register full GHRSST temporal range (#198)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,7 +269,7 @@ cd ingestion && uv run pytest -v
 **Remote data discovery:**
 - `POST /api/discover` — Discover geospatial files at a URL or S3 prefix
 - `POST /api/connect-remote` — Connect remote files as a mosaic or temporal dataset
-- `POST /api/connect-source-coop` — Register a curated source.coop product as a zero-copy pgSTAC collection (v1 products: `ghrsst-mur-v2-2024`, `gebco-2024`, `lg-land-carbon`)
+- `POST /api/connect-source-coop` — Register a curated source.coop product as a zero-copy pgSTAC collection (v1 products: `ghrsst-mur-v2`, `gebco-2024`, `lg-land-carbon`)
 
 **Other:**
 - `POST /api/bug-report` — Submit a bug report (creates a GitHub issue)

--- a/frontend/src/lib/sourceCoopCatalog.ts
+++ b/frontend/src/lib/sourceCoopCatalog.ts
@@ -15,9 +15,9 @@ export interface SourceCoopProduct {
 export const sourceCoopCatalog: SourceCoopProduct[] = [
   {
     slug: "ausantarctic/ghrsst-mur-v2",
-    name: "GHRSST MUR v2 — Daily SST (2024)",
+    name: "GHRSST MUR v2 — Daily Global SST",
     description:
-      "Multi-scale Ultra-high Resolution sea surface temperature analysis, daily global coverage. v1 shows the 2024 subset (366 days).",
+      "Multi-scale Ultra-high Resolution sea surface temperature analysis, daily global coverage across the product's full temporal range.",
     thumbnail: "/thumbnails/ghrsst.jpg",
     tags: ["ocean", "temperature", "temporal"],
     isTemporal: true,

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -26,14 +26,14 @@ class SourceCoopProduct:
 _PRODUCTS: dict[str, SourceCoopProduct] = {
     "ausantarctic/ghrsst-mur-v2": SourceCoopProduct(
         slug="ausantarctic/ghrsst-mur-v2",
-        name="GHRSST MUR v2 — Daily SST (2024)",
+        name="GHRSST MUR v2 — Daily Global SST",
         description=(
             "Multi-scale Ultra-high Resolution sea surface temperature analysis, "
-            "daily global coverage. v1 shows the 2024 subset (366 days)."
+            "daily global coverage across the product's full temporal range."
         ),
         listing_url="https://data.source.coop/ausantarctic/ghrsst-mur-v2/",
         enumerator="stac_sidecars",
-        enumerator_args={"recursive": True, "start_prefix": "2024/"},
+        enumerator_args={"recursive": True},
         is_temporal=True,
     ),
     "alexgleith/gebco-2024": SourceCoopProduct(

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -35,7 +35,7 @@ def test_ghrsst_uses_recursive_sidecars():
     p = get_product("ausantarctic/ghrsst-mur-v2")
     assert p.enumerator == "stac_sidecars"
     assert p.enumerator_args.get("recursive") is True
-    assert p.enumerator_args.get("start_prefix") == "2024/"
+    assert "start_prefix" not in p.enumerator_args
 
 
 def test_gebco_uses_path_listing():


### PR DESCRIPTION
## Summary
- Drop `start_prefix: "2024/"` from the GHRSST MUR v2 entry in `ingestion/src/services/source_coop_config.py` so the recursive sidecar walker covers the product's full temporal range.
- Rename the product ("GHRSST MUR v2 — Daily Global SST") and rewrite the description in both the backend registry and the `frontend/src/lib/sourceCoopCatalog.ts` mirror to drop the "2024 subset" qualifier.
- Update `test_ghrsst_uses_recursive_sidecars` to assert `start_prefix` is absent.

Closes #198. Builds on the background-task registration shipped in #197.

## Test plan
- [x] `uv run pytest tests/services/test_source_coop_config.py tests/services/test_example_datasets.py` passes
- [x] `npx vitest run src/lib/__tests__/sourceCoopCatalog.test.ts` passes
- [ ] Fresh deploy (`docker compose down -v && up`): verify GHRSST registers fully in the background (~10 min expected), temporal slider spans multiple years, GEBCO and Land & Carbon Lab still register correctly
- [ ] Measure full-registration wall time on fresh deploy; note it in the devlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GHRSST MUR v2 product to reflect full temporal coverage instead of 2024 subset only. Product enumeration now includes complete historical data across its entire range.

* **Documentation**
  * Updated product catalog metadata to accurately describe daily global coverage for GHRSST MUR v2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->