### PR TITLE
fix(ingestion): use nearest resampling for categorical GeoTIFF→COG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install system deps
-        run: sudo apt-get update && sudo apt-get install -y libmagic1
+        run: sudo apt-get update && sudo apt-get install -y libmagic1 gdal-bin
 
       - name: Install cng-toolkit
         run: pip install -e "../geo-conversions[all]"

--- a/ingestion/src/services/pipeline.py
+++ b/ingestion/src/services/pipeline.py
@@ -438,6 +438,22 @@ async def run_pipeline(job: Job, input_path: str, db_session_factory) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, out_filename)
 
+            # Pre-scan categorical on INPUT so the GeoTIFF→COG warp can pick
+            # nearest-neighbor resampling. Bilinear/cubic on integer category
+            # codes blends them into invalid or wrong-category values.
+            input_is_categorical = False
+            if format_pair == FormatPair.GEOTIFF_TO_COG:
+                try:
+                    input_is_categorical = (
+                        await asyncio.to_thread(detect_categories, input_path)
+                    ).is_categorical
+                except Exception as exc:
+                    logger.warning(
+                        "Pre-convert categorical detection failed on %s: %s",
+                        input_path,
+                        exc,
+                    )
+
             await asyncio.to_thread(
                 _import_and_convert,
                 format_pair,
@@ -445,6 +461,7 @@ async def run_pipeline(job: Job, input_path: str, db_session_factory) -> None:
                 output_path,
                 variable=job.variable,
                 group=job.group,
+                is_categorical=input_is_categorical,
             )
 
             # Stage 3: Validate
@@ -669,15 +686,27 @@ async def _wait_for_tipg_collection(dataset_id: str, timeout: float = 30.0) -> N
             await asyncio.sleep(1.0)
 
 
