### PR TITLE
refactor(ingestion): preserve source CRS on GeoTIFF ingest

### DIFF
--- a/ingestion/src/services/pipeline.py
+++ b/ingestion/src/services/pipeline.py
@@ -694,22 +694,27 @@ async def _wait_for_tipg_collection(dataset_id: str, timeout: float = 30.0) -> N
 def _convert_geotiff_to_cog(
     input_path: str, output_path: str, is_categorical: bool = False
 ) -> None:
-    """Convert GeoTIFF to COG using gdalwarp.
+    """Convert GeoTIFF to COG in the source CRS using gdalwarp.
 
-    For categorical rasters, uses nearest-neighbor resampling for both the warp
-    and the COG overviews. Bilinear/cubic on integer category codes blends them
-    into fractional values that truncate to wrong (but valid-looking) category
-    codes, causing bleed/stripe artifacts at low zoom. GDAL's COG driver default
-    is NEAREST for integer dtypes ≤16 bits and CUBIC for anything larger —
-    which silently corrupts categorical uint32 rasters unless we override it.
+    The source CRS is preserved — no reprojection to EPSG:4326. Both the
+    server-side render path (titiler-pgstac) and the client-side renderer
+    (deck.gl-geotiff ≥0.5) reproject non-Mercator COGs on the fly, so
+    warping to 4326 on ingest only resamples pixels unnecessarily and
+    discards the native grid.
+
+    For categorical rasters, uses nearest-neighbor resampling for overview
+    generation. Bilinear/cubic on integer category codes blends them into
+    fractional values that truncate to wrong (but valid-looking) category
+    codes, causing bleed/stripe artifacts at low zoom. GDAL's COG driver
+    default is NEAREST for integer dtypes ≤16 bits and CUBIC for anything
+    larger — which silently corrupts categorical uint32 rasters unless we
+    override it.
     """
     resampling = "near" if is_categorical else "bilinear"
     overview_resampling = "NEAREST" if is_categorical else "CUBIC"
     result = subprocess.run(
         [
             "gdalwarp",
-            "-t_srs",
-            "EPSG:4326",
             "-r",
             resampling,
             "-of",

--- a/ingestion/tests/test_pipeline.py
+++ b/ingestion/tests/test_pipeline.py
@@ -417,3 +417,70 @@ def test_cog_url_none_for_vector():
         else None
     )
     assert cog_url is None
+
+
+@requires_gdalwarp
+@pytest.mark.parametrize("epsg", [5070, 3857])
+def test_convert_geotiff_preserves_source_crs(tmp_path, epsg):
+    """COG output must stay in the source CRS — no forced warp to EPSG:4326."""
+    from rasterio.crs import CRS
+
+    width, height = 10, 10
+    src_crs = CRS.from_epsg(epsg)
+    # Construct a trivial affine in the source CRS units (metres for both).
+    transform = rasterio.transform.from_bounds(0, 0, 1000, 1000, width, height)
+    data = np.arange(width * height, dtype="float32").reshape(1, height, width)
+    path = str(tmp_path / f"input_{epsg}.tif")
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        width=width,
+        height=height,
+        count=1,
+        dtype="float32",
+        crs=src_crs,
+        transform=transform,
+    ) as dst:
+        dst.write(data)
+    output_path = str(tmp_path / f"out_{epsg}.tif")
+    _convert_geotiff_to_cog(path, output_path, is_categorical=False)
+    with rasterio.open(output_path) as src:
+        assert src.crs.to_epsg() == epsg, (
+            f"expected output CRS EPSG:{epsg}, got {src.crs}"
+        )
+
+
+@requires_gdalwarp
+def test_convert_geotiff_categorical_preserves_source_crs(tmp_path):
+    """Categorical COG in a non-4326 CRS must keep its source CRS and have overviews."""
+    from rasterio.crs import CRS
+
+    width, height = 512, 512
+    src_crs = CRS.from_epsg(5070)
+    transform = rasterio.transform.from_bounds(0, 0, 100000, 100000, width, height)
+    # Stripe pattern to force overview bleed detection.
+    data = np.full((1, height, width), 255, dtype=np.uint8)
+    for i in range(0, width, 40):
+        data[0, :, i : i + 20] = [1, 2][( i // 40) % 2]
+    path = str(tmp_path / "categorical_5070.tif")
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        width=width,
+        height=height,
+        count=1,
+        dtype="uint8",
+        crs=src_crs,
+        transform=transform,
+        nodata=255,
+    ) as dst:
+        dst.write(data)
+    output_path = str(tmp_path / "out_categorical_5070.tif")
+    _convert_geotiff_to_cog(path, output_path, is_categorical=True)
+    with rasterio.open(output_path) as src:
+        assert src.crs.to_epsg() == 5070, (
+            f"expected output CRS EPSG:5070, got {src.crs}"
+        )
+        assert src.overviews(1), "expected overviews to be built by COG driver"

--- a/ingestion/tests/test_pipeline.py
+++ b/ingestion/tests/test_pipeline.py
@@ -456,7 +456,7 @@ def test_convert_geotiff_categorical_preserves_source_crs(tmp_path):
     """Categorical COG in a non-4326 CRS must keep its source CRS and have overviews."""
     from rasterio.crs import CRS
 
-    width, height = 512, 512
+    width, height = 1024, 1024
     src_crs = CRS.from_epsg(5070)
     transform = rasterio.transform.from_bounds(0, 0, 100000, 100000, width, height)
     # Stripe pattern to force overview bleed detection.

--- a/ingestion/tests/test_pipeline.py
+++ b/ingestion/tests/test_pipeline.py
@@ -462,7 +462,7 @@ def test_convert_geotiff_categorical_preserves_source_crs(tmp_path):
     # Stripe pattern to force overview bleed detection.
     data = np.full((1, height, width), 255, dtype=np.uint8)
     for i in range(0, width, 40):
-        data[0, :, i : i + 20] = [1, 2][( i // 40) % 2]
+        data[0, :, i : i + 20] = [1, 2][(i // 40) % 2]
     path = str(tmp_path / "categorical_5070.tif")
     with rasterio.open(
         path,


### PR DESCRIPTION
## Summary

- Removes `-t_srs EPSG:4326` from the `gdalwarp` call in `_convert_geotiff_to_cog`, so COGs are written in their source CRS instead of being force-warped to 4326
- Keeps `gdalwarp` for the other COG options (DEFLATE compression, 512 blocksize, multithreading, overview resampling) — only the reprojection is dropped
- Adds three new `@requires_gdalwarp` tests that assert EPSG:5070 and EPSG:3857 inputs survive conversion with their source CRS intact, and that the categorical nearest-neighbor overview path also preserves CRS

## Why

The forced warp to EPSG:4326 was originally required because an older version of the client-side renderer only handled Mercator/4326 input. That constraint no longer applies:

- `deck.gl-geotiff` ≥0.5 reprojects non-Mercator COGs internally on the fly
- `titiler-pgstac` (server-rendered tiles) has always reprojected on demand

Dropping the warp avoids unnecessary pixel resampling (better stats, no interpolation artifacts), speeds up ingest, reduces COG file size, and preserves the native grid (e.g. NLCD is natively EPSG:5070 Albers Equal Area).

The `_extract_bounds_4326` path is **unchanged** — STAC bbox must be in EPSG:4326 and those `transform_bounds` calls are correct.

## What to manually verify in the browser

After merging and ingesting a fresh dataset (e.g. re-uploading `Annual_NLCD_LndCov_2024_CU_C1V1.tif` or any non-4326 GeoTIFF):

1. **Server-rendered tiles (titiler-pgstac)** — switch to the raster tile renderer; tiles should load correctly at all zoom levels with no seam or projection artifacts
2. **Client-side COG rendering (deck.gl)** — switch to client-side mode; the COG should render and reproject correctly in the browser without a blank or misaligned canvas
3. **Pixel inspector tooltip** — hover over the map; values should read correctly in both server and client render modes
4. **Categorical legend** — for a categorical raster (e.g. NLCD land cover), the category palette should render without bleed/stripe artifacts at low zoom
5. **`crs` / `crs_name` fields** in the dataset API response — should now reflect the source CRS (e.g. `EPSG:5070`) rather than `EPSG:4326`

> **Note:** Datasets ingested *before* this change are already stored as 4326 COGs and are unaffected. Only newly-ingested datasets will preserve their source CRS.

https://claude.ai/code/session_019eEK2DCe2ggDbGPnUUZieu

---
_Generated by [Claude Code](https://claude.ai/code/session_019eEK2DCe2ggDbGPnUUZieu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GeoTIFF → COG conversion now preserves the original source CRS instead of forcing reprojection to EPSG:4326.

* **Documentation**
  * Updated conversion docs to reflect CRS preservation and clarify categorical resampling and overview behavior.

* **Tests**
  * Added integration tests verifying CRS is retained for continuous and categorical inputs and that overviews are built for categorical rasters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->