### PR TITLE
fix(frontend): complete proj4 defs for client COG renderer

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -5,12 +5,15 @@
 	# tile URLs (XYZ, COG, PMTiles, GeoParquet) and basemap styles from
 	# basemaps.cartocdn.com; it locks down script-src/object-src/frame-ancestors
 	# to defend against XSS and clickjacking. wasm-unsafe-eval is required by
-	# DuckDB-WASM (GeoParquet client renderer).
+	# DuckDB-WASM (GeoParquet client renderer). static.cloudflareinsights.com
+	# is allowed because Cloudflare (the proxy in front of the site) injects a
+	# Web Analytics beacon when the domain has proxy + analytics enabled; the
+	# connect-src permits the matching report endpoint.
 	header {
 		Strict-Transport-Security "max-age=31536000; includeSubDomains"
 		X-Content-Type-Options "nosniff"
 		Referrer-Policy "strict-origin-when-cross-origin"
-		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https: blob:; worker-src 'self' blob:; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https: blob:; worker-src 'self' blob:; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; object-src 'none'"
 	}
 
 	# Data-serving paths: proxy to R2 public URL. Public — range requests

--- a/frontend/src/lib/layers/__tests__/cogLayer.test.ts
+++ b/frontend/src/lib/layers/__tests__/cogLayer.test.ts
@@ -46,6 +46,19 @@ describe("localEpsgResolver (EPSG defs)", () => {
       expect(ilat).toBeCloseTo(lat, 6);
     }
   });
