### PR TITLE
feat: register VIDA Global Buildings as pmtiles example dataset (#202)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,7 +269,7 @@ cd ingestion && uv run pytest -v
 **Remote data discovery:**
 - `POST /api/discover` — Discover geospatial files at a URL or S3 prefix
 - `POST /api/connect-remote` — Connect remote files as a mosaic or temporal dataset
-- `POST /api/connect-source-coop` — Register a curated source.coop product as a zero-copy pgSTAC collection (v1 products: `ghrsst-mur-v2-2024`, `gebco-2024`, `lg-land-carbon`)
+- `POST /api/connect-source-coop` — Register a curated source.coop product as a zero-copy pgSTAC collection (v1 products: `ausantarctic/ghrsst-mur-v2`, `alexgleith/gebco-2024`, `vizzuality/lg-land-carbon-data`, `vida/google-microsoft-osm-open-buildings`). Raster products (`kind="mosaic"`) run a STAC/path enumerator and register as pgSTAC mosaics; PMTiles products (`kind="pmtiles"`) read the remote PMTiles v3 header for bounds/zoom and register as a `FormatPair.PMTILES` vector dataset pointing at the source URL.
 
 **Other:**
 - `POST /api/bug-report` — Submit a bug report (creates a GitHub issue)
@@ -278,7 +278,7 @@ cd ingestion && uv run pytest -v
 
 ### Example datasets
 
-On startup, the ingestion service runs a background task (`src/services/example_datasets.py`) that registers the curated source.coop products as shared "example" datasets. These rows carry `is_example=True`, are owned by no workspace, cannot be deleted or modified via the API, and are surfaced to every workspace's `GET /api/datasets` response so a fresh deploy never has an empty library. The task is idempotent across restarts (it skips products whose `listing_url` is already present on an example row) and registers fast products before slow ones so the gallery populates quickly.
+On startup, the ingestion service runs a background task (`src/services/example_datasets.py`) that registers the curated source.coop products as shared "example" datasets. These rows carry `is_example=True`, are owned by no workspace, cannot be deleted or modified via the API, and are surfaced to every workspace's `GET /api/datasets` response so a fresh deploy never has an empty library. The task is idempotent across restarts (it skips products whose `listing_url` is already present on an example row) and registers fast products before slow ones so the gallery populates quickly. PMTiles-kind products are registered via `src/services/pmtiles_register.py`, which probes the first 127 bytes of the remote file (`src/services/pmtiles_header.py`) to extract bounds, min/max zoom, and verify the tile type is MVT; mosaic-kind products are enumerated and registered via `register_remote_collection`.
 
 ### Conversion pipeline
 

--- a/frontend/src/components/MapChapter.tsx
+++ b/frontend/src/components/MapChapter.tsx
@@ -6,7 +6,7 @@ import { CalendarPopover } from "./CalendarPopover";
 import type { Chapter } from "../lib/story";
 import type { CameraState } from "../lib/layers/types";
 import type { Connection, Dataset } from "../types";
-import { buildRasterTileLayers, buildVectorLayer } from "../lib/layers";
+import { buildRasterTileLayers, buildVectorLayer, isPMTilesDataset } from "../lib/layers";
 import { buildLayersForChapter } from "../lib/story/rendering";
 import { DEFAULT_LAYER_CONFIG } from "../lib/story";
 import { detectCadence } from "../utils/temporal";
@@ -84,7 +84,7 @@ export function MapChapter({
     return [
       buildVectorLayer({
         tileUrl: dataset.tile_url,
-        isPMTiles: dataset.tile_url.startsWith("/pmtiles/"),
+        isPMTiles: isPMTilesDataset(dataset),
         opacity: lc.opacity,
         minZoom: dataset.min_zoom ?? undefined,
         maxZoom: dataset.max_zoom ?? undefined,

--- a/frontend/src/components/MapChapter.tsx
+++ b/frontend/src/components/MapChapter.tsx
@@ -6,7 +6,11 @@ import { CalendarPopover } from "./CalendarPopover";
 import type { Chapter } from "../lib/story";
 import type { CameraState } from "../lib/layers/types";
 import type { Connection, Dataset } from "../types";
-import { buildRasterTileLayers, buildVectorLayer, isPMTilesDataset } from "../lib/layers";
+import {
+  buildRasterTileLayers,
+  buildVectorLayer,
+  isPMTilesDataset,
+} from "../lib/layers";
 import { buildLayersForChapter } from "../lib/story/rendering";
 import { DEFAULT_LAYER_CONFIG } from "../lib/story";
 import { detectCadence } from "../utils/temporal";

--- a/frontend/src/components/details/stepContent.ts
+++ b/frontend/src/components/details/stepContent.ts
@@ -1,4 +1,5 @@
 import type { Dataset } from "../../types";
+import { isPMTilesDataset } from "../../lib/layers/isPMTiles";
 import { formatBytes as formatBytesRaw } from "../../utils/format";
 import type {
   StepContent,
@@ -11,7 +12,7 @@ export type PipelineType = "raster" | "vector-postgis" | "vector-pmtiles";
 
 export function getPipelineType(dataset: Dataset): PipelineType {
   if (dataset.dataset_type === "raster") return "raster";
-  if (dataset.tile_url?.startsWith("/pmtiles/")) return "vector-pmtiles";
+  if (isPMTilesDataset(dataset)) return "vector-pmtiles";
   return "vector-postgis";
 }
 

--- a/frontend/src/hooks/useLayerBuilder.ts
+++ b/frontend/src/hooks/useLayerBuilder.ts
@@ -12,6 +12,7 @@ import {
   buildVectorLayer,
   buildGeoJsonLayer,
   arrowTableToGeoJSON,
+  isPMTilesDataset,
 } from "../lib/layers";
 import { classifyCogRenderPath } from "../lib/layers/cogDtype";
 import { parseRescaleString } from "../lib/connections";
@@ -314,7 +315,7 @@ export function useLayerBuilder({
     return [
       buildVectorLayer({
         tileUrl: ds.tile_url,
-        isPMTiles: ds.tile_url.startsWith("/pmtiles/"),
+        isPMTiles: isPMTilesDataset(ds),
         opacity,
         minZoom: ds.min_zoom ?? undefined,
         maxZoom: ds.max_zoom ?? undefined,

--- a/frontend/src/hooks/useStoryEditor.ts
+++ b/frontend/src/hooks/useStoryEditor.ts
@@ -9,6 +9,7 @@ import {
   cameraFromBounds,
   buildRasterTileLayers,
   buildVectorLayer,
+  isPMTilesDataset,
 } from "../lib/layers";
 import { buildConnectionTileUrl } from "../lib/connections";
 import {
@@ -502,7 +503,7 @@ export function useStoryEditor() {
     return [
       buildVectorLayer({
         tileUrl: ds.tile_url,
-        isPMTiles: ds.tile_url.startsWith("/pmtiles/"),
+        isPMTiles: isPMTilesDataset(ds),
         opacity: lc.opacity,
         minZoom: ds.min_zoom ?? undefined,
         maxZoom: ds.max_zoom ?? undefined,

--- a/frontend/src/lib/__tests__/sourceCoopCatalog.test.ts
+++ b/frontend/src/lib/__tests__/sourceCoopCatalog.test.ts
@@ -15,9 +15,10 @@ describe("sourceCoopCatalog", () => {
     );
   });
 
-  it("includes VIDA buildings", () => {
-    const slugs = sourceCoopCatalog.map((p) => p.slug);
-    expect(slugs).toContain("vida/google-microsoft-osm-open-buildings");
+  it("VIDA buildings is not temporal and tagged vector", () => {
+    const p = getProduct("vida/google-microsoft-osm-open-buildings");
+    expect(p.isTemporal).toBe(false);
+    expect(p.tags).toContain("vector");
   });
 
   it("every product has a name, description, thumbnail, and tags", () => {

--- a/frontend/src/lib/__tests__/sourceCoopCatalog.test.ts
+++ b/frontend/src/lib/__tests__/sourceCoopCatalog.test.ts
@@ -2,16 +2,22 @@ import { describe, expect, it } from "vitest";
 import { sourceCoopCatalog, getProduct } from "../sourceCoopCatalog";
 
 describe("sourceCoopCatalog", () => {
-  it("has exactly three v1 entries", () => {
-    expect(sourceCoopCatalog).toHaveLength(3);
+  it("has exactly four v1 entries", () => {
+    expect(sourceCoopCatalog).toHaveLength(4);
     const slugs = sourceCoopCatalog.map((p) => p.slug);
     expect(slugs).toEqual(
       expect.arrayContaining([
         "ausantarctic/ghrsst-mur-v2",
         "alexgleith/gebco-2024",
         "vizzuality/lg-land-carbon-data",
+        "vida/google-microsoft-osm-open-buildings",
       ])
     );
+  });
+
+  it("includes VIDA buildings", () => {
+    const slugs = sourceCoopCatalog.map((p) => p.slug);
+    expect(slugs).toContain("vida/google-microsoft-osm-open-buildings");
   });
 
   it("every product has a name, description, thumbnail, and tags", () => {

--- a/frontend/src/lib/layers/__tests__/isPMTiles.test.ts
+++ b/frontend/src/lib/layers/__tests__/isPMTiles.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { isPMTilesDataset } from "../isPMTiles";
+
+describe("isPMTilesDataset", () => {
+  it("returns true when format_pair is pmtiles (source.coop reference)", () => {
+    expect(
+      isPMTilesDataset({
+        format_pair: "pmtiles",
+        tile_url: "https://data.source.coop/vida/x.pmtiles",
+      })
+    ).toBe(true);
+  });
+
+  it("returns true for legacy uploaded PMTiles (tile_url prefix)", () => {
+    expect(
+      isPMTilesDataset({
+        format_pair: "shapefile-to-geoparquet",
+        tile_url: "/pmtiles/datasets/abc/converted/data.pmtiles",
+      })
+    ).toBe(true);
+    expect(
+      isPMTilesDataset({
+        format_pair: "geojson-to-geoparquet",
+        tile_url: "/pmtiles/datasets/def/converted/data.pmtiles",
+      })
+    ).toBe(true);
+  });
+
+  it("returns false for non-PMTiles vector datasets", () => {
+    expect(
+      isPMTilesDataset({
+        format_pair: "shapefile-to-geoparquet",
+        tile_url: "/vector/collections/public.sandbox_abc/tiles/{z}/{x}/{y}",
+      })
+    ).toBe(false);
+  });
+
+  it("returns false for raster datasets", () => {
+    expect(isPMTilesDataset({ format_pair: "geotiff-to-cog" })).toBe(false);
+  });
+
+  it("returns false when both fields are missing", () => {
+    expect(isPMTilesDataset({})).toBe(false);
+  });
+});

--- a/frontend/src/lib/layers/index.ts
+++ b/frontend/src/lib/layers/index.ts
@@ -5,3 +5,4 @@ export type { TileCacheEntry } from "./cogLayer";
 export { buildRasterPMTilesLayer } from "./rasterPMTilesLayer";
 export { buildVectorLayer } from "./vectorLayer";
 export { buildGeoJsonLayer, arrowTableToGeoJSON } from "./geojsonLayer";
+export { isPMTilesDataset } from "./isPMTiles";

--- a/frontend/src/lib/layers/isPMTiles.ts
+++ b/frontend/src/lib/layers/isPMTiles.ts
@@ -1,0 +1,8 @@
+export function isPMTilesDataset(ds: {
+  format_pair?: string;
+  tile_url?: string;
+}): boolean {
+  if (ds.format_pair === "pmtiles") return true;
+  if (ds.tile_url?.startsWith("/pmtiles/")) return true;
+  return false;
+}

--- a/frontend/src/lib/sourceCoopCatalog.ts
+++ b/frontend/src/lib/sourceCoopCatalog.ts
@@ -40,6 +40,15 @@ export const sourceCoopCatalog: SourceCoopProduct[] = [
     tags: ["carbon", "deforestation", "climate"],
     isTemporal: false,
   },
+  {
+    slug: "vida/google-microsoft-osm-open-buildings",
+    name: "Global Buildings (VIDA)",
+    description:
+      "Combined Google, Microsoft, and OpenStreetMap building footprints worldwide, served as PMTiles.",
+    thumbnail: "/thumbnails/vida-buildings.jpg",
+    tags: ["buildings", "global", "vector"],
+    isTemporal: false,
+  },
 ];
 
 export function getProduct(slug: string): SourceCoopProduct {

--- a/frontend/src/lib/story/rendering.ts
+++ b/frontend/src/lib/story/rendering.ts
@@ -2,6 +2,7 @@ import {
   buildRasterTileLayers,
   buildRasterPMTilesLayer,
   buildVectorLayer,
+  isPMTilesDataset,
 } from "../layers";
 import { buildConnectionTileUrl } from "../connections";
 import { DEFAULT_LAYER_CONFIG } from "./types";
@@ -157,7 +158,7 @@ export function buildLayersForChapter(
   return [
     buildVectorLayer({
       tileUrl: ds.tile_url,
-      isPMTiles: ds.tile_url.startsWith("/pmtiles/"),
+      isPMTiles: isPMTilesDataset(ds),
       opacity: lc.opacity,
       minZoom: ds.min_zoom ?? undefined,
       maxZoom: ds.max_zoom ?? undefined,

--- a/ingestion/src/models/__init__.py
+++ b/ingestion/src/models/__init__.py
@@ -29,6 +29,7 @@ class FormatPair(StrEnum):
     GEOJSON_TO_GEOPARQUET = "geojson-to-geoparquet"
     NETCDF_TO_COG = "netcdf-to-cog"
     HDF5_TO_COG = "hdf5-to-cog"
+    PMTILES = "pmtiles"
 
     @staticmethod
     def from_extension(ext: str) -> "FormatPair":
@@ -44,6 +45,7 @@ class FormatPair(StrEnum):
             ".nc4": FormatPair.NETCDF_TO_COG,
             ".h5": FormatPair.HDF5_TO_COG,
             ".hdf5": FormatPair.HDF5_TO_COG,
+            ".pmtiles": FormatPair.PMTILES,
         }
         if ext not in mapping:
             raise ValueError(f"Unsupported format: {ext}")

--- a/ingestion/src/services/example_datasets.py
+++ b/ingestion/src/services/example_datasets.py
@@ -24,6 +24,10 @@ from src.models.dataset import DatasetRow
 from src.services.enumerators import RemoteItem
 from src.services.enumerators.path_listing import enumerate_path_listing
 from src.services.enumerators.stac_sidecars import enumerate_stac_sidecars
+from src.services.pmtiles_register import (
+    PMTilesRegistrationError,
+    register_pmtiles_example,
+)
 from src.services.remote_register import (
     RemoteRegistrationError,
     register_remote_collection,
@@ -104,18 +108,21 @@ async def register_example_datasets(
             continue
         logger.info("registering example dataset: %s", product.slug)
         try:
-            items = await run_enumerator(product)
-            job = Job(filename=product.name)
-            job.workspace_id = None
-            await register_remote_collection(
-                job=job,
-                product=product,
-                items=items,
-                db_session_factory=db_session_factory,
-                is_example=True,
-            )
+            if product.kind == "pmtiles":
+                await register_pmtiles_example(product, db_session_factory)
+            else:
+                items = await run_enumerator(product)
+                job = Job(filename=product.name)
+                job.workspace_id = None
+                await register_remote_collection(
+                    job=job,
+                    product=product,
+                    items=items,
+                    db_session_factory=db_session_factory,
+                    is_example=True,
+                )
             logger.info("registered example dataset: %s", product.slug)
-        except RemoteRegistrationError:
+        except (RemoteRegistrationError, PMTilesRegistrationError):
             logger.exception("registration failed for %s", product.slug)
         except Exception:
             logger.exception("enumeration/registration failed for %s", product.slug)

--- a/ingestion/src/services/pipeline.py
+++ b/ingestion/src/services/pipeline.py
@@ -110,8 +110,7 @@ def get_credits(format_pair: FormatPair, use_pmtiles: bool = False) -> list[dict
                 "role": "Converted by",
             }
         )
-
-    if format_pair == FormatPair.PMTILES:
+    elif format_pair == FormatPair.PMTILES:
         credits.append(
             {
                 "tool": "PMTiles",
@@ -120,7 +119,11 @@ def get_credits(format_pair: FormatPair, use_pmtiles: bool = False) -> list[dict
             }
         )
         credits.append(
-            {"tool": "MapLibre", "url": "https://maplibre.org", "role": "Map rendered by"}
+            {
+                "tool": "MapLibre",
+                "url": "https://maplibre.org",
+                "role": "Map rendered by",
+            }
         )
         return credits
 

--- a/ingestion/src/services/pipeline.py
+++ b/ingestion/src/services/pipeline.py
@@ -111,6 +111,19 @@ def get_credits(format_pair: FormatPair, use_pmtiles: bool = False) -> list[dict
             }
         )
 
+    if format_pair == FormatPair.PMTILES:
+        credits.append(
+            {
+                "tool": "PMTiles",
+                "url": "https://github.com/protomaps/PMTiles",
+                "role": "Tiles served by",
+            }
+        )
+        credits.append(
+            {"tool": "MapLibre", "url": "https://maplibre.org", "role": "Map rendered by"}
+        )
+        return credits
+
     if format_pair.dataset_type == DatasetType.RASTER:
         credits.append(
             {

--- a/ingestion/src/services/pmtiles_header.py
+++ b/ingestion/src/services/pmtiles_header.py
@@ -86,20 +86,22 @@ def parse_pmtiles_header(buf: bytes) -> PMTilesHeader:
 
 async def read_pmtiles_header(url: str) -> PMTilesHeader:
     headers = {"Range": f"bytes=0-{HEADER_LEN - 1}"}
-    async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:
-        async with client.stream("GET", url, headers=headers) as resp:
-            resp.raise_for_status()
-            # Stream-read only the bytes we need. If a server or proxy ignores
-            # the Range header, `resp.content` would buffer the entire file
-            # into memory (PMTiles archives can be hundreds of GB). Using
-            # `aiter_bytes` + an early break caps us at HEADER_LEN bytes
-            # regardless of the server's behaviour.
-            body = bytearray()
-            async for chunk in resp.aiter_bytes():
-                remaining = HEADER_LEN - len(body)
-                if remaining <= 0:
-                    break
-                body.extend(chunk[:remaining])
-                if len(body) >= HEADER_LEN:
-                    break
+    async with (
+        httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client,
+        client.stream("GET", url, headers=headers) as resp,
+    ):
+        resp.raise_for_status()
+        # Stream-read only the bytes we need. If a server or proxy ignores
+        # the Range header, `resp.content` would buffer the entire file
+        # into memory (PMTiles archives can be hundreds of GB). Using
+        # `aiter_bytes` + an early break caps us at HEADER_LEN bytes
+        # regardless of the server's behaviour.
+        body = bytearray()
+        async for chunk in resp.aiter_bytes():
+            remaining = HEADER_LEN - len(body)
+            if remaining <= 0:
+                break
+            body.extend(chunk[:remaining])
+            if len(body) >= HEADER_LEN:
+                break
     return parse_pmtiles_header(bytes(body))

--- a/ingestion/src/services/pmtiles_header.py
+++ b/ingestion/src/services/pmtiles_header.py
@@ -89,5 +89,8 @@ async def read_pmtiles_header(url: str) -> PMTilesHeader:
     async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:
         resp = await client.get(url, headers=headers)
         resp.raise_for_status()
-        body = resp.content
+        # Truncate defensively in case the server ignored the Range header and
+        # streamed more than the fixed 127-byte header. The parser only reads
+        # the first HEADER_LEN bytes anyway.
+        body = resp.content[:HEADER_LEN]
     return parse_pmtiles_header(body)

--- a/ingestion/src/services/pmtiles_header.py
+++ b/ingestion/src/services/pmtiles_header.py
@@ -37,9 +37,7 @@ class PMTilesHeader:
 
 def parse_pmtiles_header(buf: bytes) -> PMTilesHeader:
     if len(buf) < HEADER_LEN:
-        raise PMTilesHeaderError(
-            f"header length {len(buf)} < required {HEADER_LEN}"
-        )
+        raise PMTilesHeaderError(f"header length {len(buf)} < required {HEADER_LEN}")
     if buf[0:7] != MAGIC:
         raise PMTilesHeaderError("bad magic bytes (not a PMTiles file)")
     version = buf[7]

--- a/ingestion/src/services/pmtiles_header.py
+++ b/ingestion/src/services/pmtiles_header.py
@@ -12,6 +12,15 @@ MAGIC = b"PMTiles"
 SUPPORTED_VERSION = 3
 TILE_TYPE_MVT = 1
 
+# PMTiles v3 fixed-header byte offsets (see https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md).
+TILE_TYPE_OFFSET = 99
+MIN_ZOOM_OFFSET = 100
+MAX_ZOOM_OFFSET = 101
+MIN_LON_E7_OFFSET = 102
+MIN_LAT_E7_OFFSET = 106
+MAX_LON_E7_OFFSET = 110
+MAX_LAT_E7_OFFSET = 114
+
 
 class PMTilesHeaderError(Exception):
     pass
@@ -38,22 +47,22 @@ def parse_pmtiles_header(buf: bytes) -> PMTilesHeader:
         raise PMTilesHeaderError(
             f"unsupported PMTiles version {version}; only {SUPPORTED_VERSION} is supported"
         )
-    tile_type = buf[99]
+    tile_type = buf[TILE_TYPE_OFFSET]
     if tile_type != TILE_TYPE_MVT:
         raise PMTilesHeaderError(
             f"tile_type {tile_type} is not MVT (1); "
             "only vector PMTiles are supported as reference datasets"
         )
-    min_zoom = buf[100]
-    max_zoom = buf[101]
+    min_zoom = buf[MIN_ZOOM_OFFSET]
+    max_zoom = buf[MAX_ZOOM_OFFSET]
     if min_zoom > max_zoom:
         raise PMTilesHeaderError(
             f"min_zoom ({min_zoom}) must be <= max_zoom ({max_zoom})"
         )
-    min_lon_e7 = struct.unpack_from("<i", buf, 102)[0]
-    min_lat_e7 = struct.unpack_from("<i", buf, 106)[0]
-    max_lon_e7 = struct.unpack_from("<i", buf, 110)[0]
-    max_lat_e7 = struct.unpack_from("<i", buf, 114)[0]
+    min_lon_e7 = struct.unpack_from("<i", buf, MIN_LON_E7_OFFSET)[0]
+    min_lat_e7 = struct.unpack_from("<i", buf, MIN_LAT_E7_OFFSET)[0]
+    max_lon_e7 = struct.unpack_from("<i", buf, MAX_LON_E7_OFFSET)[0]
+    max_lat_e7 = struct.unpack_from("<i", buf, MAX_LAT_E7_OFFSET)[0]
     bounds = (
         min_lon_e7 / 1e7,
         min_lat_e7 / 1e7,

--- a/ingestion/src/services/pmtiles_header.py
+++ b/ingestion/src/services/pmtiles_header.py
@@ -1,0 +1,84 @@
+"""Read + parse the fixed 127-byte PMTiles v3 header over HTTP."""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+
+import httpx
+
+HEADER_LEN = 127
+MAGIC = b"PMTiles"
+SUPPORTED_VERSION = 3
+TILE_TYPE_MVT = 1
+
+
+class PMTilesHeaderError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class PMTilesHeader:
+    version: int
+    tile_type: int
+    min_zoom: int
+    max_zoom: int
+    bounds: tuple[float, float, float, float]
+
+
+def parse_pmtiles_header(buf: bytes) -> PMTilesHeader:
+    if len(buf) < HEADER_LEN:
+        raise PMTilesHeaderError(
+            f"header length {len(buf)} < required {HEADER_LEN}"
+        )
+    if buf[0:7] != MAGIC:
+        raise PMTilesHeaderError("bad magic bytes (not a PMTiles file)")
+    version = buf[7]
+    if version != SUPPORTED_VERSION:
+        raise PMTilesHeaderError(
+            f"unsupported PMTiles version {version}; only {SUPPORTED_VERSION} is supported"
+        )
+    tile_type = buf[77]
+    if tile_type != TILE_TYPE_MVT:
+        raise PMTilesHeaderError(
+            f"tile_type {tile_type} is not MVT (1); "
+            "only vector PMTiles are supported as reference datasets"
+        )
+    min_zoom = buf[78]
+    max_zoom = buf[79]
+    if min_zoom > max_zoom:
+        raise PMTilesHeaderError(
+            f"min_zoom ({min_zoom}) must be <= max_zoom ({max_zoom})"
+        )
+    min_lon_e7 = struct.unpack_from("<i", buf, 82)[0]
+    min_lat_e7 = struct.unpack_from("<i", buf, 86)[0]
+    max_lon_e7 = struct.unpack_from("<i", buf, 90)[0]
+    max_lat_e7 = struct.unpack_from("<i", buf, 94)[0]
+    bounds = (
+        min_lon_e7 / 1e7,
+        min_lat_e7 / 1e7,
+        max_lon_e7 / 1e7,
+        max_lat_e7 / 1e7,
+    )
+    if not (-180.0 <= bounds[0] <= 180.0 and -180.0 <= bounds[2] <= 180.0):
+        raise PMTilesHeaderError(f"longitude bounds out of range: {bounds}")
+    if not (-90.0 <= bounds[1] <= 90.0 and -90.0 <= bounds[3] <= 90.0):
+        raise PMTilesHeaderError(f"latitude bounds out of range: {bounds}")
+    if bounds[0] > bounds[2] or bounds[1] > bounds[3]:
+        raise PMTilesHeaderError(f"inverted bounds: {bounds}")
+    return PMTilesHeader(
+        version=version,
+        tile_type=tile_type,
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        bounds=bounds,
+    )
+
+
+async def read_pmtiles_header(url: str) -> PMTilesHeader:
+    headers = {"Range": f"bytes=0-{HEADER_LEN - 1}"}
+    async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:
+        resp = await client.get(url, headers=headers)
+        resp.raise_for_status()
+        body = resp.content
+    return parse_pmtiles_header(body)

--- a/ingestion/src/services/pmtiles_header.py
+++ b/ingestion/src/services/pmtiles_header.py
@@ -38,22 +38,22 @@ def parse_pmtiles_header(buf: bytes) -> PMTilesHeader:
         raise PMTilesHeaderError(
             f"unsupported PMTiles version {version}; only {SUPPORTED_VERSION} is supported"
         )
-    tile_type = buf[77]
+    tile_type = buf[99]
     if tile_type != TILE_TYPE_MVT:
         raise PMTilesHeaderError(
             f"tile_type {tile_type} is not MVT (1); "
             "only vector PMTiles are supported as reference datasets"
         )
-    min_zoom = buf[78]
-    max_zoom = buf[79]
+    min_zoom = buf[100]
+    max_zoom = buf[101]
     if min_zoom > max_zoom:
         raise PMTilesHeaderError(
             f"min_zoom ({min_zoom}) must be <= max_zoom ({max_zoom})"
         )
-    min_lon_e7 = struct.unpack_from("<i", buf, 82)[0]
-    min_lat_e7 = struct.unpack_from("<i", buf, 86)[0]
-    max_lon_e7 = struct.unpack_from("<i", buf, 90)[0]
-    max_lat_e7 = struct.unpack_from("<i", buf, 94)[0]
+    min_lon_e7 = struct.unpack_from("<i", buf, 102)[0]
+    min_lat_e7 = struct.unpack_from("<i", buf, 106)[0]
+    max_lon_e7 = struct.unpack_from("<i", buf, 110)[0]
+    max_lat_e7 = struct.unpack_from("<i", buf, 114)[0]
     bounds = (
         min_lon_e7 / 1e7,
         min_lat_e7 / 1e7,

--- a/ingestion/src/services/pmtiles_register.py
+++ b/ingestion/src/services/pmtiles_register.py
@@ -1,0 +1,78 @@
+"""Register a source.coop PMTiles product as a zero-copy example dataset."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import sessionmaker
+
+from src.models import Dataset, DatasetType, FormatPair
+from src.models.dataset import persist_dataset
+from src.services.pipeline import get_credits
+from src.services.pmtiles_header import PMTilesHeaderError, read_pmtiles_header
+from src.services.source_coop_config import SourceCoopProduct
+
+logger = logging.getLogger(__name__)
+
+
+class PMTilesRegistrationError(Exception):
+    pass
+
+
+async def register_pmtiles_example(
+    product: SourceCoopProduct,
+    db_session_factory: sessionmaker,
+) -> str:
+    """Register a kind="pmtiles" product as an is_example=True dataset row.
+
+    Returns the new dataset ID. Raises PMTilesRegistrationError on any
+    probe/parse/persist failure.
+    """
+    if product.kind != "pmtiles" or not product.pmtiles_url:
+        raise PMTilesRegistrationError(
+            f"{product.slug}: register_pmtiles_example requires kind='pmtiles' and pmtiles_url"
+        )
+
+    try:
+        header = await read_pmtiles_header(product.pmtiles_url)
+    except PMTilesHeaderError as exc:
+        raise PMTilesRegistrationError(
+            f"{product.slug}: header probe failed: {exc}"
+        ) from exc
+    except Exception as exc:
+        raise PMTilesRegistrationError(
+            f"{product.slug}: header fetch failed: {exc}"
+        ) from exc
+
+    dataset_id = str(uuid.uuid4())
+    dataset = Dataset(
+        id=dataset_id,
+        filename=product.name,
+        dataset_type=DatasetType.VECTOR,
+        format_pair=FormatPair.PMTILES,
+        tile_url=product.pmtiles_url,
+        bounds=list(header.bounds),
+        min_zoom=header.min_zoom,
+        max_zoom=header.max_zoom,
+        validation_results=[],
+        credits=get_credits(FormatPair.PMTILES),
+        is_temporal=False,
+        timesteps=[],
+        source_url=product.listing_url,
+        workspace_id=None,
+        is_example=True,
+        is_zero_copy=True,
+        created_at=datetime.now(UTC),
+    )
+
+    try:
+        persist_dataset(db_session_factory, dataset)
+    except Exception as exc:
+        raise PMTilesRegistrationError(
+            f"{product.slug}: persist failed: {exc}"
+        ) from exc
+
+    logger.info("registered pmtiles example dataset %s (%s)", product.slug, dataset_id)
+    return dataset_id

--- a/ingestion/src/services/pmtiles_register.py
+++ b/ingestion/src/services/pmtiles_register.py
@@ -27,6 +27,11 @@ async def register_pmtiles_example(
 ) -> str:
     """Register a kind="pmtiles" product as an is_example=True dataset row.
 
+    The dataset is tagged DatasetType.VECTOR because `read_pmtiles_header`
+    rejects any PMTiles file whose tile_type is not MVT (vector). If that
+    guard is ever relaxed to admit raster PMTiles, this assignment must be
+    updated to derive the type from the parsed header.
+
     Returns the new dataset ID. Raises PMTilesRegistrationError on any
     probe/parse/persist failure.
     """

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -9,7 +9,7 @@ frontend/src/lib/sourceCoopCatalog.ts.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 
 @dataclass(frozen=True)
@@ -18,9 +18,39 @@ class SourceCoopProduct:
     name: str
     description: str
     listing_url: str
-    enumerator: str
+    kind: Literal["mosaic", "pmtiles"] = "mosaic"
+    enumerator: str = ""
     enumerator_args: dict[str, Any] = field(default_factory=dict)
     is_temporal: bool = False
+    pmtiles_url: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind == "pmtiles":
+            if not self.pmtiles_url:
+                raise ValueError(
+                    f"{self.slug}: pmtiles kind requires pmtiles_url"
+                )
+            if self.enumerator:
+                raise ValueError(
+                    f"{self.slug}: pmtiles kind must not set enumerator"
+                )
+            if self.enumerator_args:
+                raise ValueError(
+                    f"{self.slug}: pmtiles kind must not set enumerator_args"
+                )
+            if self.is_temporal:
+                raise ValueError(
+                    f"{self.slug}: pmtiles kind must not set is_temporal"
+                )
+        elif self.kind == "mosaic":
+            if not self.enumerator:
+                raise ValueError(
+                    f"{self.slug}: mosaic kind requires enumerator"
+                )
+            if self.pmtiles_url:
+                raise ValueError(
+                    f"{self.slug}: mosaic kind must not set pmtiles_url"
+                )
 
 
 _PRODUCTS: dict[str, SourceCoopProduct] = {

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -27,30 +27,20 @@ class SourceCoopProduct:
     def __post_init__(self) -> None:
         if self.kind == "pmtiles":
             if not self.pmtiles_url:
-                raise ValueError(
-                    f"{self.slug}: pmtiles kind requires pmtiles_url"
-                )
+                raise ValueError(f"{self.slug}: pmtiles kind requires pmtiles_url")
             if self.enumerator:
-                raise ValueError(
-                    f"{self.slug}: pmtiles kind must not set enumerator"
-                )
+                raise ValueError(f"{self.slug}: pmtiles kind must not set enumerator")
             if self.enumerator_args:
                 raise ValueError(
                     f"{self.slug}: pmtiles kind must not set enumerator_args"
                 )
             if self.is_temporal:
-                raise ValueError(
-                    f"{self.slug}: pmtiles kind must not set is_temporal"
-                )
+                raise ValueError(f"{self.slug}: pmtiles kind must not set is_temporal")
         elif self.kind == "mosaic":
             if not self.enumerator:
-                raise ValueError(
-                    f"{self.slug}: mosaic kind requires enumerator"
-                )
+                raise ValueError(f"{self.slug}: mosaic kind requires enumerator")
             if self.pmtiles_url:
-                raise ValueError(
-                    f"{self.slug}: mosaic kind must not set pmtiles_url"
-                )
+                raise ValueError(f"{self.slug}: mosaic kind must not set pmtiles_url")
 
 
 _PRODUCTS: dict[str, SourceCoopProduct] = {

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -92,6 +92,17 @@ _PRODUCTS: dict[str, SourceCoopProduct] = {
         enumerator_args={"filenames": ["deforest_carbon_100m_cog.tif"]},
         is_temporal=False,
     ),
+    "vida/google-microsoft-osm-open-buildings": SourceCoopProduct(
+        slug="vida/google-microsoft-osm-open-buildings",
+        name="Global Buildings (VIDA)",
+        description=(
+            "Combined Google, Microsoft, and OpenStreetMap building "
+            "footprints worldwide, published as a single PMTiles archive."
+        ),
+        listing_url="https://data.source.coop/vida/google-microsoft-osm-open-buildings/",
+        kind="pmtiles",
+        pmtiles_url="https://data.source.coop/vida/google-microsoft-osm-open-buildings/pmtiles/goog_msft_osm.pmtiles",
+    ),
 }
 
 

--- a/ingestion/tests/services/test_example_datasets.py
+++ b/ingestion/tests/services/test_example_datasets.py
@@ -171,3 +171,40 @@ def test_missing_example_products_returns_unregistered():
 
     missing_slugs = {p.slug for p in missing_example_products(factory)}
     assert "alexgleith/gebco-2024" not in missing_slugs
+
+
+def test_register_example_datasets_dispatches_pmtiles():
+    _, factory = _make_db()
+
+    from src.services.source_coop_config import SourceCoopProduct
+
+    fake_product = SourceCoopProduct(
+        slug="test/pmt",
+        name="test pmtiles",
+        description="d",
+        listing_url="https://data.source.coop/test/pmt/",
+        kind="pmtiles",
+        pmtiles_url="https://data.source.coop/test/pmt/x.pmtiles",
+    )
+
+    pmtiles_register_mock = AsyncMock(return_value="pmt-id")
+
+    with (
+        patch(
+            "src.services.example_datasets.ordered_products",
+            return_value=[fake_product],
+        ),
+        patch(
+            "src.services.example_datasets.register_pmtiles_example",
+            pmtiles_register_mock,
+        ),
+    ):
+        asyncio.run(
+            register_example_datasets(
+                db_session_factory=factory,
+                only_slugs={"test/pmt"},
+            )
+        )
+
+    pmtiles_register_mock.assert_awaited_once()
+    assert pmtiles_register_mock.await_args.args[0].slug == "test/pmt"

--- a/ingestion/tests/services/test_pmtiles_header.py
+++ b/ingestion/tests/services/test_pmtiles_header.py
@@ -137,6 +137,7 @@ def test_read_pmtiles_header_issues_range_request():
 
     with patch("src.services.pmtiles_header.httpx.AsyncClient", FakeClient):
         import asyncio
+
         parsed = asyncio.run(read_pmtiles_header("https://example/x.pmtiles"))
 
     assert parsed.tile_type == 1
@@ -159,6 +160,7 @@ def test_read_pmtiles_header_stops_after_header_len_when_server_ignores_range():
 
     with patch("src.services.pmtiles_header.httpx.AsyncClient", FakeClient):
         import asyncio
+
         parsed = asyncio.run(read_pmtiles_header("https://example/x.pmtiles"))
 
     assert parsed.tile_type == 1

--- a/ingestion/tests/services/test_pmtiles_header.py
+++ b/ingestion/tests/services/test_pmtiles_header.py
@@ -95,9 +95,12 @@ def test_read_pmtiles_header_issues_range_request():
         def raise_for_status(self):
             return None
 
+    instances: list = []
+
     class FakeClient:
         def __init__(self, *args, **kwargs):
             self.get = AsyncMock(return_value=FakeResponse())
+            instances.append(self)
 
         __aenter__ = fake_aenter
         __aexit__ = fake_aexit
@@ -107,3 +110,8 @@ def test_read_pmtiles_header_issues_range_request():
         parsed = asyncio.run(read_pmtiles_header("https://example/x.pmtiles"))
 
     assert parsed.tile_type == 1
+    assert len(instances) == 1
+    client = instances[0]
+    client.get.assert_awaited_once()
+    call_kwargs = client.get.await_args.kwargs
+    assert call_kwargs["headers"] == {"Range": "bytes=0-126"}

--- a/ingestion/tests/services/test_pmtiles_header.py
+++ b/ingestion/tests/services/test_pmtiles_header.py
@@ -24,13 +24,13 @@ def _make_header(
     buf = bytearray(127)
     buf[0:7] = b"PMTiles"
     buf[7] = version
-    buf[77] = tile_type
-    buf[78] = min_zoom
-    buf[79] = max_zoom
-    struct.pack_into("<i", buf, 82, min_lon_e7)
-    struct.pack_into("<i", buf, 86, min_lat_e7)
-    struct.pack_into("<i", buf, 90, max_lon_e7)
-    struct.pack_into("<i", buf, 94, max_lat_e7)
+    buf[99] = tile_type
+    buf[100] = min_zoom
+    buf[101] = max_zoom
+    struct.pack_into("<i", buf, 102, min_lon_e7)
+    struct.pack_into("<i", buf, 106, min_lat_e7)
+    struct.pack_into("<i", buf, 110, max_lon_e7)
+    struct.pack_into("<i", buf, 114, max_lat_e7)
     return bytes(buf)
 
 

--- a/ingestion/tests/services/test_pmtiles_header.py
+++ b/ingestion/tests/services/test_pmtiles_header.py
@@ -1,0 +1,109 @@
+import struct
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.services.pmtiles_header import (
+    PMTilesHeader,
+    PMTilesHeaderError,
+    parse_pmtiles_header,
+    read_pmtiles_header,
+)
+
+
+def _make_header(
+    version: int = 3,
+    tile_type: int = 1,
+    min_zoom: int = 0,
+    max_zoom: int = 14,
+    min_lon_e7: int = -1_800_000_000,
+    min_lat_e7: int = -850_511_287,
+    max_lon_e7: int = 1_800_000_000,
+    max_lat_e7: int = 850_511_287,
+) -> bytes:
+    buf = bytearray(127)
+    buf[0:7] = b"PMTiles"
+    buf[7] = version
+    buf[77] = tile_type
+    buf[78] = min_zoom
+    buf[79] = max_zoom
+    struct.pack_into("<i", buf, 82, min_lon_e7)
+    struct.pack_into("<i", buf, 86, min_lat_e7)
+    struct.pack_into("<i", buf, 90, max_lon_e7)
+    struct.pack_into("<i", buf, 94, max_lat_e7)
+    return bytes(buf)
+
+
+def test_parse_valid_header_returns_bounds_and_zoom():
+    header_bytes = _make_header()
+    parsed = parse_pmtiles_header(header_bytes)
+    assert isinstance(parsed, PMTilesHeader)
+    assert parsed.min_zoom == 0
+    assert parsed.max_zoom == 14
+    assert parsed.tile_type == 1
+    assert parsed.bounds[0] == pytest.approx(-180.0)
+    assert parsed.bounds[1] == pytest.approx(-85.0511287)
+    assert parsed.bounds[2] == pytest.approx(180.0)
+    assert parsed.bounds[3] == pytest.approx(85.0511287)
+
+
+def test_parse_rejects_bad_magic():
+    bad = bytearray(_make_header())
+    bad[0:7] = b"NOPMTFX"
+    with pytest.raises(PMTilesHeaderError, match="magic"):
+        parse_pmtiles_header(bytes(bad))
+
+
+def test_parse_rejects_wrong_version():
+    with pytest.raises(PMTilesHeaderError, match="version"):
+        parse_pmtiles_header(_make_header(version=2))
+
+
+def test_parse_rejects_non_mvt_tile_type():
+    with pytest.raises(PMTilesHeaderError, match="tile_type"):
+        parse_pmtiles_header(_make_header(tile_type=2))
+
+
+def test_parse_rejects_inverted_zoom_range():
+    with pytest.raises(PMTilesHeaderError, match="min_zoom"):
+        parse_pmtiles_header(_make_header(min_zoom=10, max_zoom=5))
+
+
+def test_parse_rejects_out_of_range_bounds():
+    with pytest.raises(PMTilesHeaderError, match="bounds"):
+        parse_pmtiles_header(_make_header(min_lon_e7=-2_000_000_000))
+
+
+def test_parse_rejects_short_buffer():
+    with pytest.raises(PMTilesHeaderError, match="length"):
+        parse_pmtiles_header(b"PMTiles" + b"\x00" * 10)
+
+
+def test_read_pmtiles_header_issues_range_request():
+    header_bytes = _make_header()
+
+    async def fake_aenter(self):
+        return self
+
+    async def fake_aexit(self, *_args):
+        return None
+
+    class FakeResponse:
+        status_code = 206
+        content = header_bytes
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.get = AsyncMock(return_value=FakeResponse())
+
+        __aenter__ = fake_aenter
+        __aexit__ = fake_aexit
+
+    with patch("src.services.pmtiles_header.httpx.AsyncClient", FakeClient):
+        import asyncio
+        parsed = asyncio.run(read_pmtiles_header("https://example/x.pmtiles"))
+
+    assert parsed.tile_type == 1

--- a/ingestion/tests/services/test_pmtiles_header.py
+++ b/ingestion/tests/services/test_pmtiles_header.py
@@ -4,6 +4,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from src.services.pmtiles_header import (
+    MAX_LAT_E7_OFFSET,
+    MAX_LON_E7_OFFSET,
+    MAX_ZOOM_OFFSET,
+    MIN_LAT_E7_OFFSET,
+    MIN_LON_E7_OFFSET,
+    MIN_ZOOM_OFFSET,
+    TILE_TYPE_OFFSET,
     PMTilesHeader,
     PMTilesHeaderError,
     parse_pmtiles_header,
@@ -24,13 +31,13 @@ def _make_header(
     buf = bytearray(127)
     buf[0:7] = b"PMTiles"
     buf[7] = version
-    buf[99] = tile_type
-    buf[100] = min_zoom
-    buf[101] = max_zoom
-    struct.pack_into("<i", buf, 102, min_lon_e7)
-    struct.pack_into("<i", buf, 106, min_lat_e7)
-    struct.pack_into("<i", buf, 110, max_lon_e7)
-    struct.pack_into("<i", buf, 114, max_lat_e7)
+    buf[TILE_TYPE_OFFSET] = tile_type
+    buf[MIN_ZOOM_OFFSET] = min_zoom
+    buf[MAX_ZOOM_OFFSET] = max_zoom
+    struct.pack_into("<i", buf, MIN_LON_E7_OFFSET, min_lon_e7)
+    struct.pack_into("<i", buf, MIN_LAT_E7_OFFSET, min_lat_e7)
+    struct.pack_into("<i", buf, MAX_LON_E7_OFFSET, max_lon_e7)
+    struct.pack_into("<i", buf, MAX_LAT_E7_OFFSET, max_lat_e7)
     return bytes(buf)
 
 

--- a/ingestion/tests/services/test_pmtiles_register.py
+++ b/ingestion/tests/services/test_pmtiles_register.py
@@ -1,0 +1,99 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import pytest
+
+from src.models.base import Base
+from src.models.dataset import DatasetRow
+from src.services.pmtiles_header import PMTilesHeader, PMTilesHeaderError
+from src.services.pmtiles_register import (
+    PMTilesRegistrationError,
+    register_pmtiles_example,
+)
+from src.services.source_coop_config import SourceCoopProduct
+
+
+def _make_db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _product() -> SourceCoopProduct:
+    return SourceCoopProduct(
+        slug="test/vida",
+        name="Global Buildings (VIDA)",
+        description="Combined Google, Microsoft, and OSM building footprints.",
+        listing_url="https://data.source.coop/test/vida/",
+        kind="pmtiles",
+        pmtiles_url="https://data.source.coop/test/vida/buildings.pmtiles",
+    )
+
+
+def test_register_pmtiles_example_persists_dataset_row():
+    factory = _make_db()
+    header = PMTilesHeader(
+        version=3,
+        tile_type=1,
+        min_zoom=0,
+        max_zoom=14,
+        bounds=(-180.0, -85.0, 180.0, 85.0),
+    )
+
+    with patch(
+        "src.services.pmtiles_register.read_pmtiles_header",
+        AsyncMock(return_value=header),
+    ):
+        dataset_id = asyncio.run(register_pmtiles_example(_product(), factory))
+
+    session = factory()
+    try:
+        row = session.query(DatasetRow).filter(DatasetRow.id == dataset_id).one()
+    finally:
+        session.close()
+
+    assert row.format_pair == "pmtiles"
+    assert row.dataset_type == "vector"
+    assert row.tile_url == "https://data.source.coop/test/vida/buildings.pmtiles"
+    assert row.is_example is True
+    assert row.workspace_id is None
+
+    meta = json.loads(row.metadata_json)
+    assert meta["is_zero_copy"] is True
+    assert meta["source_url"] == "https://data.source.coop/test/vida/"
+    assert meta["min_zoom"] == 0
+    assert meta["max_zoom"] == 14
+    assert meta["credits"], "expected credits list"
+
+
+def test_register_pmtiles_example_raises_when_header_probe_fails():
+    factory = _make_db()
+
+    with patch(
+        "src.services.pmtiles_register.read_pmtiles_header",
+        AsyncMock(side_effect=PMTilesHeaderError("bad magic")),
+    ):
+        with pytest.raises(PMTilesRegistrationError):
+            asyncio.run(register_pmtiles_example(_product(), factory))
+
+
+def test_register_pmtiles_example_rejects_non_pmtiles_product():
+    factory = _make_db()
+    mosaic_product = SourceCoopProduct(
+        slug="test/mosaic",
+        name="mosaic",
+        description="d",
+        listing_url="https://data.source.coop/test/mosaic/",
+        enumerator="path_listing",
+    )
+    with pytest.raises(PMTilesRegistrationError, match="kind"):
+        asyncio.run(register_pmtiles_example(mosaic_product, factory))

--- a/ingestion/tests/services/test_pmtiles_register.py
+++ b/ingestion/tests/services/test_pmtiles_register.py
@@ -2,11 +2,10 @@ import asyncio
 import json
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
-
-import pytest
 
 from src.models.base import Base
 from src.models.dataset import DatasetRow
@@ -81,9 +80,8 @@ def test_register_pmtiles_example_raises_when_header_probe_fails():
     with patch(
         "src.services.pmtiles_register.read_pmtiles_header",
         AsyncMock(side_effect=PMTilesHeaderError("bad magic")),
-    ):
-        with pytest.raises(PMTilesRegistrationError):
-            asyncio.run(register_pmtiles_example(_product(), factory))
+    ), pytest.raises(PMTilesRegistrationError):
+        asyncio.run(register_pmtiles_example(_product(), factory))
 
 
 def test_register_pmtiles_example_rejects_non_pmtiles_product():

--- a/ingestion/tests/services/test_pmtiles_register.py
+++ b/ingestion/tests/services/test_pmtiles_register.py
@@ -77,10 +77,13 @@ def test_register_pmtiles_example_persists_dataset_row():
 def test_register_pmtiles_example_raises_when_header_probe_fails():
     factory = _make_db()
 
-    with patch(
-        "src.services.pmtiles_register.read_pmtiles_header",
-        AsyncMock(side_effect=PMTilesHeaderError("bad magic")),
-    ), pytest.raises(PMTilesRegistrationError):
+    with (
+        patch(
+            "src.services.pmtiles_register.read_pmtiles_header",
+            AsyncMock(side_effect=PMTilesHeaderError("bad magic")),
+        ),
+        pytest.raises(PMTilesRegistrationError),
+    ):
         asyncio.run(register_pmtiles_example(_product(), factory))
 
 

--- a/ingestion/tests/services/test_pmtiles_register.py
+++ b/ingestion/tests/services/test_pmtiles_register.py
@@ -95,5 +95,5 @@ def test_register_pmtiles_example_rejects_non_pmtiles_product():
         listing_url="https://data.source.coop/test/mosaic/",
         enumerator="path_listing",
     )
-    with pytest.raises(PMTilesRegistrationError, match="kind"):
+    with pytest.raises(PMTilesRegistrationError):
         asyncio.run(register_pmtiles_example(mosaic_product, factory))

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -117,6 +117,8 @@ def test_vida_buildings_entry_is_pmtiles():
     p = get_product("vida/google-microsoft-osm-open-buildings")
     assert p.kind == "pmtiles"
     assert p.pmtiles_url
-    assert p.pmtiles_url.startswith("https://data.source.coop/vida/google-microsoft-osm-open-buildings/")
+    assert p.pmtiles_url.startswith(
+        "https://data.source.coop/vida/google-microsoft-osm-open-buildings/"
+    )
     assert p.pmtiles_url.endswith(".pmtiles")
     assert p.is_temporal is False

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -51,3 +51,49 @@ def test_lg_land_uses_path_listing():
 def test_lg_land_pins_single_deforestation_emissions_raster():
     p = get_product("vizzuality/lg-land-carbon-data")
     assert p.enumerator_args.get("filenames") == ["deforest_carbon_100m_cog.tif"]
+
+
+def test_product_defaults_to_mosaic_kind():
+    p = get_product("alexgleith/gebco-2024")
+    assert p.kind == "mosaic"
+    assert p.pmtiles_url is None
+
+
+def test_pmtiles_product_validates_required_fields():
+    with pytest.raises(ValueError):
+        SourceCoopProduct(
+            slug="test/bad",
+            name="bad",
+            description="bad",
+            listing_url="https://data.source.coop/test/bad/",
+            kind="pmtiles",
+            pmtiles_url=None,
+        )
+
+
+def test_pmtiles_product_rejects_enumerator_fields():
+    with pytest.raises(ValueError):
+        SourceCoopProduct(
+            slug="test/bad",
+            name="bad",
+            description="bad",
+            listing_url="https://data.source.coop/test/bad/",
+            kind="pmtiles",
+            pmtiles_url="https://data.source.coop/test/bad/x.pmtiles",
+            enumerator="path_listing",
+        )
+
+
+def test_pmtiles_product_accepts_valid_shape():
+    p = SourceCoopProduct(
+        slug="test/good",
+        name="good",
+        description="good",
+        listing_url="https://data.source.coop/test/good/",
+        kind="pmtiles",
+        pmtiles_url="https://data.source.coop/test/good/x.pmtiles",
+    )
+    assert p.kind == "pmtiles"
+    assert p.pmtiles_url == "https://data.source.coop/test/good/x.pmtiles"
+    assert p.enumerator == ""
+    assert p.is_temporal is False

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -7,13 +7,14 @@ from src.services.source_coop_config import (
 )
 
 
-def test_list_products_returns_three_v1_entries():
+def test_list_products_returns_four_v1_entries():
     products = list_products()
     slugs = {p.slug for p in products}
     assert slugs == {
         "ausantarctic/ghrsst-mur-v2",
         "alexgleith/gebco-2024",
         "vizzuality/lg-land-carbon-data",
+        "vida/google-microsoft-osm-open-buildings",
     }
 
 
@@ -109,4 +110,13 @@ def test_pmtiles_product_accepts_valid_shape():
     assert p.kind == "pmtiles"
     assert p.pmtiles_url == "https://data.source.coop/test/good/x.pmtiles"
     assert p.enumerator == ""
+    assert p.is_temporal is False
+
+
+def test_vida_buildings_entry_is_pmtiles():
+    p = get_product("vida/google-microsoft-osm-open-buildings")
+    assert p.kind == "pmtiles"
+    assert p.pmtiles_url
+    assert p.pmtiles_url.startswith("https://data.source.coop/vida/google-microsoft-osm-open-buildings/")
+    assert p.pmtiles_url.endswith(".pmtiles")
     assert p.is_temporal is False

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -84,6 +84,19 @@ def test_pmtiles_product_rejects_enumerator_fields():
         )
 
 
+def test_mosaic_product_rejects_pmtiles_url():
+    with pytest.raises(ValueError):
+        SourceCoopProduct(
+            slug="test/bad",
+            name="bad",
+            description="bad",
+            listing_url="https://data.source.coop/test/bad/",
+            kind="mosaic",
+            enumerator="path_listing",
+            pmtiles_url="https://data.source.coop/test/bad/x.pmtiles",
+        )
+
+
 def test_pmtiles_product_accepts_valid_shape():
     p = SourceCoopProduct(
         slug="test/good",

--- a/ingestion/tests/test_models.py
+++ b/ingestion/tests/test_models.py
@@ -207,6 +207,14 @@ def test_dataset_is_example_set_true():
     assert d.is_example is True
 
 
+def test_format_pair_pmtiles_is_vector():
+    assert FormatPair.PMTILES.dataset_type == DatasetType.VECTOR
+
+
+def test_format_pair_from_extension_pmtiles():
+    assert FormatPair.from_extension(".pmtiles") == FormatPair.PMTILES
+
+
 def test_dataset_row_has_is_shared_default_false(db_session):
     from src.models.dataset import DatasetRow
 

--- a/ingestion/tests/test_pipeline.py
+++ b/ingestion/tests/test_pipeline.py
@@ -49,6 +49,17 @@ def test_get_credits_vector_pmtiles():
     assert "tipg" not in names
 
 
+def test_get_credits_pmtiles_reference():
+    credits = get_credits(FormatPair.PMTILES)
+    tools = [c["tool"] for c in credits]
+    assert "PMTiles" in tools
+    assert "MapLibre" in tools
+    assert "tippecanoe" not in tools
+    assert "pgSTAC" not in tools
+    assert "TiTiler" not in tools
+    assert "tipg" not in tools
+
+
 def test_get_credits_vector_tipg_unchanged():
     credits = get_credits(FormatPair.GEOJSON_TO_GEOPARQUET, use_pmtiles=False)
     names = [c["tool"] for c in credits]

--- a/ingestion/tests/test_pipeline.py
+++ b/ingestion/tests/test_pipeline.py
@@ -51,6 +51,7 @@ def test_get_credits_vector_pmtiles():
 
 def test_get_credits_pmtiles_reference():
     credits = get_credits(FormatPair.PMTILES)
+    assert len(credits) == 2
     tools = [c["tool"] for c in credits]
     assert "PMTiles" in tools
     assert "MapLibre" in tools


### PR DESCRIPTION
## Summary

Adds zero-copy support for source.coop PMTiles reference datasets and registers VIDA's Global Buildings as the first PMTiles example (~2.7B building footprints, 254 GB `.pmtiles` on Cloudflare-fronted S3, served in ~190 ms at registration time via a single 127-byte byte-range request).

- **Backend:** `FormatPair.PMTILES` + `SourceCoopProduct.kind` field + PMTiles v3 header reader + `register_pmtiles_example` (persists an `is_example=True` dataset row with no pgSTAC collection and no R2 copy) + startup dispatch on `product.kind`.
- **Frontend:** `isPMTilesDataset(ds)` helper supporting both the new `format_pair === "pmtiles"` case and the legacy `/pmtiles/` tile_url prefix (so existing uploaded PMTiles keep rendering), 5 call sites refactored, VIDA catalog entry added for the gallery card.

Closes #202.

## Notable divergences from the plan

- The plan specified PMTiles v3 byte offsets at 77/78/79/82-94; the actual spec puts those fields 22 bytes later (99/100/101/102-114). Caught when the real VIDA file parsed with `tile_type=0` instead of `1`. Fixed in [`48a550f`](../commit/48a550f) with a follow-up ([`96a0b7b`](../commit/96a0b7b)) that extracted the offsets as named constants shared between parser and tests to prevent drift.
- Picked up a 5th call site beyond the plan's four: `stepContent.ts` was classifying datasets by `tile_url` prefix only and would have misclassified source.coop VIDA as `vector-postgis`. Routed through the helper in [`55a1f3b`](../commit/55a1f3b).

## Test plan

- [ ] `cd ingestion && uv run pytest` — 69/69 pass in touched files. Pre-existing pyarrow/pmtiles/netcdf/obstore-IAM env failures unchanged.
- [ ] `cd frontend && npx tsc --noEmit && npx vitest run` — tsc clean, 411/411 pass.
- [ ] Start worktree stack; confirm ingestion log `registered pmtiles example dataset vida/google-microsoft-osm-open-buildings (…)` appears within a few hundred ms of startup.
- [ ] `GET /api/datasets` returns the VIDA row with `format_pair: "pmtiles"`, `bounds: [-180, -55.98, 180, 83.10]`, `min_zoom: 0`, `max_zoom: 15`, `is_example: true`.
- [ ] Gallery at `/` shows the VIDA card; click navigates to `/map/<id>`, sidebar shows `Vector Tiles` mode + `pmtiles → converted` summary.
- [ ] **Visual map render** — verify on a host with real WebGL. (Verified in this environment only via the dataset row, network plumbing, and sidebar state; the headless Chromium on the dev VM has no WebGL context, so no map — GEBCO/GHRSST/Land Carbon also go blank.)
- [ ] Zoom in and confirm the browser issues 206 byte-range requests to `data.source.coop` via MapLibre (direct, not through `/api/proxy`).
- [ ] Stack restart with persistent volumes skips the VIDA product as already registered. Verified: dataset count stays at 4, log emits `example dataset already present, skipping: vida/google-microsoft-osm-open-buildings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Global Buildings (VIDA) dataset served as PMTiles; full PMTiles support: automatic detection, header probing for bounds/zoom, registration as vector example, and PMTiles-specific map credits.

* **Documentation**
  * Updated API docs to describe PMTiles product handling and registration behavior.

* **Tests**
  * Expanded test coverage for PMTiles detection, header parsing, registration flows, and credit reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->