### PR TITLE
feat(frontend): widen map legend and wrap categorical entries

### DIFF
--- a/frontend/src/lib/maptool/MapLegend/CategoricalLegend.tsx
+++ b/frontend/src/lib/maptool/MapLegend/CategoricalLegend.tsx
@@ -15,8 +15,9 @@ export function CategoricalLegend({ config }: CategoricalLegendProps) {
       m={0}
       p={0}
       display="flex"
-      flexDirection="column"
-      gap={1}
+      flexWrap="wrap"
+      gap={2}
+      style={{ maxWidth: "320px" }}
     >
       {categories.map((cat) => (
         <Flex
@@ -25,6 +26,8 @@ export function CategoricalLegend({ config }: CategoricalLegendProps) {
           alignItems="center"
           gap={2}
           fontSize="12px"
+          minW="120px"
+          flex="1 1 auto"
         >
           <Box
             display="inline-block"

--- a/frontend/src/lib/maptool/MapLegend/MapLegend.tsx
+++ b/frontend/src/lib/maptool/MapLegend/MapLegend.tsx
@@ -48,7 +48,8 @@ export function MapLegend({
       position="absolute"
       {...POSITION_STYLES[position]}
       zIndex={10}
-      maxW="280px"
+      minW="200px"
+      maxW="400px"
       rounded="md"
       borderWidth="1px"
       borderColor="gray.200"


### PR DESCRIPTION
## Summary
- Raises MapLegend max width from 280px to 400px (with a 200px min) so long category labels don't truncate
- Switches CategoricalLegend from a single column to a wrapping flex layout capped at 320px so legends with many classes fill horizontal space instead of growing into a tall strip

## Test plan
- [ ] Open a map with a categorical raster that has many classes (e.g. UK Soil Types, 13 classes)
- [ ] Confirm the legend wraps into multiple columns rather than stacking vertically
- [ ] Confirm long labels no longer truncate
- [ ] Spot-check non-categorical (continuous colorbar) legends still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved map legend layout to wrap items across multiple rows for better visual organization and space utilization.
  * Adjusted map legend responsive width constraints for enhanced flexibility across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->