### PR TITLE
fix(frontend): guard pixel inspector against missing sourceTile.bounds

### DIFF
--- a/frontend/src/components/PixelInspector.tsx
+++ b/frontend/src/components/PixelInspector.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from "@chakra-ui/react";
 
 interface HoverSourceTile {
   index: { x: number; y: number; z?: number };
-  bounds: [number, number, number, number] | number[];
+  bounds?: [number, number, number, number] | number[];
   content?: {
     data?: {
       raw?: ArrayLike<number>;
@@ -31,6 +31,10 @@ function lookupValue(
   const height = data?.height;
   if (!raw || !width || !height) return null;
 
+  // deck.gl's picking info.sourceTile does not always carry bounds — e.g. a
+  // tile still loading, or a sub-layer whose parent tile exposes bbox under a
+  // different shape. Bail rather than let the destructure throw.
+  if (!sourceTile.bounds || sourceTile.bounds.length < 4) return null;
   const [west, south, east, north] = sourceTile.bounds as [
     number,
     number,

--- a/frontend/src/components/__tests__/PixelInspector.test.tsx
+++ b/frontend/src/components/__tests__/PixelInspector.test.tsx
@@ -100,6 +100,25 @@ describe("usePixelInspector categorical branch", () => {
     expect(result.current.hoverInfo).toBeNull();
   });
 
+  it("returns null without throwing when sourceTile has no bounds", async () => {
+    const { result } = renderHook(() => usePixelInspector(null));
+    act(() => {
+      result.current.onHover({
+        coordinate: [-5, 5],
+        x: 0,
+        y: 0,
+        sourceTile: {
+          index: { x: 0, y: 0, z: 0 },
+          content: {
+            data: { raw: new Float32Array([1, 2, 3, 4]), width: 2, height: 2 },
+          },
+        },
+      });
+    });
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+    expect(result.current.hoverInfo).toBeNull();
+  });
+
   it("samples from the hovered tile's own data, not a shared cache", async () => {
     const cats = [
       { value: 1, color: "#f00", label: "One" },


### PR DESCRIPTION
## Summary

- Fixes \`Uncaught TypeError: undefined is not iterable\` thrown on hover over categorical client-rendered COGs. Reproduces on any dataset where deck.gl's \`info.sourceTile\` is truthy but \`bounds\` is absent (e.g. tile mid-load, sub-layer without bounds propagation).
- Roots out the destructure of \`sourceTile.bounds\` by marking it optional and bailing to \`null\` when missing.
- Adds a regression test covering the missing-bounds path.

## Test plan

- [x] \`npx vitest run src/components/__tests__/PixelInspector.test.tsx\` — 8/8 pass, incl. new case
- [x] \`npx vitest run\` — full frontend suite (453 tests) green
- [x] \`npx tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pixel inspector crashes when tile boundary information is unavailable, improving stability when inspecting unloaded or partial tiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->