### PR TITLE
fix(frontend): read tile extent from boundingBox, not non-existent bounds

### DIFF
--- a/frontend/src/components/PixelInspector.tsx
+++ b/frontend/src/components/PixelInspector.tsx
@@ -1,9 +1,20 @@
 import { useState, useCallback, useRef } from "react";
 import { Box, Text } from "@chakra-ui/react";
 
+type TileBbox =
+  | { west: number; south: number; east: number; north: number }
+  | { left: number; top: number; right: number; bottom: number };
+
 interface HoverSourceTile {
   index: { x: number; y: number; z?: number };
-  bounds?: [number, number, number, number] | number[];
+  /**
+   * deck.gl v9 Tile2DHeader.boundingBox: `[[minX, minY], [maxX, maxY]]`.
+   * This is the non-deprecated extent accessor and is always populated by
+   * the tileset at construction time.
+   */
+  boundingBox?: [number[], number[]];
+  /** Legacy/alternate shape returned by some tileset implementations. */
+  bbox?: TileBbox;
   content?: {
     data?: {
       raw?: ArrayLike<number>;
@@ -11,6 +22,30 @@ interface HoverSourceTile {
       height?: number;
     };
   };
+}
+
+function resolveTileExtent(
+  sourceTile: HoverSourceTile
+): [number, number, number, number] | null {
+  const bb = sourceTile.boundingBox;
+  if (bb && bb[0]?.length >= 2 && bb[1]?.length >= 2) {
+    const [[minX, minY], [maxX, maxY]] = bb;
+    if ([minX, minY, maxX, maxY].every((v) => typeof v === "number")) {
+      return [minX, minY, maxX, maxY];
+    }
+  }
+  const bbox = sourceTile.bbox;
+  if (bbox) {
+    if ("west" in bbox) return [bbox.west, bbox.south, bbox.east, bbox.north];
+    if ("left" in bbox)
+      return [
+        bbox.left,
+        Math.min(bbox.top, bbox.bottom),
+        bbox.right,
+        Math.max(bbox.top, bbox.bottom),
+      ];
+  }
+  return null;
 }
 
 interface DeckHoverInfo {
@@ -31,16 +66,9 @@ function lookupValue(
   const height = data?.height;
   if (!raw || !width || !height) return null;
 
-  // deck.gl's picking info.sourceTile does not always carry bounds — e.g. a
-  // tile still loading, or a sub-layer whose parent tile exposes bbox under a
-  // different shape. Bail rather than let the destructure throw.
-  if (!sourceTile.bounds || sourceTile.bounds.length < 4) return null;
-  const [west, south, east, north] = sourceTile.bounds as [
-    number,
-    number,
-    number,
-    number,
-  ];
+  const extent = resolveTileExtent(sourceTile);
+  if (!extent) return null;
+  const [west, south, east, north] = extent;
   const spanX = east - west;
   const spanY = north - south;
   if (spanX <= 0 || spanY <= 0) return null;

--- a/frontend/src/components/__tests__/PixelInspector.test.tsx
+++ b/frontend/src/components/__tests__/PixelInspector.test.tsx
@@ -35,13 +35,17 @@ function hoverInfo(opts: {
     width = 2,
     height = 2,
   } = opts;
+  const [minX, minY, maxX, maxY] = tileBounds;
   return {
     coordinate,
     x,
     y,
     sourceTile: {
       index: { x: tileX, y: tileY, z: 0 },
-      bounds: tileBounds,
+      boundingBox: [
+        [minX, minY],
+        [maxX, maxY],
+      ] as [number[], number[]],
       content: { data: { raw, width, height } },
     },
   };
@@ -117,6 +121,31 @@ describe("usePixelInspector categorical branch", () => {
     });
     await new Promise((r) => requestAnimationFrame(() => r(null)));
     expect(result.current.hoverInfo).toBeNull();
+  });
+
+  it("reads extent from legacy bbox object when boundingBox is absent", async () => {
+    const cats = [{ value: 1, color: "#f00", label: "One" }];
+    const { result } = renderHook(() => usePixelInspector(null, cats));
+    act(() => {
+      result.current.onHover({
+        coordinate: [-5, 5],
+        x: 10,
+        y: 20,
+        sourceTile: {
+          index: { x: 0, y: 0, z: 0 },
+          bbox: { west: -10, south: -10, east: 10, north: 10 },
+          content: {
+            data: { raw: new Float32Array([1, 1, 1, 1]), width: 2, height: 2 },
+          },
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.hoverInfo).toMatchObject({
+        kind: "categorical",
+        label: "One",
+      });
+    });
   });
 
   it("samples from the hovered tile's own data, not a shared cache", async () => {


### PR DESCRIPTION
## Summary

- PR #302 stopped the crash on hover, but the tooltip still never appeared because the "missing bounds" guard always short-circuited.
- Root cause: @developmentseed/deck.gl-raster 0.4.0 (installed transitively via deck.gl-geotiff 0.4.0) returns \`{bbox: {west,south,east,north}, ...}\` from \`getTileMetadata\` — **not** \`{bounds}\`. deck.gl's \`Tile2DHeader\` normalizes that into \`boundingBox: [[minX, minY], [maxX, maxY]]\`.
- We were reading \`sourceTile.bounds\`, which is never populated in the shipped library version.

## Fix

- Read tile extent from \`sourceTile.boundingBox\` (the documented non-deprecated API) with a fallback to \`sourceTile.bbox\` in both \`{west,south,east,north}\` and \`{left,top,right,bottom}\` shapes.
- Extent resolution moved into a tiny \`resolveTileExtent\` helper so the shape handling is isolated.

## Verification

Traced the prod bundle: the TMS tileset emits \`bbox\` / \`projectedBbox\` / \`projectedCorners\` (no \`bounds\` field). deck.gl's \`Tile2DHeader\` setter converts the \`bbox\` object to \`boundingBox\`. That's the stable accessor we key off of.

## Test plan

- [x] \`npx vitest run src/components/__tests__/PixelInspector.test.tsx\` — 9/9 pass (existing tests updated to use \`boundingBox\`; added coverage for the \`bbox\` fallback path)
- [x] \`npx vitest run\` — full frontend suite (454 tests) green
- [x] \`npx tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tile extent resolution to support multiple format variations, including deck.gl v9 compatibility and legacy tile data structures.

* **Tests**
  * Added test coverage for backward compatibility with legacy tile extent formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->