### PR TITLE
fix(ingestion): upload raw file off event loop

### DIFF
--- a/ingestion/src/services/pipeline.py
+++ b/ingestion/src/services/pipeline.py
@@ -423,8 +423,13 @@ async def run_pipeline(job: Job, input_path: str, db_session_factory) -> None:
                         )
                         return
 
-        # Upload raw file to S3
-        storage.upload_raw(input_path, job.dataset_id, job.filename)
+        # Upload raw file to S3 off the event loop. obstore.put is blocking,
+        # and on large files it stalls the SSE ping coroutine long enough for
+        # intermediate proxies (Cloudflare ~100s) to drop the job stream —
+        # surfacing as "Connection lost" even though the pipeline completes.
+        await asyncio.to_thread(
+            storage.upload_raw, input_path, job.dataset_id, job.filename
+        )
 
         # Stage 2: Convert
         job.status = JobStatus.CONVERTING

--- a/ingestion/src/services/temporal_pipeline.py
+++ b/ingestion/src/services/temporal_pipeline.py
@@ -198,8 +198,12 @@ async def run_infile_temporal_pipeline(
     uploaded_keys: list[str] = []
 
     try:
-        # Upload raw file
-        raw_key = storage.upload_raw(input_path, job.dataset_id, job.filename)
+        # Upload raw file off the event loop. obstore.put blocks, and on large
+        # files it stalls the SSE ping coroutine long enough for intermediate
+        # proxies to drop the job stream.
+        raw_key = await asyncio.to_thread(
+            storage.upload_raw, input_path, job.dataset_id, job.filename
+        )
         uploaded_keys.append(raw_key)
         original_file_size = os.path.getsize(input_path)
 
@@ -366,8 +370,11 @@ async def run_temporal_pipeline(
 
                 original_file_size += os.path.getsize(input_path)
 
-                # Upload raw
-                raw_key = storage.upload_raw(input_path, job.dataset_id, entry.filename)
+                # Upload raw off the event loop (see note on upload_raw in
+                # run_pipeline).
+                raw_key = await asyncio.to_thread(
+                    storage.upload_raw, input_path, job.dataset_id, entry.filename
+                )
                 uploaded_keys.append(raw_key)
 
                 # Convert


### PR DESCRIPTION
## Summary

Resolves the "Connection lost" error reported in #299 (and also #208 before the OOM fix in #210). The ingestion pipeline was calling the synchronous `obstore.put` directly on the async coroutine, which blocked the event loop for the duration of the S3 upload.

On large files that wait is long enough for intermediate proxies (Cloudflare's ~100 s idle timeout) to drop the `/api/jobs/{id}/stream` SSE connection before `sse-starlette`'s ping coroutine can run. The browser's `EventSource` errors out, its retry budget (3 × 1–3 s) evaporates, and the UI surfaces "Connection lost" — even though the pipeline is still progressing server-side. That's why the dataset still lands in the library despite the error.

The fix wraps `upload_raw` in `asyncio.to_thread` at all three call sites (`run_pipeline`, both paths in `run_temporal_pipeline`), matching what `upload_converted` already does one stage later.

## Scope note

#299 also mentions raster distortion persisting despite #297. That's a separate problem and not addressed here — I'll investigate once we have the specific file/dataset to reproduce against.

## Test plan

- [ ] `cd ingestion && uv run pytest tests/test_pipeline.py -q` — all green
- [ ] Upload a large (500 MB+) GeoTIFF on the worktree stack and confirm the SSE stream stays connected through the upload stage (previously: "Connection lost" during "Scanning" on files this size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized file upload handling in data pipelines to improve system responsiveness and throughput during data ingestion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->