### PR TITLE
fix(frontend): unify URL input and fix empty featured dataset buttons

### DIFF
--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -182,7 +182,7 @@ export function FileUploader({
           </Button>
         )}
         {!embedded && (
-          <Text color="#aaa" fontSize="12px" mt={4}>
+          <Text color="brand.textSecondary" fontSize="12px" mt={4}>
             Up to 15 GB
           </Text>
         )}
@@ -226,7 +226,7 @@ export function FileUploader({
           >
             <Box flex={1} h="1px" bg="brand.border" />
             <Text
-              color="#aaa"
+              color="brand.textSecondary"
               fontSize="12px"
               textTransform="uppercase"
               letterSpacing="1px"
@@ -249,7 +249,7 @@ export function FileUploader({
               onChange={(e) => setUrl(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleUrlSubmit()}
               size="md"
-              borderColor="#ddd"
+              borderColor="brand.border"
               disabled={disabled}
             />
             <Button

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -21,6 +21,7 @@ interface FileUploaderProps {
   onUrlSubmitted: (url: string) => void;
   disabled?: boolean;
   embedded?: boolean;
+  hideUrlInput?: boolean;
 }
 
 const extractFilesFromEntry = async (
@@ -52,6 +53,7 @@ export function FileUploader({
   onUrlSubmitted,
   disabled,
   embedded,
+  hideUrlInput,
 }: FileUploaderProps) {
   const [dragOver, setDragOver] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -213,53 +215,57 @@ export function FileUploader({
         </Text>
       )}
 
-      <Flex
-        align="center"
-        gap={4}
-        w="100%"
-        maxW={embedded ? "100%" : "480px"}
-        mt={embedded ? 3 : 6}
-      >
-        <Box flex={1} h="1px" bg="brand.border" />
-        <Text
-          color="#aaa"
-          fontSize="12px"
-          textTransform="uppercase"
-          letterSpacing="1px"
-        >
-          or
-        </Text>
-        <Box flex={1} h="1px" bg="brand.border" />
-      </Flex>
+      {!hideUrlInput && (
+        <>
+          <Flex
+            align="center"
+            gap={4}
+            w="100%"
+            maxW={embedded ? "100%" : "480px"}
+            mt={embedded ? 3 : 6}
+          >
+            <Box flex={1} h="1px" bg="brand.border" />
+            <Text
+              color="#aaa"
+              fontSize="12px"
+              textTransform="uppercase"
+              letterSpacing="1px"
+            >
+              or
+            </Text>
+            <Box flex={1} h="1px" bg="brand.border" />
+          </Flex>
 
-      <Flex
-        gap={2}
-        mt={embedded ? 3 : 5}
-        w="100%"
-        maxW={embedded ? "100%" : "480px"}
-      >
-        <Input
-          flex={1}
-          placeholder="Paste an S3, GCS, or HTTP URL"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && handleUrlSubmit()}
-          size="md"
-          borderColor="#ddd"
-          disabled={disabled}
-        />
-        <Button
-          bg="brand.brown"
-          color="white"
-          size="md"
-          fontWeight={600}
-          borderRadius="4px"
-          onClick={handleUrlSubmit}
-          disabled={disabled || !url.trim()}
-        >
-          Fetch
-        </Button>
-      </Flex>
+          <Flex
+            gap={2}
+            mt={embedded ? 3 : 5}
+            w="100%"
+            maxW={embedded ? "100%" : "480px"}
+          >
+            <Input
+              flex={1}
+              placeholder="Paste an S3, GCS, or HTTP URL"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleUrlSubmit()}
+              size="md"
+              borderColor="#ddd"
+              disabled={disabled}
+            />
+            <Button
+              bg="brand.brown"
+              color="white"
+              size="md"
+              fontWeight={600}
+              borderRadius="4px"
+              onClick={handleUrlSubmit}
+              disabled={disabled || !url.trim()}
+            >
+              Fetch
+            </Button>
+          </Flex>
+        </>
+      )}
     </Flex>
   );
 }

--- a/frontend/src/components/VisualizeDataCardContent.tsx
+++ b/frontend/src/components/VisualizeDataCardContent.tsx
@@ -97,7 +97,7 @@ export function VisualizeDataCardContent({
       <Flex align="center" gap={4} w="100%" mt={3}>
         <Box flex={1} h="1px" bg="brand.border" />
         <Text
-          color="#aaa"
+          color="brand.textSecondary"
           fontSize="12px"
           textTransform="uppercase"
           letterSpacing="1px"
@@ -115,7 +115,7 @@ export function VisualizeDataCardContent({
           onChange={(e) => setUrlInput(e.target.value)}
           onKeyDown={handleKeyDown}
           size="md"
-          borderColor="#ddd"
+          borderColor="brand.border"
           flex={1}
         />
         <Button

--- a/frontend/src/components/VisualizeDataCardContent.tsx
+++ b/frontend/src/components/VisualizeDataCardContent.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Box, Button, Flex, Input, Spinner, Text } from "@chakra-ui/react";
+import { Box, Button, Flex, Input, Text } from "@chakra-ui/react";
 import { FileUploader } from "./FileUploader";
 import { useUrlDetection } from "../hooks/useUrlDetection";
 import { workspaceFetch } from "../lib/api";
@@ -7,7 +7,8 @@ import type { UrlDetectionResult } from "../hooks/useUrlDetection";
 
 interface ExampleDataset {
   id: string;
-  title: string;
+  title: string | null;
+  filename: string | null;
   is_example?: boolean;
 }
 
@@ -69,11 +70,15 @@ export function VisualizeDataCardContent({
                 key={ds.id}
                 size="xs"
                 variant="outline"
-                colorPalette="orange"
+                bg="white"
+                color="brand.brown"
+                borderColor="brand.border"
                 flexShrink={0}
+                fontWeight={500}
+                _hover={{ borderColor: "brand.orange", color: "brand.orange" }}
                 onClick={() => onExampleClicked(ds.id)}
               >
-                {ds.title}
+                {ds.title || ds.filename || "Untitled"}
               </Button>
             ))}
           </Flex>
@@ -86,27 +91,45 @@ export function VisualizeDataCardContent({
         onUrlSubmitted={() => {}}
         disabled={false}
         embedded
+        hideUrlInput
       />
+
+      <Flex align="center" gap={4} w="100%" mt={3}>
+        <Box flex={1} h="1px" bg="brand.border" />
+        <Text
+          color="#aaa"
+          fontSize="12px"
+          textTransform="uppercase"
+          letterSpacing="1px"
+        >
+          or
+        </Text>
+        <Box flex={1} h="1px" bg="brand.border" />
+      </Flex>
 
       <Flex gap={2} mt={3} align="center">
         <Input
           aria-label="URL"
-          placeholder="Paste a URL to a COG, PMTiles, GeoJSON…"
+          placeholder="Paste a URL — we'll detect tile sources vs. files to convert"
           value={urlInput}
           onChange={(e) => setUrlInput(e.target.value)}
           onKeyDown={handleKeyDown}
-          size="sm"
+          size="md"
+          borderColor="#ddd"
           flex={1}
         />
         <Button
-          size="sm"
-          colorPalette="orange"
+          bg="brand.orange"
+          color="white"
+          size="md"
+          fontWeight={600}
+          borderRadius="4px"
+          _hover={{ bg: "brand.orangeHover" }}
           onClick={handleContinue}
           disabled={detecting || !urlInput.trim()}
         >
           {detecting ? "Detecting…" : "Continue"}
         </Button>
-        {detecting && <Spinner size="sm" />}
       </Flex>
 
       {error && (


### PR DESCRIPTION
## Summary
Follow-up polish on the homepage redesign shipped in #291.

- **Unified URL input.** The Visualize card previously had two URL inputs (one from `FileUploader` with a "Fetch" button, plus the new one wired to `useUrlDetection`). Added a `hideUrlInput` prop to `FileUploader` so the embedded usage suppresses its built-in URL row; the card now has a single orange "Continue" input that auto-detects whether to run the convert-url flow or register a connection (xyz/pmtiles/parquet/cog).
- **Featured datasets render as empty boxes.** Example datasets from source.coop ship with `title = null`; the label was falling back to nothing. Falls back to `filename` (then "Untitled"). Also switched the buttons to explicit brand token styling (`bg="white" color="brand.brown" borderColor="brand.border"` with `brand.orange` hover) so the text renders reliably regardless of Chakra v3 `colorPalette` resolution on the `outline` variant.

## Screenshot
Featured datasets now show readable labels, URL input is single and orange:

![after](https://github.com/user-attachments/assets/placeholder.png)

## Test plan
- [ ] `cd frontend && npx vitest run` (445 passing locally)
- [ ] `cd frontend && npx tsc --noEmit`
- [ ] Visualize card shows 4 featured-dataset buttons with titles and a single URL input
- [ ] Paste a COG URL → connection registered
- [ ] Paste a GeoTIFF URL → convert-url flow starts
- [ ] UploadModal / InlineUpload still show their URL input (feature-flagged via `hideUrlInput`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional ability to hide the URL input in the file uploader

* **Improvements**
  * Redesigned featured dataset buttons with clearer visual hierarchy and hover states
  * Added a centered “or” separator between uploader and URL input
  * Updated URL input styling and placeholder for better visibility
  * Continue button restyled; removes spinner and shows “Detecting…” text when active
  * Datasets now fall back to filename or “Untitled” when no title is present
<!-- end of auto-generated comment: release notes by coderabbit.ai -->