### PR TITLE
fix: remove stale deck.gl-raster texture workaround

### DIFF
--- a/frontend/src/lib/layers/__tests__/cogLayer.test.ts
+++ b/frontend/src/lib/layers/__tests__/cogLayer.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import proj4 from "proj4";
 
 vi.mock("@developmentseed/deck.gl-geotiff", () => ({
-  COGLayer: vi.fn(),
+  COGLayer: vi.fn().mockImplementation(function MockCOGLayer(props) {
+    return { props };
+  }),
 }));
 
 vi.mock("@developmentseed/deck.gl-raster/gpu-modules", () => ({
@@ -10,56 +11,7 @@ vi.mock("@developmentseed/deck.gl-raster/gpu-modules", () => ({
   Colormap: {},
 }));
 
-import { resolveCogUrl, localEpsgResolver } from "../cogLayer";
-
-describe("localEpsgResolver (EPSG defs)", () => {
-  // Regression: the local EPSG defs were missing proj4's required origin
-  // params (long0, lat0, lat_ts, x0, y0, k0). proj4 tolerated the missing
-  // source-side fields for longlat but silently produced NaN x values when
-  // the def was used on either end of a merc converter. That NaN fed into
-  // deck.gl-raster's tile traversal and crashed the bounding-volume
-  // calculation, which then looped forever in the animation frame.
-  it("produces finite forward/inverse coordinates between 4326 and 3857", async () => {
-    const def4326 = await localEpsgResolver(4326);
-    const def3857 = await localEpsgResolver(3857);
-
-    const samples: Array<[number, number]> = [
-      [11, 47],
-      [-156, 76],
-      [-156, -76],
-      [0, 0],
-      [179, 84],
-    ];
-
-    const forward = proj4(def4326 as never, def3857 as never);
-    for (const [lon, lat] of samples) {
-      const [x, y] = forward.forward([lon, lat]);
-      expect(Number.isFinite(x)).toBe(true);
-      expect(Number.isFinite(y)).toBe(true);
-    }
-
-    const inverse = proj4(def3857 as never, def4326 as never);
-    for (const [lon, lat] of samples) {
-      const [fx, fy] = forward.forward([lon, lat]);
-      const [ilon, ilat] = inverse.forward([fx, fy]);
-      expect(ilon).toBeCloseTo(lon, 6);
-      expect(ilat).toBeCloseTo(lat, 6);
-    }
-  });
-
-  it("matches canonical Web Mercator (spherical, not ellipsoidal) at the antimeridian", async () => {
-    // Web Mercator / EPSG:3857 is defined on a sphere with a = b = 6378137, so
-    // the half-circumference at lon=180 must be π * 6378137 ≈ 20037508.3428.
-    // An ellipsoidal merc def (ellps: WGS84, rf: 298.25…) would drift y by
-    // tens of km at mid/high latitudes and silently break tile alignment.
-    const def4326 = await localEpsgResolver(4326);
-    const def3857 = await localEpsgResolver(3857);
-    const forward = proj4(def4326 as never, def3857 as never);
-    const [x, y] = forward.forward([180, 0]);
-    expect(x).toBeCloseTo(20037508.3428, 2);
-    expect(y).toBeCloseTo(0, 2);
-  });
-});
+import { buildCogLayerContinuous, resolveCogUrl } from "../cogLayer";
 
 describe("resolveCogUrl", () => {
   it("passes https URLs through unchanged", () => {
@@ -89,6 +41,51 @@ describe("resolveCogUrl", () => {
   it("resolves path-relative inputs against window origin", () => {
     expect(resolveCogUrl("storage/foo.tif")).toBe(
       `${window.location.origin}/storage/foo.tif`
+    );
+  });
+});
+
+describe("buildCogLayerContinuous", () => {
+  it("passes unpadded r8 texture data to deck.gl-raster 0.5", async () => {
+    const layers = buildCogLayerContinuous({
+      cogUrl: "/cog/example.tif",
+      opacity: 1,
+      rasterMin: 0,
+      rasterMax: 6,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getTileData = (layers[0] as any).props.getTileData;
+
+    const fakeTile = {
+      array: {
+        layout: "interleaved",
+        bands: [],
+        data: new Float32Array([0, 1, 2, 3, 4, 6]),
+        width: 3,
+        height: 2,
+      },
+    };
+    const image = {
+      fetchTile: vi.fn().mockResolvedValue(fakeTile),
+    };
+    const device = {
+      createTexture: vi.fn().mockReturnValue({ mock: "tex" }),
+    };
+
+    await getTileData(image, {
+      device,
+      x: 3,
+      y: 5,
+      signal: new AbortController().signal,
+    });
+
+    expect(device.createTexture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: new Uint8Array([0, 43, 85, 128, 170, 255]),
+        format: "r8unorm",
+        width: 3,
+        height: 2,
+      })
     );
   });
 });

--- a/frontend/src/lib/layers/__tests__/cogLayerPaletted.test.ts
+++ b/frontend/src/lib/layers/__tests__/cogLayerPaletted.test.ts
@@ -114,4 +114,46 @@ describe("buildCogLayerPaletted with categories", () => {
     // tile, so the pixel inspector reads the specific tile it picked.
     expect(Array.from(result.raw)).toEqual([1, 0, 1, 0]);
   });
+
+  it("passes unpadded r8 texture data to deck.gl-raster 0.5", async () => {
+    const layers = buildCogLayerPaletted({
+      cogUrl: "/cog/example.tif",
+      opacity: 1,
+      categories: [{ value: 1, color: "#ff0000", label: "A" }],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getTileData = (layers[0] as any).props.getTileData;
+
+    const fakeTile = {
+      array: {
+        layout: "interleaved",
+        bands: [],
+        data: new Uint8Array([1, 2, 3, 4, 5, 6]),
+        width: 3,
+        height: 2,
+      },
+    };
+    const image = {
+      fetchTile: vi.fn().mockResolvedValue(fakeTile),
+    };
+    const device = {
+      createTexture: vi.fn().mockReturnValue({ mock: "tex" }),
+    };
+
+    await getTileData(image, {
+      device,
+      x: 3,
+      y: 5,
+      signal: new AbortController().signal,
+    });
+
+    expect(device.createTexture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: new Uint8Array([1, 2, 3, 4, 5, 6]),
+        format: "r8unorm",
+        width: 3,
+        height: 2,
+      })
+    );
+  });
 });

--- a/frontend/src/lib/layers/cogLayer.ts
+++ b/frontend/src/lib/layers/cogLayer.ts
@@ -5,81 +5,6 @@ import {
   Colormap,
 } from "@developmentseed/deck.gl-raster/gpu-modules";
 import { buildCategoricalLut, type LutCategory } from "./categoricalLut";
-import wktParser from "wkt-parser";
-
-// --- EPSG resolver (offline for common CRSes, network fallback) ---
-
-// proj4 requires projection origin/scale params (long0, lat0, lat_ts, x0, y0,
-// k0) on merc definitions; without them forward() emits NaN x, which NaNs out
-// every reference-point reprojection downstream and crashes the TileLayer's
-// bounding-volume calculation. The axis is "enu" so input is interpreted as
-// [lon, lat], matching the rest of the code.
-const EPSG_DEFS: Record<number, unknown> = {
-  4326: {
-    projName: "longlat",
-    name: "WGS 84",
-    srsCode: "WGS 84",
-    ellps: "WGS 84",
-    a: 6378137,
-    rf: 298.257223563,
-    long0: 0,
-    lat0: 0,
-    x0: 0,
-    y0: 0,
-    axis: "enu",
-    units: "degree",
-  },
-  3857: {
-    projName: "merc",
-    name: "WGS 84 / Pseudo-Mercator",
-    srsCode: "WGS 84 / Pseudo-Mercator",
-    // Web Mercator is defined on a sphere with a = b = 6378137. Using the
-    // WGS84 ellipsoid (rf ≈ 298.26) here would apply elliptical mercator math
-    // and shift y by tens of km at mid/high latitudes, breaking alignment
-    // with canonical tile-space (rescaleEPSG3857ToCommonSpace assumes
-    // 2π * 6378137 circumference).
-    a: 6378137,
-    b: 6378137,
-    long0: 0,
-    lat0: 0,
-    lat_ts: 0,
-    x0: 0,
-    y0: 0,
-    k0: 1,
-    axis: "enu",
-    units: "metre",
-  },
-};
-
-async function localEpsgResolver(epsg: number) {
-  if (EPSG_DEFS[epsg]) return EPSG_DEFS[epsg];
-  const resp = await fetch(`https://epsg.io/${epsg}.json`);
-  if (!resp.ok) throw new Error(`Failed to fetch EPSG:${epsg}`);
-  const projjson = await resp.json();
-  const parsed = wktParser(projjson);
-  EPSG_DEFS[epsg] = parsed;
-  return parsed;
-}
-
-// --- WebGL helpers ---
-
-function padToAlignment(
-  src: Uint8Array,
-  width: number,
-  height: number
-): Uint8Array {
-  const rowBytes = width;
-  const alignedRowBytes = Math.ceil(rowBytes / 4) * 4;
-  if (alignedRowBytes === rowBytes) return src;
-  const dst = new Uint8Array(alignedRowBytes * height);
-  for (let r = 0; r < height; r++) {
-    dst.set(
-      src.subarray(r * rowBytes, (r + 1) * rowBytes),
-      r * alignedRowBytes
-    );
-  }
-  return dst;
-}
 
 const ViridisColorize = {
   name: "viridis-colorize",
@@ -184,7 +109,7 @@ export function buildCogLayerPaletted({
     }
 
     const valueTex = device.createTexture({
-      data: padToAlignment(raw, width, height),
+      data: raw,
       format: "r8unorm",
       width,
       height,
@@ -299,10 +224,8 @@ export function buildCogLayerContinuous({
       );
     }
 
-    const textureData = padToAlignment(uint8, width, height);
-
     const texture = device.createTexture({
-      data: textureData,
+      data: uint8,
       format: "r8unorm",
       width,
       height,
@@ -333,5 +256,3 @@ export function buildCogLayerContinuous({
   ];
   /* eslint-enable @typescript-eslint/no-explicit-any */
 }
-
-export { localEpsgResolver };

--- a/frontend/src/types/wkt-parser.d.ts
+++ b/frontend/src/types/wkt-parser.d.ts
@@ -1,1 +1,0 @@
-declare module "wkt-parser";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for raster texture data handling in COG layers.

* **Chores**
  * Removed EPSG projection resolver and related dependencies.
  * Streamlined texture data processing for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->