### PR TITLE
feat: add CORS headers to /storage/* endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ docker compose --profile prod up -d --build
 - The `caddy_data` volume persists TLS certificates — don't delete it or you'll hit Let's Encrypt rate limits
 - Caddy applies baseline security headers to every response (HSTS, CSP, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`). The CSP allows `'wasm-unsafe-eval'` for DuckDB-WASM, whitelists `https://static.cloudflareinsights.com` (Cloudflare Web Analytics beacon) and `https://plausible.io` (Plausible analytics tracker) on `script-src`, and is permissive on `connect-src`/`img-src` to accommodate user-supplied tile URLs and the CARTO basemap. When adding any new third-party script origin, update both the `Caddyfile` CSP `script-src` directive and this note
 - Tile responses (`/cog/*`, `/raster/*`, `/vector/*`) are served with `Cache-Control: public, max-age=3600`. Tile URLs are immutable per dataset (a change to the underlying data produces a new STAC item id or query param), so a 1-hour browser cache is safe and reduces Hetzner egress
+- `/storage/*` (R2 proxy) responds with `Access-Control-Allow-Origin: *` and preflight handling for `OPTIONS`, so shared COGs can be fetched cross-origin by external tile/raster clients. The path is already public at the edge; CORS just unblocks browsers from reading the bytes on a non-sandbox origin
 
 ## CI/CD
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -20,13 +20,29 @@
 
 	# Data-serving paths: proxy to R2 public URL. Public — range requests
 	# from PMTiles / DuckDB WASM can't carry Basic Auth credentials.
+	# CORS headers are set so shared COGs (is_shared=true) can be consumed
+	# cross-origin by external clients (deck.gl-raster, external map apps,
+	# etc.). Access is already gated by the share flag at the API layer;
+	# once the underlying object is served through this path it's public.
 	handle /storage/* {
-		uri strip_prefix /storage
-		reverse_proxy {$R2_PUBLIC_URL} {
-			header_up Host {upstream_hostport}
-			header_up -Authorization
-			transport http {
-				tls
+		header {
+			Access-Control-Allow-Origin "*"
+			Access-Control-Allow-Methods "GET, HEAD, OPTIONS"
+			Access-Control-Allow-Headers "Range"
+			Access-Control-Expose-Headers "Content-Length, Content-Range, Accept-Ranges, ETag"
+		}
+		@options method OPTIONS
+		handle @options {
+			respond 204
+		}
+		handle {
+			uri strip_prefix /storage
+			reverse_proxy {$R2_PUBLIC_URL} {
+				header_up Host {upstream_hostport}
+				header_up -Authorization
+				transport http {
+					tls
+				}
 			}
 		}
 	}

--- a/Caddyfile
+++ b/Caddyfile
@@ -25,6 +25,7 @@
 	# etc.). Access is already gated by the share flag at the API layer;
 	# once the underlying object is served through this path it's public.
 	handle /storage/* {
+		uri strip_prefix /storage
 		header {
 			Access-Control-Allow-Origin "*"
 			Access-Control-Allow-Methods "GET, HEAD, OPTIONS"
@@ -36,7 +37,6 @@
 			respond 204
 		}
 		handle {
-			uri strip_prefix /storage
 			reverse_proxy {$R2_PUBLIC_URL} {
 				header_up Host {upstream_hostport}
 				header_up -Authorization


### PR DESCRIPTION
## Summary
- Adds `Access-Control-Allow-Origin: *`, `Allow-Methods: GET, HEAD, OPTIONS`, `Allow-Headers: Range`, and `Expose-Headers: Content-Length, Content-Range, Accept-Ranges, ETag` to the `/storage/*` Caddy handler
- Short-circuits `OPTIONS` preflight requests with a 204 so they don't hit the R2 upstream
- Updates CLAUDE.md with a one-line note under the prod deployment section

## Motivation
A third-party developer wanted to load our NLCD COG into a deck.gl-raster demo on their own origin and got blocked by the browser's CORS preflight. The path was already public at the edge (no basic-auth) and data access is already gated by `is_shared` at the API layer — this just unblocks cross-origin reads of bytes the sandbox already serves to anyone with the link.

## Test plan
- [ ] Local: `docker run --rm -e SITE_ADDRESS=... -v "$PWD/Caddyfile:/etc/caddy/Caddyfile" caddy:2-alpine caddy validate ...` returns `Valid configuration` ✅ done before commit
- [ ] Post-deploy: `curl -i -H "Origin: https://example.com" https://cngsandbox.org/storage/datasets/d425d937-.../converted/Annual_NLCD_LndCov_2023_CU_C1V1.tif` shows `Access-Control-Allow-Origin: *`
- [ ] Post-deploy: `curl -i -X OPTIONS -H "Origin: https://example.com" -H "Access-Control-Request-Method: GET" -H "Access-Control-Request-Headers: Range" https://cngsandbox.org/storage/...` returns `HTTP/2 204` with the CORS headers
- [ ] Post-deploy: existing flows still work — load a shared `/map/:id` page for a COG and confirm tiles render, open an `/story/:id` page and confirm chapters load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Storage endpoint now supports cross-origin browser access, avoiding CORS read failures when fetching shared raster/COG resources.
  * Preflight (OPTIONS) requests are handled directly to speed responses.
  * Range requests and content-related headers are permitted/exposed so partial downloads and streaming work reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->