### PR TITLE
fix(mcp): correct response unwrap + forward workspace header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,8 +336,10 @@ cd mcp && uv run pytest -v
 ### Running the server
 
 ```bash
-cng-mcp --api-url http://localhost:8086    # Communicates over stdio
+cng-mcp --api-url http://localhost:8086 --workspace-id <8-char-id>   # Communicates over stdio
 ```
+
+The ingestion API requires an `X-Workspace-Id` header on workspace-listing endpoints (`GET /api/datasets`, `GET /api/connections`, `GET /api/stories`). The MCP server forwards this header when started with `--workspace-id` (or `SANDBOX_WORKSPACE_ID` env var). Without it, those listing endpoints will return 400 and the MCP tools will surface empty results.
 
 See `mcp/README.md` for client config examples and `mcp/ARCHITECTURE.md` for design notes.
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -18,13 +18,15 @@ pip install cng-mcp
 
 ```bash
 # Default API URL (http://localhost:8086)
-cng-mcp
+cng-mcp --workspace-id <8-char-id>
 
 # Custom API URL
-cng-mcp --api-url http://your-sandbox.com
+cng-mcp --api-url http://your-sandbox.com --workspace-id <8-char-id>
 ```
 
 The server communicates over stdio. Connect with any MCP client.
+
+The ingestion API requires an `X-Workspace-Id` header on workspace-listing endpoints (`/api/datasets`, `/api/connections`, `/api/stories`). Pass `--workspace-id` (or set `SANDBOX_WORKSPACE_ID`) so the server can forward it — without it, listing endpoints return 400.
 
 ### 2. Use with Claude Desktop / Code
 
@@ -35,7 +37,7 @@ Add to your MCP client config:
   "mcpServers": {
     "cng-sandbox": {
       "command": "cng-mcp",
-      "args": ["--api-url", "http://localhost:8086"]
+      "args": ["--api-url", "http://localhost:8086", "--workspace-id", "abcd1234"]
     }
   }
 }
@@ -55,7 +57,7 @@ Create a new story.
 **Input**:
 - `title` (string)
 - `description` (string)
-- `chapters` (array): each with `title`, `text`, `dataset_id`, `map_state`, `layer_config`
+- `chapters` (array): each with `title`, `narrative`, `map_state`, and `layer_config` (containing `dataset_id` or `connection_id`)
 
 ### update_story
 Modify an existing story.

--- a/mcp/src/cng_mcp/client/sandbox_api.py
+++ b/mcp/src/cng_mcp/client/sandbox_api.py
@@ -8,19 +8,35 @@ import httpx
 class SandboxAPIClient:
     """Async HTTP client for sandbox ingestion API."""
 
-    def __init__(self, api_url: str, http_client: Optional[httpx.AsyncClient] = None):
+    def __init__(
+        self,
+        api_url: str,
+        workspace_id: Optional[str] = None,
+        http_client: Optional[httpx.AsyncClient] = None,
+    ):
         self.api_url = api_url.rstrip("/")
+        self.workspace_id = workspace_id
         self.http_client = http_client or httpx.AsyncClient()
 
+    def _headers(self) -> dict[str, str]:
+        if self.workspace_id:
+            return {"X-Workspace-Id": self.workspace_id}
+        return {}
+
     async def get_datasets(self) -> list[dict[str, Any]]:
-        """Get all datasets in workspace."""
-        response = await self.http_client.get(f"{self.api_url}/api/datasets")
+        """Get all datasets visible to the caller's workspace."""
+        response = await self.http_client.get(
+            f"{self.api_url}/api/datasets", headers=self._headers()
+        )
         response.raise_for_status()
-        return response.json().get("datasets", [])
+        return response.json()
 
     async def get_story(self, story_id: str) -> dict[str, Any]:
         """Get story by ID."""
-        response = await self.http_client.get(f"{self.api_url}/api/stories/{quote(story_id, safe='')}")
+        response = await self.http_client.get(
+            f"{self.api_url}/api/stories/{quote(story_id, safe='')}",
+            headers=self._headers(),
+        )
         response.raise_for_status()
         return response.json()
 
@@ -34,6 +50,7 @@ class SandboxAPIClient:
         response = await self.http_client.post(
             f"{self.api_url}/api/stories",
             json={"title": title, "description": description, "chapters": chapters},
+            headers=self._headers(),
         )
         response.raise_for_status()
         return response.json()
@@ -43,15 +60,18 @@ class SandboxAPIClient:
         response = await self.http_client.patch(
             f"{self.api_url}/api/stories/{quote(story_id, safe='')}",
             json=updates,
+            headers=self._headers(),
         )
         response.raise_for_status()
         return response.json()
 
     async def get_connections(self) -> list[dict[str, Any]]:
