### PR TITLE
fix(ingestion): probe .tif URLs for COG structure in /api/inspect-url

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,7 @@ cd ingestion && uv run pytest -v
 
 **Other:**
 - `POST /api/bug-report` — Submit a bug report (creates a GitHub issue)
-- `POST /api/inspect-url` — Inspect a remote URL before registering it as a connection; body `{"url": "..."}`; returns `{format, is_cog, size_bytes, bounds, has_errors, error_detail}` (`bounds` is reserved for future use and always `null` currently). Format is detected from the path/template (`xyz`, `pmtiles`, `parquet`, `cog`, `tiff`, `geojson`, or `unknown`). For non-XYZ URLs, runs SSRF validation (`validate_url_safe`) and a HEAD probe for `content-length`
+- `POST /api/inspect-url` — Inspect a remote URL before registering it as a connection; body `{"url": "..."}`; returns `{format, is_cog, size_bytes, bounds, has_errors, error_detail}` (`bounds` is reserved for future use and always `null` currently). Format is detected from the path/template (`xyz`, `pmtiles`, `parquet`, `cog`, `tiff`, `geojson`, or `unknown`). For non-XYZ URLs, runs SSRF validation (`validate_url_safe`) and a HEAD probe for `content-length`. When the detected format is `tiff` and the HEAD probe succeeds, also runs `check_remote_is_cog` (10s timeout) to refine the `is_cog` flag; probe failures are swallowed and surfaced as `is_cog=false` rather than as errors
 - `GET /api/proxy` — Proxy GET requests to external URLs (used by the frontend for CORS-restricted resources); HTTPS-only, blocks private/loopback IPs, restricts to `.pmtiles`/`.tif`/`.tiff` extensions, rejects redirects, caps responses at 50 MB
 - `GET /api/health` — Health check
 

--- a/ingestion/src/routes/inspect.py
+++ b/ingestion/src/routes/inspect.py
@@ -1,12 +1,19 @@
+import asyncio
+import logging
 from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
+from src.services.cog_checker import check_remote_is_cog
 from src.services.url_validation import SSRFError, validate_url_safe
 
 router = APIRouter(prefix="/api", tags=["inspection"])
+
+logger = logging.getLogger(__name__)
+
+COG_PROBE_TIMEOUT_SECONDS = 10.0
 
 
 class InspectUrlRequest(BaseModel):
@@ -53,6 +60,17 @@ async def _probe_size(url: str) -> tuple[int | None, str | None]:
         return None, str(exc)
 
 
+async def _probe_is_cog(url: str) -> bool:
+    try:
+        result = await asyncio.wait_for(
+            check_remote_is_cog(url), timeout=COG_PROBE_TIMEOUT_SECONDS
+        )
+        return result.is_cog
+    except Exception as exc:
+        logger.info("COG probe failed for %s: %s", url, exc)
+        return False
+
+
 @router.post("/inspect-url", response_model=InspectUrlResponse)
 async def inspect_url(request: InspectUrlRequest) -> InspectUrlResponse:
     format_detected, is_cog = _detect_format(request.url)
@@ -73,6 +91,8 @@ async def inspect_url(request: InspectUrlRequest) -> InspectUrlResponse:
             )
         size_bytes, error_detail = await _probe_size(request.url)
         has_errors = error_detail is not None
+        if format_detected == "tiff" and not has_errors:
+            is_cog = await _probe_is_cog(request.url)
     return InspectUrlResponse(
         format=format_detected,
         is_cog=is_cog,

--- a/ingestion/src/routes/inspect.py
+++ b/ingestion/src/routes/inspect.py
@@ -67,7 +67,8 @@ async def _probe_is_cog(url: str) -> bool:
         )
         return result.is_cog
     except Exception as exc:
-        logger.info("COG probe failed for %s: %s", url, exc)
+        safe_url = urlparse(url)._replace(query="", fragment="").geturl()
+        logger.info("COG probe failed for %s: %s", safe_url, exc)
         return False
 
 

