### PR TITLE
chore: enable Claude Code plugins and Playwright MCP

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,31 @@
       "Bash(DROP *)",
       "Bash(DELETE FROM*)"
     ]
+  },
+  "mcpServers": {
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "disabled": false,
+      "args": [
+        "@playwright/mcp@latest",
+        "--headless"
+      ],
+      "env": {}
+    }
+  },
+  "enabledPlugins": {
+    "claude-md-management@claude-plugins-official": true,
+    "slack@claude-plugins-official": false,
+    "github@claude-plugins-official": true,
+    "supabase@claude-plugins-official": false,
+    "code-review@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true,
+    "vercel@claude-plugins-official": false,
+    "chrome-devtools-mcp@chrome-devtools-plugins": false,
+    "superpowers@claude-plugins-official": true,
+    "obsidian@obsidian-skills": true,
+    "caveman@caveman": true,
+    "devseed-blog@ds-skills": true
   }
 }


### PR DESCRIPTION
## Summary

Local Claude Code repo config additions:

- **enabledPlugins** — explicit on/off for installed plugins.
  - On: claude-md-management, github, code-review, ralph-loop, superpowers, obsidian, caveman, devseed-blog
  - Off: slack, supabase, vercel, chrome-devtools-mcp
- **mcpServers** — `playwright` MCP server, stdio + headless. Required for VM-based screenshot testing per the project CLAUDE.md.

No code or behavior changes. Repo-tracked Claude config only.

## Test plan

- [ ] CI green (no code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration settings to enhance tool integrations and plugin management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->