-        """Get all external tile source connections."""
-        response = await self.http_client.get(f"{self.api_url}/api/connections")
+        """Get all external tile source connections in the caller's workspace."""
+        response = await self.http_client.get(
+            f"{self.api_url}/api/connections", headers=self._headers()
+        )
         response.raise_for_status()
-        return response.json().get("connections", [])
+        return response.json()
 
     async def validate_layer_config(
         self,
@@ -69,6 +89,7 @@ class SandboxAPIClient:
         response = await self.http_client.post(
             f"{self.api_url}/api/validate-layer-config",
             json=payload,
+            headers=self._headers(),
         )
         response.raise_for_status()
         return response.json()

--- a/mcp/src/cng_mcp/server.py
+++ b/mcp/src/cng_mcp/server.py
@@ -114,10 +114,10 @@ RESOURCE_DEFINITIONS = [
 ]
 
 
-def create_server(sandbox_api_url: str) -> Server:
+def create_server(sandbox_api_url: str, workspace_id: str | None = None) -> Server:
     """Create and configure MCP server."""
     server: Server = Server("cng-sandbox")
-    client = SandboxAPIClient(api_url=sandbox_api_url)
+    client = SandboxAPIClient(api_url=sandbox_api_url, workspace_id=workspace_id)
 
     @server.list_tools()
     async def handle_list_tools() -> list[Tool]:
@@ -180,6 +180,13 @@ async def main():
         help="Sandbox API URL (default: http://localhost:8086)",
     )
     parser.add_argument(
+        "--workspace-id",
+        default=os.getenv("SANDBOX_WORKSPACE_ID"),
+        help="Workspace ID to scope requests (sent as X-Workspace-Id). "
+        "Defaults to $SANDBOX_WORKSPACE_ID. Without it, workspace-listing "
+        "endpoints will return empty lists.",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -191,8 +198,14 @@ async def main():
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
-    server = create_server(sandbox_api_url=args.api_url)
-    logger.info(f"CNG MCP Server starting (API: {args.api_url})")
+    server = create_server(
+        sandbox_api_url=args.api_url, workspace_id=args.workspace_id
+    )
+    logger.info(
+        "CNG MCP Server starting (API: %s, workspace: %s)",
+        args.api_url,
+        args.workspace_id or "<none>",
+    )
 
     async with stdio_server() as (read_stream, write_stream):
         await server.run(read_stream, write_stream, server.create_initialization_options())

--- a/mcp/src/cng_mcp/tools/stories.py
+++ b/mcp/src/cng_mcp/tools/stories.py
@@ -15,9 +15,12 @@ async def read_story_tool(client: SandboxAPIClient, story_id: str) -> TextConten
     if chapters:
         lines.append("## Chapters\n")
         for i, ch in enumerate(chapters, 1):
+            lc = ch.get("layer_config") or {}
+            layer_ref = lc.get("dataset_id") or lc.get("connection_id") or "unknown"
+            narrative = ch.get("narrative") or ch.get("text") or ""
             lines.append(f"### {i}. {ch.get('title', 'Untitled Chapter')}")
-            lines.append(f"- **Dataset**: {ch.get('dataset_id', 'unknown')}")
-            lines.append(f"- **Text**: {ch.get('text', '')}\n")
+            lines.append(f"- **Layer**: {layer_ref}")
+            lines.append(f"- **Narrative**: {narrative}\n")
     return TextContent(type="text", text="\n".join(lines))
 
 

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -40,10 +40,25 @@ def sample_story():
         "chapters": [
             {
                 "id": "ch_001",
+                "order": 0,
+                "type": "scrollytelling",
                 "title": "Overview",
-                "text": "Starting with global coverage...",
-                "dataset_id": "dataset_abc123",
-                "map_state": {"center": [0, 0], "zoom": 2},
+                "narrative": "Starting with global coverage...",
+                "transition": "fly-to",
+                "overlay_position": "left",
+                "map_state": {
+                    "center": [0, 0],
+                    "zoom": 2,
+                    "bearing": 0,
+                    "pitch": 0,
+                    "basemap": "dark",
+                },
+                "layer_config": {
+                    "dataset_id": "dataset_abc123",
+                    "colormap": "viridis",
+                    "opacity": 0.8,
+                    "basemap": "dark",
+                },
             }
         ],
         "created_at": "2025-01-01T00:00:00Z",

--- a/mcp/tests/test_client_sandbox_api.py
+++ b/mcp/tests/test_client_sandbox_api.py
@@ -14,14 +14,31 @@ def _make_response(json_data):
 
 @pytest.mark.asyncio
 async def test_get_datasets_returns_list(sandbox_api_url, mock_http_client):
-    mock_http_client.get = AsyncMock(return_value=_make_response({
-        "datasets": [{"id": "ds_1", "filename": "data.tif", "dataset_type": "raster", "is_example": False}]
-    }))
-    client = SandboxAPIClient(api_url=sandbox_api_url, http_client=mock_http_client)
+    mock_http_client.get = AsyncMock(return_value=_make_response(
+        [{"id": "ds_1", "filename": "data.tif", "dataset_type": "raster", "is_example": False}]
+    ))
+    client = SandboxAPIClient(
+        api_url=sandbox_api_url, workspace_id="ws12345x", http_client=mock_http_client
+    )
     datasets = await client.get_datasets()
     assert len(datasets) == 1
     assert datasets[0]["id"] == "ds_1"
-    mock_http_client.get.assert_called_once_with("http://localhost:8086/api/datasets")
+    mock_http_client.get.assert_called_once_with(
+        "http://localhost:8086/api/datasets",
+        headers={"X-Workspace-Id": "ws12345x"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_datasets_without_workspace_sends_no_header(
+    sandbox_api_url, mock_http_client
+):
+    mock_http_client.get = AsyncMock(return_value=_make_response([]))
+    client = SandboxAPIClient(api_url=sandbox_api_url, http_client=mock_http_client)
+    await client.get_datasets()
+    mock_http_client.get.assert_called_once_with(
+        "http://localhost:8086/api/datasets", headers={}
+    )
 
 
 @pytest.mark.asyncio
@@ -30,7 +47,9 @@ async def test_get_story_by_id(sandbox_api_url, mock_http_client, sample_story):
     client = SandboxAPIClient(api_url=sandbox_api_url, http_client=mock_http_client)
     story = await client.get_story(story_id="story_xyz789")
     assert story["id"] == "story_xyz789"
-    mock_http_client.get.assert_called_once_with("http://localhost:8086/api/stories/story_xyz789")
+    mock_http_client.get.assert_called_once_with(
+        "http://localhost:8086/api/stories/story_xyz789", headers={}
+    )
 
 
 @pytest.mark.asyncio
@@ -52,13 +71,19 @@ async def test_update_story(sandbox_api_url, mock_http_client):
 
 @pytest.mark.asyncio
 async def test_get_connections(sandbox_api_url, mock_http_client):
-    mock_http_client.get = AsyncMock(return_value=_make_response({
-        "connections": [{"id": "conn_1", "name": "Test", "url": "https://ex.com/{z}/{x}/{y}.tif", "connection_type": "cog"}]
-    }))
-    client = SandboxAPIClient(api_url=sandbox_api_url, http_client=mock_http_client)
+    mock_http_client.get = AsyncMock(return_value=_make_response(
+        [{"id": "conn_1", "name": "Test", "url": "https://ex.com/{z}/{x}/{y}.tif", "connection_type": "cog"}]
+    ))
+    client = SandboxAPIClient(
+        api_url=sandbox_api_url, workspace_id="ws87654x", http_client=mock_http_client
+    )
     connections = await client.get_connections()
     assert len(connections) == 1
     assert connections[0]["id"] == "conn_1"
+    mock_http_client.get.assert_called_once_with(
+        "http://localhost:8086/api/connections",
+        headers={"X-Workspace-Id": "ws87654x"},
+    )
 
 
 @pytest.mark.asyncio

--- a/mcp/tests/test_e2e.py
+++ b/mcp/tests/test_e2e.py
@@ -20,7 +20,7 @@ def _make_response(json_data):
 @pytest.mark.asyncio
 async def test_e2e_agent_discover_datasets(mock_http_client, sample_dataset):
     """E2E: Agent discovers available datasets."""
-    mock_http_client.get = AsyncMock(return_value=_make_response({"datasets": [sample_dataset]}))
+    mock_http_client.get = AsyncMock(return_value=_make_response([sample_dataset]))
     client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
     result = await read_datasets_tool(client)
     assert isinstance(result, TextContent)

--- a/mcp/tests/test_resources_datasets.py
+++ b/mcp/tests/test_resources_datasets.py
@@ -15,7 +15,7 @@ def _make_response(json_data):
 
 @pytest.mark.asyncio
 async def test_list_datasets_resource_empty(mock_http_client):
-    mock_http_client.get = AsyncMock(return_value=_make_response({"datasets": []}))
+    mock_http_client.get = AsyncMock(return_value=_make_response([]))
     client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
     content = await list_datasets_resource(client)
     assert "No datasets available" in content
@@ -23,7 +23,7 @@ async def test_list_datasets_resource_empty(mock_http_client):
 
 @pytest.mark.asyncio
 async def test_list_datasets_resource_with_data(mock_http_client, sample_dataset):
-    mock_http_client.get = AsyncMock(return_value=_make_response({"datasets": [sample_dataset]}))
+    mock_http_client.get = AsyncMock(return_value=_make_response([sample_dataset]))
     client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
     content = await list_datasets_resource(client)
     assert "Available Datasets" in content

--- a/mcp/tests/test_tools_connections.py
+++ b/mcp/tests/test_tools_connections.py
@@ -16,7 +16,7 @@ def _make_response(json_data):
 
 @pytest.mark.asyncio
 async def test_read_connections_tool(mock_http_client, sample_connection):
-    mock_http_client.get = AsyncMock(return_value=_make_response({"connections": [sample_connection]}))
+    mock_http_client.get = AsyncMock(return_value=_make_response([sample_connection]))
     client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
     result = await read_connections_tool(client)
     assert isinstance(result, TextContent)
@@ -26,7 +26,7 @@ async def test_read_connections_tool(mock_http_client, sample_connection):
 
 @pytest.mark.asyncio
 async def test_read_connections_tool_empty(mock_http_client):
-    mock_http_client.get = AsyncMock(return_value=_make_response({"connections": []}))
+    mock_http_client.get = AsyncMock(return_value=_make_response([]))
     client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
     result = await read_connections_tool(client)
     assert "No external connections" in result.text

--- a/mcp/tests/test_tools_datasets.py
+++ b/mcp/tests/test_tools_datasets.py
@@ -16,7 +16,7 @@ def _make_response(json_data):
 
 @pytest.mark.asyncio
 async def test_read_datasets_tool_empty(mock_http_client):
-    mock_http_client.get = AsyncMock(return_value=_make_response({"datasets": []}))
+    mock_http_client.get = AsyncMock(return_value=_make_response([]))
     client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
     result = await read_datasets_tool(client)
     assert isinstance(result, TextContent)
@@ -25,7 +25,7 @@ async def test_read_datasets_tool_empty(mock_http_client):
 
 @pytest.mark.asyncio
 async def test_read_datasets_tool_with_data(mock_http_client, sample_dataset):
-    mock_http_client.get = AsyncMock(return_value=_make_response({"datasets": [sample_dataset]}))
+    mock_http_client.get = AsyncMock(return_value=_make_response([sample_dataset]))
     client = SandboxAPIClient(api_url="http://localhost:8086", http_client=mock_http_client)
     result = await read_datasets_tool(client)
     assert "elevation.tif" in result.text

--- a/mcp/tests/test_tools_stories.py
+++ b/mcp/tests/test_tools_stories.py
@@ -22,6 +22,10 @@ async def test_read_story_tool(mock_http_client, sample_story):
     assert isinstance(result, TextContent)
     assert "Global Elevation Analysis" in result.text
     assert "Overview" in result.text
+    # Chapter narrative and dataset reference both come from the nested
+    # layer_config / narrative fields, not a flat text/dataset_id.
+    assert "Starting with global coverage" in result.text
+    assert "dataset_abc123" in result.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `SandboxAPIClient.get_datasets` / `get_connections` called `.get("datasets", [])` / `.get("connections", [])` on what was already a bare list from the ingestion API, raising `AttributeError` on any real call.
- The client never forwarded `X-Workspace-Id`, so workspace-listing endpoints would still return empty lists even after the unwrap was fixed.
- `read_story_tool` read `chapter.dataset_id` and `chapter.text`, but the real chapter schema puts those under `chapter.layer_config.dataset_id` and uses `chapter.narrative` — so every chapter rendered as "Dataset: unknown, Text: (empty)".
- Existing tests mirrored the wrong shapes end-to-end, so they all passed while prod was broken.

## Changes
- Client accepts optional `workspace_id` and sends `X-Workspace-Id` automatically.
- `get_datasets` / `get_connections` return the list they receive.
- Server exposes `--workspace-id` (also read from `$SANDBOX_WORKSPACE_ID`).
- `read_story_tool` walks `layer_config` + `narrative` and falls back to `connection_id` when `dataset_id` is absent.
- Test fixtures updated to the real API shapes (bare lists; full chapter schema with `layer_config` and `narrative`).

## Test plan
- [x] `cd mcp && uv run --extra dev pytest` — all 25 tests pass
- [x] Smoke test against a running ingestion API: stdio MCP round-trip for `read_datasets`, `read_connections`, `read_story` returns expected content for the three example datasets, my ESA WorldCover connection, and the "From Trench to Peak" example story
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)