--- a/ingestion/tests/test_inspect.py
+++ b/ingestion/tests/test_inspect.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+from src.services.cog_checker import CogCheckResult
+
 
 def test_inspect_url_detects_pmtiles(client, monkeypatch):
     fake_resp = MagicMock(status_code=200, headers={"content-length": "1234"})
@@ -48,15 +50,83 @@ def test_inspect_url_detects_cog(client, monkeypatch):
     assert body["is_cog"] is True
 
 
-def test_inspect_url_detects_tiff(client, monkeypatch):
+def test_inspect_url_tiff_probed_as_cog(client, monkeypatch):
     async def fake_head(self, url):
         return MagicMock(status_code=200, headers={"content-length": "1"})
 
+    async def fake_probe(url):
+        return CogCheckResult(is_cog=True, has_tiling=True, has_overviews=True)
+
     monkeypatch.setattr("httpx.AsyncClient.head", fake_head)
+    monkeypatch.setattr("src.routes.inspect.check_remote_is_cog", fake_probe)
+
     resp = client.post(
         "/api/inspect-url", json={"url": "https://example.com/raster.tif"}
     )
-    assert resp.json()["format"] == "tiff"
+    body = resp.json()
+    assert body["format"] == "tiff"
+    assert body["is_cog"] is True
+
+
+def test_inspect_url_tiff_probed_as_non_cog(client, monkeypatch):
+    async def fake_head(self, url):
+        return MagicMock(status_code=200, headers={"content-length": "1"})
+
+    async def fake_probe(url):
+        return CogCheckResult(is_cog=False, has_tiling=False, has_overviews=False)
+
+    monkeypatch.setattr("httpx.AsyncClient.head", fake_head)
+    monkeypatch.setattr("src.routes.inspect.check_remote_is_cog", fake_probe)
+
+    resp = client.post(
+        "/api/inspect-url", json={"url": "https://example.com/raster.tif"}
+    )
+    body = resp.json()
+    assert body["format"] == "tiff"
+    assert body["is_cog"] is False
+
+
+def test_inspect_url_tiff_cog_probe_failure_falls_back(client, monkeypatch):
+    async def fake_head(self, url):
+        return MagicMock(status_code=200, headers={"content-length": "1"})
+
+    async def fake_probe(url):
+        raise RuntimeError("vsicurl connection refused")
+
+    monkeypatch.setattr("httpx.AsyncClient.head", fake_head)
+    monkeypatch.setattr("src.routes.inspect.check_remote_is_cog", fake_probe)
+
+    resp = client.post(
+        "/api/inspect-url", json={"url": "https://example.com/raster.tif"}
+    )
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body["format"] == "tiff"
+    assert body["is_cog"] is False
+    assert body["has_errors"] is False
+
+
+def test_inspect_url_tiff_skips_cog_probe_when_head_fails(client, monkeypatch):
+    async def fake_head(self, url):
+        raise RuntimeError("network down")
+
+    probe_called = {"value": False}
+
+    async def fake_probe(url):
+        probe_called["value"] = True
+        return CogCheckResult(is_cog=True, has_tiling=True, has_overviews=True)
+
+    monkeypatch.setattr("httpx.AsyncClient.head", fake_head)
+    monkeypatch.setattr("src.routes.inspect.check_remote_is_cog", fake_probe)
+
+    resp = client.post(
+        "/api/inspect-url", json={"url": "https://example.com/raster.tif"}
+    )
+    body = resp.json()
+    assert body["format"] == "tiff"
+    assert body["is_cog"] is False
+    assert body["has_errors"] is True
+    assert probe_called["value"] is False
 
 
 def test_inspect_url_detects_xyz_template_without_head(client):

