### PR TITLE
fix(frontend): legend layout + sidebar scroll + shared map category visibility

### DIFF
--- a/frontend/src/components/RasterSidebarControls.tsx
+++ b/frontend/src/components/RasterSidebarControls.tsx
@@ -42,6 +42,7 @@ interface RasterSidebarControlsProps {
   onRescaleChange: (min: number | null, max: number | null) => void;
   colormapReversed: boolean;
   onColormapReversedChange: (reversed: boolean) => void;
+  shared?: boolean;
 }
 
 function parseOrNull(s: string): number | null {
@@ -81,6 +82,7 @@ export function RasterSidebarControls(props: RasterSidebarControlsProps) {
     onRescaleChange,
     colormapReversed,
     onColormapReversedChange,
+    shared = false,
   } = props;
 
   const [minDraft, setMinDraft] = useState<string>(
@@ -119,7 +121,7 @@ export function RasterSidebarControls(props: RasterSidebarControlsProps) {
         Visualization Controls
       </Text>
 
-      {isCategorical && categories && categories.length > 0 && datasetId && (
+      {isCategorical && categories && categories.length > 0 && datasetId && !shared && (
         <>
           <EditableCategoryLegend
             datasetId={datasetId}

--- a/frontend/src/components/RasterSidebarControls.tsx
+++ b/frontend/src/components/RasterSidebarControls.tsx
@@ -121,29 +121,33 @@ export function RasterSidebarControls(props: RasterSidebarControlsProps) {
         Visualization Controls
       </Text>
 
-      {isCategorical && categories && categories.length > 0 && datasetId && !shared && (
-        <>
-          <EditableCategoryLegend
-            datasetId={datasetId}
-            source={source}
-            categories={categories}
-            onCategoriesChange={onCategoriesChange ?? (() => {})}
-          />
-          {onCategoricalOverride && (
-            <Text
-              fontSize="10px"
-              color="brand.textSecondary"
-              mt={1}
-              mb={3}
-              cursor="pointer"
-              _hover={{ color: "brand.orange" }}
-              onClick={() => onCategoricalOverride(false)}
-            >
-              Show as continuous →
-            </Text>
-          )}
-        </>
-      )}
+      {isCategorical &&
+        categories &&
+        categories.length > 0 &&
+        datasetId &&
+        !shared && (
+          <>
+            <EditableCategoryLegend
+              datasetId={datasetId}
+              source={source}
+              categories={categories}
+              onCategoriesChange={onCategoriesChange ?? (() => {})}
+            />
+            {onCategoricalOverride && (
+              <Text
+                fontSize="10px"
+                color="brand.textSecondary"
+                mt={1}
+                mb={3}
+                cursor="pointer"
+                _hover={{ color: "brand.orange" }}
+                onClick={() => onCategoricalOverride(false)}
+              >
+                Show as continuous →
+              </Text>
+            )}
+          </>
+        )}
 
       {!isCategorical && (
         <>

--- a/frontend/src/lib/maptool/MapLegend/CategoricalLegend.tsx
+++ b/frontend/src/lib/maptool/MapLegend/CategoricalLegend.tsx
@@ -15,8 +15,9 @@ export function CategoricalLegend({ config }: CategoricalLegendProps) {
       m={0}
       p={0}
       display="flex"
-      flexDirection="column"
-      gap={1}
+      flexWrap="wrap"
+      gap={2}
+      style={{ maxWidth: "320px" }}
     >
       {categories.map((cat) => (
         <Flex
@@ -25,6 +26,8 @@ export function CategoricalLegend({ config }: CategoricalLegendProps) {
           alignItems="center"
           gap={2}
           fontSize="12px"
+          minW="120px"
+          flex="1 1 auto"
         >
           <Box
             display="inline-block"

--- a/frontend/src/lib/maptool/MapLegend/MapLegend.tsx
+++ b/frontend/src/lib/maptool/MapLegend/MapLegend.tsx
@@ -48,7 +48,8 @@ export function MapLegend({
       position="absolute"
       {...POSITION_STYLES[position]}
       zIndex={10}
-      maxW="280px"
+      minW="200px"
+      maxW="400px"
       rounded="md"
       borderWidth="1px"
       borderColor="gray.200"

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -643,7 +643,7 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
             bg="brand.bgSubtle"
             borderLeftWidth="1px"
             borderColor="brand.border"
-            overflow="hidden"
+            overflow="auto"
           >
             <MapSidePanel
               item={item}


### PR DESCRIPTION
## Summary
- Legend now displays horizontally with 1-3 responsive columns (min 200px, max 400px)
- Sidebar scrolling enabled (was previously locked with overflow=hidden)
- Categories excluded from shared map view, only appear on editing page

## Changes
- **MapLegend.tsx**: Updated container width constraints from maxW=280px to minW=200px maxW=400px
- **CategoricalLegend.tsx**: Changed from vertical layout to wrapping flex with minW=120px items
- **RasterSidebarControls.tsx**: Added shared prop, gated category rendering behind !shared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "shared" mode that hides the categorical legend editor.

* **Improvements**
  * Legend layout now wraps responsively with improved spacing for better readability.
  * Legend sizing adjusted for improved responsiveness across screen widths.
  * Map side panel now scrolls when content exceeds available height for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->