### PR TITLE
fix(frontend): look up pixel values by hovered tile, not dataset bounds

### DIFF
--- a/frontend/src/components/PixelInspector.tsx
+++ b/frontend/src/components/PixelInspector.tsx
@@ -2,36 +2,41 @@ import { useState, useCallback, useRef } from "react";
 import { Box, Text } from "@chakra-ui/react";
 import type { TileCacheEntry } from "../lib/layers/cogLayer";
 
+interface HoverSourceTile {
+  index: { x: number; y: number; z?: number };
+  bounds: [number, number, number, number] | number[];
+}
+
+interface DeckHoverInfo {
+  x: number;
+  y: number;
+  coordinate?: [number, number];
+  sourceTile?: HoverSourceTile;
+}
+
 function lookupValue(
   cache: Map<string, TileCacheEntry>,
+  sourceTile: HoverSourceTile,
   lng: number,
   lat: number
 ): number | null {
-  let bestEntry: TileCacheEntry | null = null;
-  let bestRes = Infinity;
+  const key = `${sourceTile.index.x}/${sourceTile.index.y}`;
+  const entry = cache.get(key);
+  if (!entry) return null;
 
-  for (const [, entry] of cache) {
-    const [west, south, east, north] = entry.bounds;
-    if (lng >= west && lng <= east && lat >= south && lat <= north) {
-      const res = (east - west) / entry.width;
-      if (res < bestRes) {
-        bestRes = res;
-        bestEntry = entry;
-      }
-    }
-  }
+  const [west, south, east, north] = sourceTile.bounds as [
+    number,
+    number,
+    number,
+    number,
+  ];
+  if (lng < west || lng > east || lat < south || lat > north) return null;
 
-  if (!bestEntry) return null;
+  const px = Math.floor(((lng - west) / (east - west)) * entry.width);
+  const py = Math.floor(((north - lat) / (north - south)) * entry.height);
+  if (px < 0 || px >= entry.width || py < 0 || py >= entry.height) return null;
 
-  const [west, south, east, north] = bestEntry.bounds;
-  const px = Math.floor(((lng - west) / (east - west)) * bestEntry.width);
-  const py = Math.floor(((north - lat) / (north - south)) * bestEntry.height);
-
-  if (px < 0 || px >= bestEntry.width || py < 0 || py >= bestEntry.height) {
-    return null;
-  }
-
-  const val = bestEntry.data[py * bestEntry.width + px];
+  const val = entry.data[py * entry.width + px];
   if (val !== val) return null;
   return val;
 }