--- a/ingestion/tests/test_inspect.py
+++ b/ingestion/tests/test_inspect.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from src.services.cog_checker import CogCheckResult
 
 
@@ -50,7 +52,8 @@ def test_inspect_url_detects_cog(client, monkeypatch):
     assert body["is_cog"] is True
 
 
-def test_inspect_url_tiff_probed_as_cog(client, monkeypatch):
+@pytest.mark.parametrize("ext", [".tif", ".tiff"])
+def test_inspect_url_tiff_probed_as_cog(client, monkeypatch, ext):
     async def fake_head(self, url):
         return MagicMock(status_code=200, headers={"content-length": "1"})
 
@@ -61,14 +64,15 @@ def test_inspect_url_tiff_probed_as_cog(client, monkeypatch):
     monkeypatch.setattr("src.routes.inspect.check_remote_is_cog", fake_probe)
 
     resp = client.post(
-        "/api/inspect-url", json={"url": "https://example.com/raster.tif"}
+        "/api/inspect-url", json={"url": f"https://example.com/raster{ext}"}
     )
     body = resp.json()
     assert body["format"] == "tiff"
     assert body["is_cog"] is True
 
 
-def test_inspect_url_tiff_probed_as_non_cog(client, monkeypatch):
+@pytest.mark.parametrize("ext", [".tif", ".tiff"])
+def test_inspect_url_tiff_probed_as_non_cog(client, monkeypatch, ext):
     async def fake_head(self, url):
         return MagicMock(status_code=200, headers={"content-length": "1"})
 
@@ -79,7 +83,7 @@ def test_inspect_url_tiff_probed_as_non_cog(client, monkeypatch):
     monkeypatch.setattr("src.routes.inspect.check_remote_is_cog", fake_probe)
 
     resp = client.post(
-        "/api/inspect-url", json={"url": "https://example.com/raster.tif"}
+        "/api/inspect-url", json={"url": f"https://example.com/raster{ext}"}
     )
     body = resp.json()
     assert body["format"] == "tiff"


### PR DESCRIPTION
## Summary

- `/api/inspect-url` was inferring `is_cog` from file extension only: `.cog` → true, `.tif`/`.tiff` → false. Real-world COGs almost always use `.tif` (swisstopo, Source Cooperative, USGS), so the frontend URL-entry box routed every `.tif` URL to the upload-and-convert path even when it was already a valid COG.
- Wire the existing `check_remote_is_cog` helper (GDAL `/vsicurl/` header probe, checks tiling + overviews) into the tiff branch of the endpoint with a 10s timeout.
- On probe failure (timeout, network error, unsupported URL), fall back to `is_cog=False` rather than surfacing an error — the user can still take the upload path.

## Test plan

- [x] Existing inspect tests still pass
- [x] New test: tiff URL where COG probe returns `is_cog=True` → response `is_cog=True`
- [x] New test: tiff URL where COG probe returns `is_cog=False` → response `is_cog=False`
- [x] New test: tiff URL where COG probe raises → response `is_cog=False`, `has_errors=False`
- [x] New test: tiff URL where HEAD probe already failed → COG probe skipped, `is_cog=False`, `has_errors=True`
- [ ] Manual E2E: paste the swisstopo URL that triggered this bug (`https://data.geo.admin.ch/ch.swisstopo.swissalti3d/.../swissalti3d_2019_2600-1199_0.5_2056_5728.tif`) into the visualize-data box and confirm it routes to the "create connection" flow instead of upload + convert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved TIFF inspection that performs an additional COG probe (with a bounded timeout) and treats probe failures as non-COG without surfacing errors.

* **Bug Fixes**
  * Probe failures no longer turn into endpoint errors; responses remain stable and indicate is_cog=false when probing fails.

* **Documentation**
  * Updated /api/inspect-url documentation to reflect the new TIFF/COG behavior.

* **Tests**
  * Expanded tests covering successful probes, non-COG results, probe failures, and skipped probes when initial checks fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->