-def _convert_geotiff_to_cog(input_path: str, output_path: str) -> None:
-    """Convert GeoTIFF to COG using gdalwarp."""
+def _convert_geotiff_to_cog(
+    input_path: str, output_path: str, is_categorical: bool = False
+) -> None:
+    """Convert GeoTIFF to COG using gdalwarp.
+
+    For categorical rasters, uses nearest-neighbor resampling for both the warp
+    and the COG overviews. Bilinear/cubic on integer category codes blends them
+    into fractional values that truncate to wrong (but valid-looking) category
+    codes, causing bleed/stripe artifacts at low zoom. GDAL's COG driver default
+    is NEAREST for integer dtypes ≤16 bits and CUBIC for anything larger —
+    which silently corrupts categorical uint32 rasters unless we override it.
+    """
+    resampling = "near" if is_categorical else "bilinear"
+    overview_resampling = "NEAREST" if is_categorical else "CUBIC"
     result = subprocess.run(
         [
             "gdalwarp",
             "-t_srs",
             "EPSG:4326",
             "-r",
-            "bilinear",
+            resampling,
             "-of",
             "COG",
             "-multi",
@@ -689,6 +718,8 @@ def _convert_geotiff_to_cog(input_path: str, output_path: str) -> None:
             "BLOCKSIZE=512",
             "-co",
             "NUM_THREADS=ALL_CPUS",
+            "-co",
+            f"OVERVIEW_RESAMPLING={overview_resampling}",
             input_path,
             output_path,
         ],
@@ -753,10 +784,11 @@ def _import_and_convert(
     output_path: str,
     variable: str | None = None,
     group: str | None = None,
+    is_categorical: bool = False,
 ) -> None:
     """Import the appropriate cng-toolkit converter and run it."""
     if format_pair == FormatPair.GEOTIFF_TO_COG:
-        _convert_geotiff_to_cog(input_path, output_path)
+        _convert_geotiff_to_cog(input_path, output_path, is_categorical=is_categorical)
     elif format_pair in (
         FormatPair.SHAPEFILE_TO_GEOPARQUET,
         FormatPair.GEOJSON_TO_GEOPARQUET,

--- a/ingestion/tests/test_pipeline.py
+++ b/ingestion/tests/test_pipeline.py
@@ -349,8 +349,8 @@ def test_convert_geotiff_categorical_flag_changes_resampling(
     """Without the flag, the COG driver uses its dtype-based default (CUBIC
     for uint32) and boundary-adjacent overviews carry bleed codes. With the
     flag, no bleed. This guards the branching in _convert_geotiff_to_cog."""
-    default_out = str(tmp_path / "default.tif")
-    categorical_out = str(tmp_path / "categorical.tif")
+    default_out = str(tmp_path / "out_default.tif")
+    categorical_out = str(tmp_path / "out_categorical.tif")
     _convert_geotiff_to_cog(categorical_uint32_tif, default_out, is_categorical=False)
     _convert_geotiff_to_cog(
         categorical_uint32_tif, categorical_out, is_categorical=True

--- a/ingestion/tests/test_pipeline.py
+++ b/ingestion/tests/test_pipeline.py
@@ -1,3 +1,5 @@
+import shutil
+
 import geopandas as gpd
 import numpy as np
 import pytest
@@ -7,12 +9,18 @@ from shapely.geometry import Point, Polygon
 
 from src.models import DatasetType, FormatPair
 from src.services.pipeline import (
+    _convert_geotiff_to_cog,
     _detect_use_pmtiles,
     _extract_band_metadata,
     _extract_feature_stats,
     _extract_zoom_range_raster,
     get_credits,
     validate_geojson_structure,
+)
+
+requires_gdalwarp = pytest.mark.skipif(
+    shutil.which("gdalwarp") is None,
+    reason="gdalwarp CLI not installed on host",
 )
 
 
@@ -275,6 +283,129 @@ def test_cog_url_built_for_raster():
         else None
     )
     assert cog_url == "/storage/datasets/abc-123/converted/data.tif"
+
+
+@pytest.fixture
+def categorical_uint32_tif(tmp_path):
+    """A uint32 categorical raster with many adjacent category stripes —
+    under non-nearest resampling, boundary blending produces bleed codes
+    between 1, 7 and 13 (e.g. 3, 4, 5, 10, 11). Size + stripe pitch are
+    tuned to force the COG driver to build at least three overview levels.
+    """
+    width, height = 2048, 2048
+    data = np.full((height, width), 255, dtype=np.uint32)
+    for i in range(50, width - 50, 20):
+        data[50 : height - 50, i : i + 20] = [1, 7, 13][(i // 20) % 3]
+    path = str(tmp_path / "categorical.tif")
+    transform = from_bounds(-5.0, 50.0, 5.0, 60.0, width, height)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        width=width,
+        height=height,
+        count=1,
+        dtype="uint32",
+        crs="EPSG:4326",
+        transform=transform,
+        nodata=255,
+        tiled=True,
+        blockxsize=512,
+        blockysize=512,
+    ) as dst:
+        dst.write(data, 1)
+    return path
+
+
+@requires_gdalwarp
+def test_convert_geotiff_categorical_preserves_codes(categorical_uint32_tif, tmp_path):
+    output_path = str(tmp_path / "out.tif")
+    _convert_geotiff_to_cog(categorical_uint32_tif, output_path, is_categorical=True)
+
+    allowed = {1, 7, 13, 255}
+    with rasterio.open(output_path) as src:
+        overviews = src.overviews(1)
+        assert overviews, "expected overviews to be built by COG driver"
+        for level in overviews:
+            data = src.read(
+                1,
+                out_shape=(
+                    max(1, src.height // level),
+                    max(1, src.width // level),
+                ),
+            )
+            unique = set(int(v) for v in np.unique(data))
+            bleed = unique - allowed
+            assert not bleed, (
+                f"overview x{level} has non-category values {sorted(bleed)} — "
+                "resampling is blending category codes"
+            )
+
+
+@requires_gdalwarp
+def test_convert_geotiff_categorical_flag_changes_resampling(
+    categorical_uint32_tif, tmp_path
+):
+    """Without the flag, the COG driver uses its dtype-based default (CUBIC
+    for uint32) and boundary-adjacent overviews carry bleed codes. With the
+    flag, no bleed. This guards the branching in _convert_geotiff_to_cog."""
+    default_out = str(tmp_path / "default.tif")
+    categorical_out = str(tmp_path / "categorical.tif")
+    _convert_geotiff_to_cog(categorical_uint32_tif, default_out, is_categorical=False)
+    _convert_geotiff_to_cog(
+        categorical_uint32_tif, categorical_out, is_categorical=True
+    )
+
+    allowed = {1, 7, 13, 255}
+
+    def bleed_across_overviews(path: str) -> set[int]:
+        out: set[int] = set()
+        with rasterio.open(path) as src:
+            for level in src.overviews(1):
+                data = src.read(
+                    1,
+                    out_shape=(
+                        max(1, src.height // level),
+                        max(1, src.width // level),
+                    ),
+                )
+                out |= {int(v) for v in np.unique(data)} - allowed
+        return out
+
+    assert bleed_across_overviews(default_out), (
+        "expected non-categorical path to produce bleed — otherwise this test "
+        "doesn't actually validate the fix"
+    )
+    assert not bleed_across_overviews(categorical_out)
+
+
+@requires_gdalwarp
+def test_convert_geotiff_continuous_uses_bilinear_default(tmp_path):
+    # Smooth float raster — bilinear is appropriate and should not error.
+    width, height = 128, 128
+    data = np.fromfunction(lambda y, x: (x + y).astype("float32"), (height, width))
+    path = str(tmp_path / "continuous.tif")
+    transform = from_bounds(-5.0, 50.0, 5.0, 60.0, width, height)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        width=width,
+        height=height,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=transform,
+        tiled=True,
+        blockxsize=64,
+        blockysize=64,
+    ) as dst:
+        dst.write(data, 1)
+    output_path = str(tmp_path / "out.tif")
+    _convert_geotiff_to_cog(path, output_path, is_categorical=False)
+    with rasterio.open(output_path) as src:
+        assert src.count == 1
+        assert "float" in str(src.dtypes[0])
 
 
 def test_cog_url_none_for_vector():


### PR DESCRIPTION
## Summary

Bilinear warp + the COG driver's cubic overview default for uint32 rasters blend integer category codes at boundaries into values that collide with other valid categories. At low/mid zoom this renders as wrong-color bleed and diagonal stripes in every client-rendered categorical dataset.

- Detect categorical on the **input** file (before conversion) and thread the flag through `_import_and_convert` → `_convert_geotiff_to_cog`
- Categorical path uses `-r near` + `-co OVERVIEW_RESAMPLING=NEAREST`; continuous path unchanged
- Install `gdal-bin` in the backend CI job so new tests exercise the real `gdalwarp`

### Proof

On a 4096×4096 uint32 raster with three interleaved category stripes (1, 7, 13) + nodata 255:

| Path | overview bleed values |
|---|---|
| **OLD** (bilinear + cubic overviews) | x2: [2, 12] &nbsp;·&nbsp; x4: [4, 10] &nbsp;·&nbsp; x8: [0, 3, 4, 5, 9, 10, 11, 14] |
| **NEW** (nearest + nearest overviews) | none |

Existing (corrupted) datasets need re-ingestion — the damage is baked into the COG.

## Test plan

- [ ] `cd ingestion && uv run pytest tests/test_pipeline.py -v` — all green locally (new tests skip without `gdalwarp`)
- [ ] CI `backend` job runs the new categorical tests (gdal-bin installed)
- [ ] Re-ingest `natural_capital_pedotopes.tif` after merge and verify no bleed at low zoom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Raster conversions now detect categorical inputs and apply matching resampling/overview behavior to preserve categorical integrity

* **Bug Fixes**
  * Added graceful recovery when categorical detection fails to avoid pipeline errors

* **Tests**
  * Added coverage and host-aware tests for categorical and continuous raster conversion paths

* **Chores**
  * Updated CI to include additional system package for raster processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->