### PR TITLE
fix(frontend): update renderTile return type for deck.gl-raster 0.5.0

### DIFF
--- a/frontend/src/components/UnifiedMap.tsx
+++ b/frontend/src/components/UnifiedMap.tsx
@@ -124,6 +124,8 @@ export const UnifiedMap = forwardRef<any, UnifiedMapProps>(function UnifiedMap(
           zoom={camera.zoom}
           bearing={camera.bearing}
           pitch={camera.pitch}
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error preserveDrawingBuffer not in react-map-gl's Map prop types but forwarded to maplibre-gl
           preserveDrawingBuffer={enableSnapshot ?? false}
         />
       </DeckGL>

--- a/frontend/src/components/UnifiedMap.tsx
+++ b/frontend/src/components/UnifiedMap.tsx
@@ -124,7 +124,6 @@ export const UnifiedMap = forwardRef<any, UnifiedMapProps>(function UnifiedMap(
           zoom={camera.zoom}
           bearing={camera.bearing}
           pitch={camera.pitch}
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error preserveDrawingBuffer not in react-map-gl's Map prop types but forwarded to maplibre-gl
           preserveDrawingBuffer={enableSnapshot ?? false}
         />

--- a/frontend/src/components/UnifiedMap.tsx
+++ b/frontend/src/components/UnifiedMap.tsx
@@ -124,7 +124,6 @@ export const UnifiedMap = forwardRef<any, UnifiedMapProps>(function UnifiedMap(
           zoom={camera.zoom}
           bearing={camera.bearing}
           pitch={camera.pitch}
-          // @ts-expect-error preserveDrawingBuffer removed from MapOptions types in maplibre-gl v5
           preserveDrawingBuffer={enableSnapshot ?? false}
         />
       </DeckGL>

--- a/frontend/src/lib/layers/cogLayer.ts
+++ b/frontend/src/lib/layers/cogLayer.ts
@@ -205,10 +205,12 @@ export function buildCogLayerPaletted({
     return { texture: valueTex, lutTexture: lutTex, width, height, raw };
   };
 
-  const renderTile = (data: { texture: unknown; lutTexture: unknown }) => [
-    { module: CreateTexture, props: { textureName: data.texture } },
-    { module: Colormap, props: { colormapTexture: data.lutTexture } },
-  ];
+  const renderTile = (data: { texture: unknown; lutTexture: unknown }) => ({
+    renderPipeline: [
+      { module: CreateTexture, props: { textureName: data.texture } },
+      { module: Colormap, props: { colormapTexture: data.lutTexture } },
+    ],
+  });
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
   return [
@@ -310,10 +312,12 @@ export function buildCogLayerContinuous({
     return { texture, width, height, raw: rawSnapshot };
   };
 
-  const renderTile = (data: { texture: unknown }) => [
-    { module: CreateTexture, props: { textureName: data.texture } },
-    { module: ViridisColorize },
-  ];
+  const renderTile = (data: { texture: unknown }) => ({
+    renderPipeline: [
+      { module: CreateTexture, props: { textureName: data.texture } },
+      { module: ViridisColorize },
+    ],
+  });
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
   return [


### PR DESCRIPTION
## Summary

- `deck.gl-raster` 0.5.0 changed the `renderTile` callback's expected return type from a bare `RasterModule[]` array to `{ renderPipeline: RasterModule[] }` (the new `RenderTileResult` type). Both custom `renderTile` functions in `cogLayer.ts` were returning bare arrays, so `_renderSubLayers` destructured `renderPipeline` as `undefined` and rendered nothing — explaining why client-side COG layers went blank after the 0.5 upgrade.
- Also removes a now-stale `@ts-expect-error` in `UnifiedMap.tsx` — maplibre-gl v5 re-added `preserveDrawingBuffer` to its type definitions, so the suppression was causing a TypeScript error.

## Test plan

- [ ] Open a continuous (float) COG dataset in client render mode — viridis colormap should appear
- [ ] Open a categorical (integer/paletted) COG dataset in client render mode — LUT colors should appear
- [ ] Pixel inspector still shows correct values on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal tile rendering configuration moved to a new structured format for rendering pipelines.
  * Reduced build-time/type-checker warnings in the map component by clarifying a suppression rationale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->