### PR TITLE
chore(ci): add Dependabot for deps and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,20 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       actions:
-        patterns:
-          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: npm
     directory: /frontend
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       minor-and-patch:
@@ -24,6 +29,8 @@ updates:
     directory: /ingestion
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       minor-and-patch:
@@ -35,6 +42,8 @@ updates:
     directory: /mcp
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       minor-and-patch:
@@ -49,7 +58,10 @@ updates:
       - /ingestion
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       docker:
-        patterns:
-          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: uv
+    directory: /ingestion
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: uv
+    directory: /mcp
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directories:
+      - /caddy
+      - /frontend
+      - /ingestion
+    schedule:
+      interval: weekly
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,12 +144,12 @@ By default, release-please uses `GITHUB_TOKEN`, which means its PRs won't trigge
 
 Dependabot is configured via `.github/dependabot.yml` to open weekly PRs for:
 
-- GitHub Actions (grouped into a single PR)
-- npm dependencies in `frontend/` (minor + patch grouped; majors open separately)
-- uv dependencies in `ingestion/` and `mcp/` (minor + patch grouped; majors open separately)
-- Docker base images in `caddy/`, `frontend/`, and `ingestion/` (grouped into a single PR)
+- GitHub Actions
+- npm dependencies in `frontend/`
+- uv dependencies in `ingestion/` and `mcp/`
+- Docker base images in `caddy/`, `frontend/`, and `ingestion/`
 
-Dependabot PRs go through the same CI checks as any other PR. Review and merge them like normal feature PRs — release-please will fold the resulting `chore(deps):` commits into the next release changelog.
+Minor and patch updates are grouped per ecosystem to limit PR noise; major updates open as individual PRs so they get reviewed on their own. Each ecosystem uses a 7-day cooldown so Dependabot skips versions released in the last week (reduces exposure to compromised fresh releases). Dependabot PRs go through the same CI checks as any other PR. Review and merge them like normal feature PRs — release-please will fold the resulting `chore(deps):` commits into the next release changelog.
 
 ### Conventional Commits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,17 @@ By default, release-please uses `GITHUB_TOKEN`, which means its PRs won't trigge
    - Add `RELEASE_BOT_ID` as a **variable** (the App ID)
    - Add `RELEASE_BOT_PRIVATE_KEY` as a **secret** (the private key PEM)
 
+### Dependency updates
+
+Dependabot is configured via `.github/dependabot.yml` to open weekly PRs for:
+
+- GitHub Actions (grouped into a single PR)
+- npm dependencies in `frontend/` (minor + patch grouped; majors open separately)
+- uv dependencies in `ingestion/` and `mcp/` (minor + patch grouped; majors open separately)
+- Docker base images in `caddy/`, `frontend/`, and `ingestion/` (grouped into a single PR)
+
+Dependabot PRs go through the same CI checks as any other PR. Review and merge them like normal feature PRs — release-please will fold the resulting `chore(deps):` commits into the next release changelog.
+
 ### Conventional Commits
 
 All commits to `main` must use conventional prefixes:


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering five ecosystems: `github-actions`, `npm` (frontend), `uv` (ingestion + mcp), and `docker` (caddy, frontend, ingestion Dockerfiles)
- Weekly schedule with grouped minor/patch updates to limit PR noise; majors come as individual PRs so they get reviewed on their own
- `open-pull-requests-limit: 5` per language ecosystem as a ceiling

Motivation: avoid the next "dependency silently out of date" situation, and follows the pattern from [developmentseed/contributor-network#101](https://github.com/developmentseed/contributor-network/pull/101).

## Test plan
- [ ] Merge and confirm Dependabot opens its first batch of grouped PRs within ~1 day
- [ ] Verify one PR from each ecosystem (`github-actions`, `npm`, `uv`, `docker`) eventually appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency-update configuration to run weekly with grouped PRs, limits on open updates, and aggregated minor/patch updates; dependency-update commits will be included in future release changelogs.
* **Documentation**
  * Added CI/CD docs describing the dependency update cadence, grouping behavior, PR handling, and that dependency PRs run the same CI checks as other changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->