### PR TITLE
feat: gate SPA behind basic auth with carve-out for shared views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Service names: `database`, `stac-api`, `raster-tiler`, `vector-tiler`, `cog-tile
 
 ## Production Deployment (Hetzner)
 
-The sandbox can be deployed to a public URL with HTTPS using the `prod` Docker Compose profile. The frontend and shared `/map` / `/story` views are public; write operations and workspace listings are gated behind HTTP basic auth via Caddy.
+The sandbox can be deployed to a public URL with HTTPS using the `prod` Docker Compose profile. Shared `/map` / `/story` views are public; the rest of the SPA, write operations, and workspace listings are gated behind HTTP basic auth via Caddy.
 
 ### Auth model
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,8 @@ The sandbox can be deployed to a public URL with HTTPS using the `prod` Docker C
 
 Caddy applies basic auth selectively (see `Caddyfile`):
 
-- **Public (no auth):** frontend SPA, `/storage/*` (R2 proxy), `/cog/*`, `/raster/*`, `/vector/*`, individual resource reads like `GET /api/datasets/{id}`, `GET /api/connections/{id}`, `GET /api/stories/{id}`, `/api/proxy`, `/api/health`. This lets shared map/story URLs load for anyone without a password prompt, and lets PMTiles / DuckDB-WASM range requests succeed (they can't send basic auth).
-- **Auth required:** all non-GET/HEAD requests to `/api/*` (uploads, creates, updates, deletes) and workspace-listing reads (`GET /api/datasets`, `GET /api/connections`, `GET /api/stories`).
+- **Public (no auth):** `/assets/*` (hashed SPA bundle), shared SPA views (`/map/*` including `/map/connection/*`, `/story/:id`, `/story/:id/embed`), `/storage/*` (R2 proxy), `/cog/*`, `/raster/*`, `/vector/*`, individual resource reads like `GET /api/datasets/{id}`, `GET /api/connections/{id}`, `GET /api/stories/{id}`, `/api/proxy`, `/api/health`. This lets shared map/story URLs load for anyone without a password prompt, and lets PMTiles / DuckDB-WASM range requests succeed (they can't send basic auth).
+- **Auth required:** all other SPA paths (root `/`, `/library`, `/discover`, `/about`, `/story/new`, `/story/:id/edit`, `/w/:workspaceId/*`) so the password prompt appears up front instead of surprising the user mid-flow; plus all non-GET/HEAD requests to `/api/*` (uploads, creates, updates, deletes) and workspace-listing reads (`GET /api/datasets`, `GET /api/connections`, `GET /api/stories`). API auth remains as defense-in-depth — the SPA gate alone doesn't stop someone from hitting the API directly.
 
 ### Prerequisites
 
@@ -102,9 +102,9 @@ docker compose --profile prod up -d --build
 
 ### Verify
 
-- Visit `https://cngsandbox.org` — the SPA should load without a password prompt
-- Attempt an authenticated action (e.g. opening the dataset library or uploading a file) — should prompt for username/password
-- Upload a file to verify CORS works end-to-end
+- Visit `https://cngsandbox.org` — should prompt for username/password immediately (root is gated)
+- After authing, verify the SPA loads and uploads work end-to-end
+- Open a shared map URL (e.g. `https://cngsandbox.org/map/<dataset-id>`) in an incognito window — should load without any prompt
 
 ### Notes
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -90,9 +90,14 @@
 		}
 	}
 
-	# Frontend: serve static files from the production build. Public so
-	# the SPA can load for shared map/story URLs — write actions in the UI
-	# still hit auth-gated API endpoints.
+	# Frontend: serve static files from the production build.
+	#
+	# Auth model: shared /map and /story reader URLs are public so anyone
+	# with the link can view them. The rest of the SPA (upload, library,
+	# discover, story editor, workspace-scoped routes) is gated behind basic
+	# auth at this layer so the password prompt appears up front instead of
+	# surprising the user mid-flow. /assets/* must stay public or the SPA
+	# bundle can't load.
 	#
 	# Cache policy: hashed assets (/assets/*) are immutable and cached
 	# for 1 year. index.html must always be revalidated so browsers
@@ -107,7 +112,29 @@
 		@notAssets not path /assets/*
 		header @notAssets Cache-Control "no-cache"
 
-		try_files {path} /index.html
-		file_server
+		# Auth required for any SPA path that isn't /assets/* or a public
+		# shared view. Public shared views: /map/* (including
+		# /map/connection/*) and /story/:id plus /story/:id/embed where
+		# :id is a UUID. Matching the UUID shape explicitly keeps
+		# /story/new (the editor's "create" route) and /story/:id/edit
+		# behind auth without needing a regex lookahead (Go's RE2 engine
+		# doesn't support them).
+		#
+		# The route block forces basic_auth to run before try_files. In
+		# Caddy's default directive ordering, try_files rewrites the URI
+		# to /index.html before basic_auth evaluates its matcher — which
+		# would make every SPA fallback look like /index.html and break
+		# the public-path carve-out. route preserves written order.
+		@spaNeedsAuth {
+			not path /assets/*
+			not path_regexp ^/(map/.+|story/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(/embed)?/?)$
+		}
+		route {
+			basic_auth @spaNeedsAuth {
+				{$AUTH_USER} {$AUTH_PASSWORD_HASH}
+			}
+			try_files {path} /index.html
+			file_server
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Move the password prompt to the front of the experience: root and workspace routes now prompt immediately rather than surprising users mid-flow (clicking "browse library" was producing a prompt they could cancel and keep using the site).
- Carve out public paths in Caddy for shared views so `/map/*` and `/story/:id(/embed)?` continue to load without a prompt — `:id` is matched as a UUID so `/story/new` and `/story/:id/edit` stay behind auth.
- `/assets/*` stays public (SPA bundle must load). API auth rules are unchanged and act as defense-in-depth.
- Wrap `basic_auth` + `try_files` in a `route {}` block — Caddy's default directive order runs `try_files` before `basic_auth`, which would rewrite every non-file path to `/index.html` before the auth matcher evaluated and collapse the public/gated distinction. `route` preserves written order.

## Test plan

- [x] `caddy validate` passes
- [x] Smoke test: run Caddy locally against a dummy static dir; verify `/`, `/library`, `/discover`, `/story/new`, `/story/:uuid/edit`, `/w/:id/library` return 401; `/map/abc`, `/map/connection/abc`, `/story/:uuid`, `/story/:uuid/embed`, `/assets/app.js` return 200; all gated paths return 200 when `-u demo:test` is supplied
- [x] Verified the UUID-shape regex matches 19 representative paths correctly (Python re with same semantics as RE2)
- [ ] Post-deploy on cngsandbox.org: visit `/` → prompted up front; visit a shared `/map/:id` or `/story/:id` URL in incognito → loads without prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated verification instructions to reflect new authentication requirements and public access behavior.

* **Security**
  * Authentication now required at application entry point and protected editor paths. Shared maps, stories, and static assets remain publicly accessible without login. API security remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->