+
+  it("matches canonical Web Mercator (spherical, not ellipsoidal) at the antimeridian", async () => {
+    // Web Mercator / EPSG:3857 is defined on a sphere with a = b = 6378137, so
+    // the half-circumference at lon=180 must be π * 6378137 ≈ 20037508.3428.
+    // An ellipsoidal merc def (ellps: WGS84, rf: 298.25…) would drift y by
+    // tens of km at mid/high latitudes and silently break tile alignment.
+    const def4326 = await localEpsgResolver(4326);
+    const def3857 = await localEpsgResolver(3857);
+    const forward = proj4(def4326 as never, def3857 as never);
+    const [x, y] = forward.forward([180, 0]);
+    expect(x).toBeCloseTo(20037508.3428, 2);
+    expect(y).toBeCloseTo(0, 2);
+  });
 });
 
 describe("resolveCogUrl", () => {

--- a/frontend/src/lib/layers/__tests__/cogLayer.test.ts
+++ b/frontend/src/lib/layers/__tests__/cogLayer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import proj4 from "proj4";
 
 vi.mock("@developmentseed/deck.gl-geotiff", () => ({
   COGLayer: vi.fn(),
@@ -6,9 +7,46 @@ vi.mock("@developmentseed/deck.gl-geotiff", () => ({
 
 vi.mock("@developmentseed/deck.gl-raster/gpu-modules", () => ({
   CreateTexture: {},
+  Colormap: {},
 }));
 
-import { resolveCogUrl } from "../cogLayer";
+import { resolveCogUrl, localEpsgResolver } from "../cogLayer";
+
+describe("localEpsgResolver (EPSG defs)", () => {
+  // Regression: the local EPSG defs were missing proj4's required origin
+  // params (long0, lat0, lat_ts, x0, y0, k0). proj4 tolerated the missing
+  // source-side fields for longlat but silently produced NaN x values when
+  // the def was used on either end of a merc converter. That NaN fed into
+  // deck.gl-raster's tile traversal and crashed the bounding-volume
+  // calculation, which then looped forever in the animation frame.
+  it("produces finite forward/inverse coordinates between 4326 and 3857", async () => {
+    const def4326 = await localEpsgResolver(4326);
+    const def3857 = await localEpsgResolver(3857);
+
+    const samples: Array<[number, number]> = [
+      [11, 47],
+      [-156, 76],
+      [-156, -76],
+      [0, 0],
+      [179, 84],
+    ];
+
+    const forward = proj4(def4326 as never, def3857 as never);
+    for (const [lon, lat] of samples) {
+      const [x, y] = forward.forward([lon, lat]);
+      expect(Number.isFinite(x)).toBe(true);
+      expect(Number.isFinite(y)).toBe(true);
+    }
+
+    const inverse = proj4(def3857 as never, def4326 as never);
+    for (const [lon, lat] of samples) {
+      const [fx, fy] = forward.forward([lon, lat]);
+      const [ilon, ilat] = inverse.forward([fx, fy]);
+      expect(ilon).toBeCloseTo(lon, 6);
+      expect(ilat).toBeCloseTo(lat, 6);
+    }
+  });
+});
 
 describe("resolveCogUrl", () => {
   it("passes https URLs through unchanged", () => {

--- a/frontend/src/lib/layers/cogLayer.ts
+++ b/frontend/src/lib/layers/cogLayer.ts
@@ -10,6 +10,11 @@ import wktParser from "wkt-parser";
 
 // --- EPSG resolver (offline for common CRSes, network fallback) ---
 
+// proj4 requires projection origin/scale params (long0, lat0, lat_ts, x0, y0,
+// k0) on merc definitions; without them forward() emits NaN x, which NaNs out
+// every reference-point reprojection downstream and crashes the TileLayer's
+// bounding-volume calculation. The axis is "enu" so input is interpreted as
+// [lon, lat], matching the rest of the code.
 const EPSG_DEFS: Record<number, unknown> = {
   4326: {
     projName: "longlat",
@@ -18,7 +23,11 @@ const EPSG_DEFS: Record<number, unknown> = {
     ellps: "WGS 84",
     a: 6378137,
     rf: 298.257223563,
-    axis: "neu",
+    long0: 0,
+    lat0: 0,
+    x0: 0,
+    y0: 0,
+    axis: "enu",
     units: "degree",
   },
   3857: {
@@ -28,6 +37,12 @@ const EPSG_DEFS: Record<number, unknown> = {
     ellps: "WGS 84",
     a: 6378137,
     rf: 298.257223563,
+    long0: 0,
+    lat0: 0,
+    lat_ts: 0,
+    x0: 0,
+    y0: 0,
+    k0: 1,
     axis: "enu",
     units: "metre",
   },

--- a/frontend/src/lib/layers/cogLayer.ts
+++ b/frontend/src/lib/layers/cogLayer.ts
@@ -34,9 +34,13 @@ const EPSG_DEFS: Record<number, unknown> = {
     projName: "merc",
     name: "WGS 84 / Pseudo-Mercator",
     srsCode: "WGS 84 / Pseudo-Mercator",
-    ellps: "WGS 84",
+    // Web Mercator is defined on a sphere with a = b = 6378137. Using the
+    // WGS84 ellipsoid (rf ≈ 298.26) here would apply elliptical mercator math
+    // and shift y by tens of km at mid/high latitudes, breaking alignment
+    // with canonical tile-space (rescaleEPSG3857ToCommonSpace assumes
+    // 2π * 6378137 circumference).
     a: 6378137,
-    rf: 298.257223563,
+    b: 6378137,
     long0: 0,
     lat0: 0,
     lat_ts: 0,


### PR DESCRIPTION
## Summary

- Fix infinite console-error loop on published stories that render COGs client-side (chapters 2–5 of the example story at `/story/e630e9ff-…`).
- Root cause: local EPSG_DEFS for 4326/3857 in `cogLayer.ts` omitted proj4's required projection params (`long0`, `lat0`, `lat_ts`, `x0`, `y0`, `k0`), causing `proj4(def4326, "EPSG:3857").forward([lon,lat])` to emit `[NaN, y]`. NaN propagated through `deck.gl-raster`'s reference-point reprojection → `makeOrientedBoundingBoxFromPoints` threw `Invalid number null` → TileLayer's `_selectedTiles` stayed unassigned → the animation-frame loop kept retrying and erroring.
- Also flips 4326's axis from `"neu"` to `"enu"` so input is interpreted as `[lon, lat]`, matching every call site.
- Widens CSP `script-src` to allow `static.cloudflareinsights.com` (Cloudflare proxy auto-injects a Web Analytics beacon in front of `cngsandbox.org`; the previous CSP blocked it, producing a console error on every load).

## Test plan

- [x] `cd frontend && npx vitest run` → 433/433 pass, including a new regression test that forward/inverse-projects sample coords between the two local defs and asserts finite + round-trippable values.
- [ ] After deploy, load `https://cngsandbox.org/story/e630e9ff-508d-4621-8c43-63dacfdf0e78`, scroll through chapters 2–5 (DEM + GOES client-rendered COGs), confirm no `Invalid number null` / `_selectedTiles is not iterable` errors in devtools.
- [ ] Confirm the Cloudflare Insights beacon no longer shows a CSP violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Content-Security-Policy to allow Cloudflare Insights scripts for analytics.
* **Bug Fixes**
  * Corrected offline map projection definitions to improve coordinate reprojection accuracy and antimeridian handling.
* **Tests**
  * Added unit tests validating EPSG projection transforms and round-trip coordinate accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->