### PR TITLE
fix(ingestion): drop workspace auth from jobs SSE stream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ cd ingestion && uv run pytest -v
 
 **Jobs:**
 - `GET /api/jobs/{id}` — Get job status
-- `GET /api/jobs/{id}/stream` — SSE stream of conversion progress
+- `GET /api/jobs/{id}/stream` — SSE stream of conversion progress; no workspace auth on this endpoint (EventSource cannot send custom headers); job UUIDs are the only access barrier — a scoped auth token or cookie-based workspace auth would be more robust for production
 
 **Datasets:**
 - `GET /api/datasets` — List datasets belonging to the caller's workspace plus any dataset flagged `is_example=True` (example datasets are visible to every workspace)

--- a/ingestion/src/routes/jobs.py
+++ b/ingestion/src/routes/jobs.py
@@ -33,8 +33,17 @@ async def get_job(job_id: str, request: Request):
 
 @router.get("/jobs/{job_id}/stream")
 async def stream_job(job_id: str, request: Request):
-    """SSE stream of job status updates."""
-    job = _get_job_for_workspace(job_id, request)
+    """SSE stream of job status updates.
+
+    No workspace auth on this endpoint: browser EventSource cannot send
+    custom headers, so requiring X-Workspace-Id would 404 every client.
+    Job UUIDs are the only access barrier — same tradeoff as
+    /api/connections/{id}/stream. A scoped auth token or cookie-based
+    workspace auth would be more robust for production.
+    """
+    job = jobs.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
 
     async def event_generator():
         last_status = (None, None)

--- a/ingestion/tests/test_job_scoping.py
+++ b/ingestion/tests/test_job_scoping.py
@@ -34,11 +34,26 @@ def test_job_without_workspace_accessible(client):
     del jobs[job.id]
 
 
-def test_stream_hidden_from_other_workspace(client, app):
+def test_stream_accessible_without_workspace_header(app):
+    """Stream endpoint intentionally skips workspace scoping so browser
+    EventSource (which can't send custom headers) can connect. Job UUIDs
+    are the access barrier — same tradeoff as /api/connections/{id}/stream.
+    """
+    from starlette.testclient import TestClient
+
+    from src.models import JobStatus
+
     job = Job(filename="test.tif")
     job.workspace_id = "ownerXYZ"
+    # Flip to READY so the SSE generator yields once and exits cleanly.
+    job.status = JobStatus.READY
     jobs[job.id] = job
 
-    resp = client.get(f"/api/jobs/{job.id}/stream")
-    assert resp.status_code == 404
+    # No X-Workspace-Id header — mirrors browser EventSource.
+    anon = TestClient(app, raise_server_exceptions=False)
+    resp = anon.get(f"/api/jobs/{job.id}/stream")
+    assert resp.status_code == 200
+
+    resp_missing = anon.get("/api/jobs/does-not-exist/stream")
+    assert resp_missing.status_code == 404
     del jobs[job.id]


### PR DESCRIPTION
## Summary

Real fix for #299 (and #208 before it). My previous PR #300 addressed a genuine hygiene issue — blocking `upload_raw` on the event loop — but it was not the actual cause of the "Connection lost" errors users have been hitting.

## Root cause

`/api/jobs/{id}/stream` requires the `X-Workspace-Id` header (added in #195 to prevent cross-workspace status leaks). Browser `EventSource` **cannot send custom headers** — only the initial upload POST (via `workspaceFetch`) carries the header. So every SSE connection from the frontend hits:

```python
workspace_id = request.headers.get("x-workspace-id", "")  # ""
if job.workspace_id and workspace_id != job.workspace_id:  # True
    raise HTTPException(status_code=404, detail="Job not found")
```

→ immediate 404 → 3 retries all 404 → "Connection lost. Please refresh the page."

The dataset still lands in the library because the background pipeline task is unaffected — the error is purely a frontend visibility problem.

The evidence from the user's browser console (three 404s on `/api/jobs/e24f47d7-.../stream`) matches exactly.

## Fix

Drop workspace scoping from the stream endpoint specifically. This matches the existing [`/api/connections/{id}/stream`](https://github.com/aboydnw/cng-sandbox/blob/main/ingestion/src/routes/connections.py) pattern (documented in CLAUDE.md: "no workspace auth on this endpoint (EventSource cannot send custom headers); connection UUIDs are the only access barrier"). Job UUIDs carry the same protection.

`GET /api/jobs/{id}` (non-stream) keeps its workspace scoping — `fetch` can send the header normally.

## Follow-ups

- A query-parameter or cookie-based workspace token would close the UUID-guessing gap for production. Out of scope here.
- The distortion-persists complaint in #299 is a separate issue (user reports it's client-render only, titiler is fine). Need the specific dataset + file to reproduce.

## Test plan

- [ ] `cd ingestion && uv run pytest tests/test_job_scoping.py -v`
- [ ] Deploy, upload a file through the workspace UI, confirm the progress bar advances through all stages with no "Connection lost" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Job streaming endpoint is now accessible without workspace authentication headers (EventSource limitation).
  * Stream endpoint returns proper 404 for missing jobs.

* **Tests**
  * Updated stream tests to expect access without workspace headers and to validate missing-job behavior.

* **Documentation**
  * Clarified stream endpoint behavior and recommended more robust auth approaches (scoped tokens or cookie-based auth).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->