### PR TITLE
fix(frontend): link homepage example stories to edit view

### DIFF
--- a/frontend/src/components/BuildStoryCardContent.tsx
+++ b/frontend/src/components/BuildStoryCardContent.tsx
@@ -31,7 +31,7 @@ export function BuildStoryCardContent() {
   };
 
   const handleView = (storyId: string) => {
-    navigate(workspacePath(`/story/${storyId}`));
+    navigate(workspacePath(`/story/${storyId}/edit`));
   };
 
   return (


### PR DESCRIPTION
## Summary
- Homepage example-story buttons now link to `/story/:id/edit`, matching the library page behavior
- Follow-up to #316 — reader route was the wrong target

## Test plan
- [ ] Click an example story button on the landing page — opens the story editor view
- [ ] Behavior matches clicking the same example story from the library page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Story cards now navigate to edit view when selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->