### PR TITLE
fix(frontend): view example stories from homepage instead of forking

### DIFF
--- a/frontend/src/components/BuildStoryCardContent.tsx
+++ b/frontend/src/components/BuildStoryCardContent.tsx
@@ -13,7 +13,6 @@ interface ExampleStory {
 export function BuildStoryCardContent() {
   const navigate = useNavigate();
   const { workspacePath } = useWorkspace();
-  const [error, setError] = useState<string | null>(null);
   const [examples, setExamples] = useState<ExampleStory[]>([]);
 
   useEffect(() => {
@@ -28,22 +27,11 @@ export function BuildStoryCardContent() {
   }, []);
 
   const handleStartFromScratch = () => {
-    setError(null);
     navigate(workspacePath("/story/new"));
   };
 
-  const handleFork = async (storyId: string) => {
-    setError(null);
-    try {
-      const r = await workspaceFetch(`/api/stories/${storyId}/fork`, {
-        method: "POST",
-      });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const forked = await r.json();
-      navigate(workspacePath(`/story/${forked.id}/edit`));
-    } catch {
-      setError("Failed to fork story. Please try again.");
-    }
+  const handleView = (storyId: string) => {
+    navigate(workspacePath(`/story/${storyId}`));
   };
 
   return (
@@ -51,7 +39,7 @@ export function BuildStoryCardContent() {
       {examples.length > 0 && (
         <Box mb={3}>
           <Text fontSize="xs" color="brand.textSecondary" mb={1.5}>
-            Start from a template
+            Explore an example
           </Text>
           <Flex gap={2} overflowX="auto" pb={1}>
             {examples.map((story) => (
@@ -61,7 +49,7 @@ export function BuildStoryCardContent() {
                 variant="outline"
                 colorPalette="orange"
                 flexShrink={0}
-                onClick={() => handleFork(story.id)}
+                onClick={() => handleView(story.id)}
               >
                 {story.title}
               </Button>
@@ -86,12 +74,6 @@ export function BuildStoryCardContent() {
       >
         Start from scratch
       </Button>
-
-      {error && (
-        <Text fontSize="xs" color="red.400" mt={2}>
-          {error}
-        </Text>
-      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- Homepage example-story buttons now open the story reader instead of forking a copy into the user's library
- Matches the library page behavior
- Relabels the section from "Start from a template" to "Explore an example"

## Test plan
- [ ] Open landing page, click an example story button — should navigate to the story reader, not create a new draft
- [ ] Verify no new story appears in Library afterwards
- [ ] Verify "Start from scratch" button still navigates to /story/new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined user interaction by changing the story action from fork to view, with simplified navigation.
  * Updated example section heading copy to reflect example-focused messaging.
  * Removed fork-related error messages and associated error handling from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->