### PR TITLE
fix(frontend): hide Mark as categorical card on shared map view

### DIFF
--- a/frontend/src/components/RasterSidebarControls.tsx
+++ b/frontend/src/components/RasterSidebarControls.tsx
@@ -145,7 +145,7 @@ export function RasterSidebarControls(props: RasterSidebarControlsProps) {
 
       {!isCategorical && (
         <>
-          {canMarkCategorical && datasetId && onDatasetUpdated && (
+          {!shared && canMarkCategorical && datasetId && onDatasetUpdated && (
             <MarkAsCategoricalCard
               datasetId={datasetId}
               onSuccess={onDatasetUpdated}

--- a/frontend/src/components/__tests__/RasterSidebarControls.test.tsx
+++ b/frontend/src/components/__tests__/RasterSidebarControls.test.tsx
@@ -61,6 +61,29 @@ describe("RasterSidebarControls shared prop", () => {
       screen.queryByText(/File exceeds 500 MB browser limit/)
     ).not.toBeInTheDocument();
   });
+
+  it("renders the mark-as-categorical card when not shared", () => {
+    renderCtrl({
+      canMarkCategorical: true,
+      datasetId: "d1",
+      onDatasetUpdated: vi.fn(),
+    });
+    expect(
+      screen.getByRole("button", { name: /mark as categorical/i })
+    ).toBeInTheDocument();
+  });
+
+  it("hides the mark-as-categorical card when shared", () => {
+    renderCtrl({
+      shared: true,
+      canMarkCategorical: true,
+      datasetId: "d1",
+      onDatasetUpdated: vi.fn(),
+    });
+    expect(
+      screen.queryByRole("button", { name: /mark as categorical/i })
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("RasterSidebarControls rescale + flip", () => {


### PR DESCRIPTION
## Summary
- Gate the "Mark as categorical" card in `RasterSidebarControls` behind `!shared` so the write action no longer shows on read-only shared map pages.
- Add a regression test pair (shown when not shared, hidden when shared).

## Test plan
- [x] `npx vitest run src/components/__tests__/RasterSidebarControls.test.tsx`
- [x] `npx vitest run` (full frontend suite, 479 pass)
- [x] `npx tsc --noEmit`
- [ ] Manual: open a shared `/map/<id>` URL for a non-categorical raster — card should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visibility of the "Mark as Categorical" option to properly hide it when datasets are marked as shared.

* **Tests**
  * Added test coverage to verify the "Mark as Categorical" option behavior for both shared and non-shared states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->