@@ -79,19 +84,20 @@ export function usePixelInspector(
   const hoverRafRef = useRef<number | null>(null);
 
   const onHover = useCallback(
-    (info: { coordinate?: [number, number]; x: number; y: number }) => {
+    (info: DeckHoverInfo) => {
       if (hoverRafRef.current !== null) {
         cancelAnimationFrame(hoverRafRef.current);
       }
-      if (!info.coordinate) {
+      if (!info.coordinate || !info.sourceTile) {
         hoverRafRef.current = null;
         setHoverInfo(null);
         return;
       }
+      const sourceTile = info.sourceTile;
       hoverRafRef.current = requestAnimationFrame(() => {
         hoverRafRef.current = null;
         const [lng, lat] = info.coordinate!;
-        const value = lookupValue(tileCacheRef.current, lng, lat);
+        const value = lookupValue(tileCacheRef.current, sourceTile, lng, lat);
         if (value === null) {
           setHoverInfo(null);
           return;

--- a/frontend/src/components/__tests__/PixelInspector.test.tsx
+++ b/frontend/src/components/__tests__/PixelInspector.test.tsx
@@ -21,9 +21,35 @@ function seededCache(): Map<string, TileCacheEntry> {
     data: new Float32Array([1, 2, 3, 4]),
     width: 2,
     height: 2,
-    bounds: [-10, -10, 10, 10],
   });
   return m;
+}
+
+function hoverInfo(opts: {
+  coordinate: [number, number];
+  x: number;
+  y: number;
+  tileX?: number;
+  tileY?: number;
+  tileBounds?: [number, number, number, number];
+}) {
+  const {
+    coordinate,
+    x,
+    y,
+    tileX = 0,
+    tileY = 0,
+    tileBounds = [-10, -10, 10, 10],
+  } = opts;
+  return {
+    coordinate,
+    x,
+    y,
+    sourceTile: {
+      index: { x: tileX, y: tileY, z: 0 },
+      bounds: tileBounds,
+    },
+  };
 }
 
 describe("usePixelInspector categorical branch", () => {
@@ -37,7 +63,7 @@ describe("usePixelInspector categorical branch", () => {
       return usePixelInspector(ref, null, cats);
     });
     act(() => {
-      result.current.onHover({ coordinate: [-5, 5], x: 10, y: 20 });
+      result.current.onHover(hoverInfo({ coordinate: [-5, 5], x: 10, y: 20 }));
     });
     await waitFor(() => {
       expect(result.current.hoverInfo).toMatchObject({
@@ -57,7 +83,7 @@ describe("usePixelInspector categorical branch", () => {
       return usePixelInspector(ref, null, cats);
     });
     act(() => {
-      result.current.onHover({ coordinate: [-5, 5], x: 0, y: 0 });
+      result.current.onHover(hoverInfo({ coordinate: [-5, 5], x: 0, y: 0 }));
     });
     await new Promise((r) => requestAnimationFrame(() => r(null)));
     expect(result.current.hoverInfo).toBeNull();
@@ -69,12 +95,65 @@ describe("usePixelInspector categorical branch", () => {
       return usePixelInspector(ref, null);
     });
     act(() => {
-      result.current.onHover({ coordinate: [-5, 5], x: 0, y: 0 });
+      result.current.onHover(hoverInfo({ coordinate: [-5, 5], x: 0, y: 0 }));
     });
     await waitFor(() => {
       expect(result.current.hoverInfo).toMatchObject({
         kind: "numeric",
         value: 1,
+      });
+    });
+  });
+
+  it("returns null when sourceTile is missing (hover off COG layer)", async () => {
+    const { result } = renderHook(() => {
+      const ref = useRef(seededCache());
+      return usePixelInspector(ref, null);
+    });
+    act(() => {
+      result.current.onHover({ coordinate: [-5, 5], x: 0, y: 0 });
+    });
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+    expect(result.current.hoverInfo).toBeNull();
+  });
+
+  it("samples the right pixel from the right tile when multiple tiles are cached", async () => {
+    const cache = new Map<string, TileCacheEntry>();
+    cache.set("0/0", {
+      data: new Float32Array([1, 1, 1, 1]),
+      width: 2,
+      height: 2,
+    });
+    cache.set("1/0", {
+      data: new Float32Array([2, 2, 2, 2]),
+      width: 2,
+      height: 2,
+    });
+    const cats = [
+      { value: 1, color: "#f00", label: "One" },
+      { value: 2, color: "#0f0", label: "Two" },
+    ];
+    const { result } = renderHook(() => {
+      const ref = useRef(cache);
+      return usePixelInspector(ref, null, cats);
+    });
+    // Hover the second tile; inspector must look it up by index, not bounds.
+    act(() => {
+      result.current.onHover(
+        hoverInfo({
+          coordinate: [15, 5],
+          x: 0,
+          y: 0,
+          tileX: 1,
+          tileY: 0,
+          tileBounds: [10, -10, 30, 10],
+        })
+      );
+    });
+    await waitFor(() => {
+      expect(result.current.hoverInfo).toMatchObject({
+        kind: "categorical",
+        label: "Two",
       });
     });
   });

--- a/frontend/src/hooks/__tests__/useLayerBuilder.test.ts
+++ b/frontend/src/hooks/__tests__/useLayerBuilder.test.ts
@@ -354,7 +354,6 @@ describe("useLayerBuilder — COG connection client render", () => {
     expect(opts.categories).toEqual([
       { value: 1, color: "#ff0000", label: "A" },
     ]);
-    expect(opts.datasetBounds).toEqual([-10, -10, 10, 10]);
     expect(opts.tileCacheRef).toBeDefined();
   });
 

--- a/frontend/src/lib/layers/__tests__/cogLayerPaletted.test.ts
+++ b/frontend/src/lib/layers/__tests__/cogLayerPaletted.test.ts
@@ -56,13 +56,13 @@ describe("buildCogLayerPaletted with categories", () => {
       opacity: 1,
       categories: [{ value: 1, color: "#ff0000", label: "A" }],
       tileCacheRef: cacheRef,
-      datasetBounds: [-10, -10, 10, 10],
     });
     expect(layers).toHaveLength(1);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const layerProps = (layers[0] as any).props;
     expect(typeof layerProps.getTileData).toBe("function");
     expect(typeof layerProps.renderTile).toBe("function");
+    expect(layerProps.pickable).toBe(true);
   });
 
   it("returns a layer with the default pipeline when categories are omitted", () => {
@@ -83,7 +83,6 @@ describe("buildCogLayerPaletted with categories", () => {
       opacity: 1,
       categories: [{ value: 1, color: "#ff0000", label: "A" }],
       tileCacheRef: cacheRef,
-      datasetBounds: [-10, -10, 10, 10],
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const getTileData = (layers[0] as any).props.getTileData;
@@ -116,7 +115,6 @@ describe("buildCogLayerPaletted with categories", () => {
     expect(entry).toBeDefined();
     expect(entry!.width).toBe(2);
     expect(entry!.height).toBe(2);
-    expect(entry!.bounds).toEqual([-10, -10, 10, 10]);
     // raw values preserved
     expect(Array.from(entry!.data)).toEqual([1, 0, 1, 0]);
   });

--- a/frontend/src/lib/layers/__tests__/resolveRasterLayers.test.ts
+++ b/frontend/src/lib/layers/__tests__/resolveRasterLayers.test.ts
@@ -70,7 +70,6 @@ describe("resolveRasterLayers", () => {
     expect(buildCogLayerContinuous).toHaveBeenCalledTimes(1);
     expect(buildCogLayerContinuous).toHaveBeenCalledWith(
       expect.objectContaining({
-        datasetBounds: [-10, -10, 10, 10],
         rasterMin: 0,
         rasterMax: 1,
         opacity: 0.8,

--- a/frontend/src/lib/layers/cogLayer.ts
+++ b/frontend/src/lib/layers/cogLayer.ts
@@ -109,7 +109,6 @@ export interface TileCacheEntry {
   data: Float32Array;
   width: number;
   height: number;
-  bounds: [number, number, number, number];
 }
 
 const MAX_CACHED_TILES = 256;
@@ -126,7 +125,6 @@ interface CogLayerOptions {
   opacity: number;
   rasterMin: number;
   rasterMax: number;
-  datasetBounds: [number, number, number, number] | null;
   tileCacheRef: MutableRefObject<Map<string, TileCacheEntry>>;
 }
 
@@ -135,7 +133,6 @@ interface CogLayerPalettedOptions {
   opacity: number;
   categories?: LutCategory[];
   tileCacheRef?: MutableRefObject<Map<string, TileCacheEntry>>;
-  datasetBounds?: [number, number, number, number] | null;
 }
 
 export function buildCogLayerPaletted({
@@ -143,7 +140,6 @@ export function buildCogLayerPaletted({
   opacity,
   categories,
   tileCacheRef,
-  datasetBounds,
 }: CogLayerPalettedOptions): Layer[] {
   const url = resolveCogUrl(cogUrl);
 
@@ -201,7 +197,7 @@ export function buildCogLayerPaletted({
       raw[i] = source[i] & 0xff;
     }
 
-    if (tileCacheRef && datasetBounds) {
+    if (tileCacheRef) {
       const cacheKey = `${x}/${y}`;
       const cache = tileCacheRef.current;
       // Widen to Float32Array to satisfy existing TileCacheEntry typing;
@@ -212,7 +208,6 @@ export function buildCogLayerPaletted({
         data: cached,
         width,
         height,
-        bounds: datasetBounds,
       });
       while (cache.size > MAX_CACHED_TILES) {
         const firstKey = cache.keys().next().value;
@@ -253,6 +248,7 @@ export function buildCogLayerPaletted({
       getTileData,
       renderTile,
       maxError: 0.03,
+      pickable: true,
     } as any),
   ];
   /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -263,7 +259,6 @@ export function buildCogLayerContinuous({
   opacity,
   rasterMin,
   rasterMax,
-  datasetBounds,
   tileCacheRef,
 }: CogLayerOptions): Layer[] {
   const url = resolveCogUrl(cogUrl);
@@ -315,14 +310,13 @@ export function buildCogLayerContinuous({
     }
 
     // Cache raw float data for pixel inspector
-    if (datasetBounds) {
+    {
       const cacheKey = `${x}/${y}`;
       const cache = tileCacheRef.current;
       cache.set(cacheKey, {
         data: new Float32Array(floatData),
         width,
         height,
-        bounds: datasetBounds,
       });
       while (cache.size > MAX_CACHED_TILES) {
         const firstKey = cache.keys().next().value;
@@ -371,6 +365,7 @@ export function buildCogLayerContinuous({
       getTileData,
       renderTile,
       maxError: 0.03,
+      pickable: true,
     } as any),
   ];
   /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/frontend/src/lib/layers/resolveRasterLayers.ts
+++ b/frontend/src/lib/layers/resolveRasterLayers.ts
@@ -63,7 +63,6 @@ export function resolveRasterLayers(
         opacity,
         categories: effectiveCategories,
         tileCacheRef,
-        datasetBounds: item.bounds,
       });
     } else {
       const parsed = parseRescaleString(item.rescale);
@@ -72,7 +71,6 @@ export function resolveRasterLayers(
         opacity,
         rasterMin: rescaleMin ?? parsed?.min ?? item.rasterMin ?? 0,
         rasterMax: rescaleMax ?? parsed?.max ?? item.rasterMax ?? 1,
-        datasetBounds: item.bounds,
         tileCacheRef,
       });
     }


### PR DESCRIPTION
## Summary

- Fixes categorical pixel tooltip never appearing on client-rendered COGs (e.g. https://cngsandbox.org/map/7cc764cf-58b9-427b-98a2-79ae39377721).
- Every decoded tile was cached with `bounds: datasetBounds`, so `lookupValue` always returned the first-inserted entry and mapped the hover coordinate onto a 256-wide pixel grid stretched across the whole dataset. Numeric tooltips silently showed a wrong number; categorical tooltips almost never matched a category value and dropped entirely.
- `usePixelInspector` now consumes `info.sourceTile.{index, bounds}` from the deck.gl hover event and samples the specific cached tile using the tile's own bbox. Cache entries are keyed by `x/y` with no bounds field. Both COG layer builders set `pickable: true` so the underlying `TileLayer` surfaces `sourceTile` on hover.
- Tile bounds from the custom `TileMatrixSetTileset` are in the COG's native CRS, so this is exact for 4326 COGs (every sandbox-converted dataset, including the demo link). External 3857 COG connections will need a proj4 hop before this path returns a correct pixel — follow-up if we care.

## Test plan

- [x] `frontend/npx vitest run` — 451 tests pass (includes 2 new cases: tile-indexed lookup with multiple tiles, and hover-off-COG returning null)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke in a real browser (this VM has no WebGL so deck.gl picking can't be exercised from here). Open https://cngsandbox.org/map/7cc764cf-58b9-427b-98a2-79ae39377721 after deploy and confirm: hovering the raster shows the coloured-swatch tooltip with the correct category label; moving around the dataset updates the label; hovering off the raster dismisses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * COG layers now support interactive picking and respond to pointer events.

* **Improvements**
  * Enhanced pixel value inspection accuracy and responsiveness during hover interactions on raster layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->