### PR TITLE
feat: honor dataset preferred colormap in map and story views

### DIFF
--- a/frontend/src/components/MapSidePanel.tsx
+++ b/frontend/src/components/MapSidePanel.tsx
@@ -68,6 +68,12 @@ interface MapSidePanelProps {
   onDatasetUpdated: () => void;
   // Shared view
   shared?: boolean;
+  savePreferredColormap?: {
+    currentSavedColormap: string | null;
+    currentSavedReversed: boolean | null;
+    onSave: () => Promise<void>;
+    saving: boolean;
+  };
 }
 
 export function MapSidePanel({
@@ -105,6 +111,7 @@ export function MapSidePanel({
   canMarkContinuous,
   onDatasetUpdated,
   shared = false,
+  savePreferredColormap,
 }: MapSidePanelProps) {
   const [mode, setMode] = useState<PanelMode>("controls");
   const [refreshKey, setRefreshKey] = useState(0);
@@ -224,6 +231,7 @@ export function MapSidePanel({
           colormapReversed={colormapReversed}
           onColormapReversedChange={onColormapReversedChange}
           shared={shared}
+          savePreferredColormap={savePreferredColormap}
         />
       )}
 

--- a/frontend/src/components/RasterSidebarControls.tsx
+++ b/frontend/src/components/RasterSidebarControls.tsx
@@ -1,5 +1,12 @@
 import { useState, useEffect } from "react";
-import { Box, Button, Flex, NativeSelect, Text, IconButton } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Flex,
+  NativeSelect,
+  Text,
+  IconButton,
+} from "@chakra-ui/react";
 import { ArrowsLeftRight, ArrowCounterClockwise } from "@phosphor-icons/react";
 import { ColormapDropdown } from "./ColormapDropdown";
 import { EditableCategoryLegend } from "./EditableCategoryLegend";
@@ -216,37 +223,44 @@ export function RasterSidebarControls(props: RasterSidebarControlsProps) {
                   <ArrowsLeftRight size={14} weight="bold" />
                 </IconButton>
               </Flex>
-              {!shared && savePreferredColormap && (() => {
-                const matchesSaved =
-                  savePreferredColormap.currentSavedColormap === colormapName &&
-                  (savePreferredColormap.currentSavedReversed ?? false) ===
-                    colormapReversed;
-                const label = matchesSaved ? "Saved" : "Save as default";
-                return (
-                  <Button
-                    type="button"
-                    variant="plain"
-                    size="xs"
-                    h="auto"
-                    minW={0}
-                    p={0}
-                    mt="4px"
-                    fontSize="10px"
-                    fontWeight={400}
-                    color={matchesSaved ? "brand.textSecondary" : "brand.orange"}
-                    bg="transparent"
-                    cursor={matchesSaved ? "default" : "pointer"}
-                    _hover={{
-                      color: matchesSaved ? "brand.textSecondary" : "brand.brown",
-                    }}
-                    aria-label={label}
-                    disabled={matchesSaved || savePreferredColormap.saving}
-                    onClick={() => void savePreferredColormap.onSave()}
-                  >
-                    {savePreferredColormap.saving ? "Saving…" : label}
-                  </Button>
-                );
-              })()}
+              {!shared &&
+                savePreferredColormap &&
+                (() => {
+                  const matchesSaved =
+                    savePreferredColormap.currentSavedColormap ===
+                      colormapName &&
+                    (savePreferredColormap.currentSavedReversed ?? false) ===
+                      colormapReversed;
+                  const label = matchesSaved ? "Saved" : "Save as default";
+                  return (
+                    <Button
+                      type="button"
+                      variant="plain"
+                      size="xs"
+                      h="auto"
+                      minW={0}
+                      p={0}
+                      mt="4px"
+                      fontSize="10px"
+                      fontWeight={400}
+                      color={
+                        matchesSaved ? "brand.textSecondary" : "brand.orange"
+                      }
+                      bg="transparent"
+                      cursor={matchesSaved ? "default" : "pointer"}
+                      _hover={{
+                        color: matchesSaved
+                          ? "brand.textSecondary"
+                          : "brand.brown",
+                      }}
+                      aria-label={label}
+                      disabled={matchesSaved || savePreferredColormap.saving}
+                      onClick={() => void savePreferredColormap.onSave()}
+                    >
+                      {savePreferredColormap.saving ? "Saving…" : label}
+                    </Button>
+                  );
+                })()}
             </Box>
           )}
 

--- a/frontend/src/components/RasterSidebarControls.tsx
+++ b/frontend/src/components/RasterSidebarControls.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Box, Flex, NativeSelect, Text, IconButton } from "@chakra-ui/react";
+import { Box, Button, Flex, NativeSelect, Text, IconButton } from "@chakra-ui/react";
 import { ArrowsLeftRight, ArrowCounterClockwise } from "@phosphor-icons/react";
 import { ColormapDropdown } from "./ColormapDropdown";
 import { EditableCategoryLegend } from "./EditableCategoryLegend";
@@ -45,6 +45,12 @@ interface RasterSidebarControlsProps {
   colormapReversed: boolean;
   onColormapReversedChange: (reversed: boolean) => void;
   shared?: boolean;
+  savePreferredColormap?: {
+    currentSavedColormap: string | null;
+    currentSavedReversed: boolean | null;
+    onSave: () => Promise<void>;
+    saving: boolean;
+  };
 }
 
 function parseOrNull(s: string): number | null {
@@ -86,6 +92,7 @@ export function RasterSidebarControls(props: RasterSidebarControlsProps) {
     colormapReversed,
     onColormapReversedChange,
     shared = false,
+    savePreferredColormap,
   } = props;
 
   const [minDraft, setMinDraft] = useState<string>(
@@ -209,6 +216,37 @@ export function RasterSidebarControls(props: RasterSidebarControlsProps) {
                   <ArrowsLeftRight size={14} weight="bold" />
                 </IconButton>
               </Flex>
+              {!shared && savePreferredColormap && (() => {
+                const matchesSaved =
+                  savePreferredColormap.currentSavedColormap === colormapName &&
+                  (savePreferredColormap.currentSavedReversed ?? false) ===
+                    colormapReversed;
+                const label = matchesSaved ? "Saved" : "Save as default";
+                return (
+                  <Button
+                    type="button"
+                    variant="plain"
+                    size="xs"
+                    h="auto"
+                    minW={0}
+                    p={0}
+                    mt="4px"
+                    fontSize="10px"
+                    fontWeight={400}
+                    color={matchesSaved ? "brand.textSecondary" : "brand.orange"}
+                    bg="transparent"
+                    cursor={matchesSaved ? "default" : "pointer"}
+                    _hover={{
+                      color: matchesSaved ? "brand.textSecondary" : "brand.brown",
+                    }}
+                    aria-label={label}
+                    disabled={matchesSaved || savePreferredColormap.saving}
+                    onClick={() => void savePreferredColormap.onSave()}
+                  >
+                    {savePreferredColormap.saving ? "Saving…" : label}
+                  </Button>
+                );
+              })()}
             </Box>
           )}
 

--- a/frontend/src/components/ReportCard.test.tsx
+++ b/frontend/src/components/ReportCard.test.tsx
@@ -64,6 +64,8 @@ function makeDataset(overrides: Partial<Dataset> = {}): Dataset {
     is_shared: false,
     source_url: null,
     expires_at: null,
+    preferred_colormap: null,
+    preferred_colormap_reversed: null,
     ...overrides,
   };
 }

--- a/frontend/src/components/StoryCTABanner.tsx
+++ b/frontend/src/components/StoryCTABanner.tsx
@@ -48,9 +48,25 @@ export function StoryCTABanner({ dataset, connection }: StoryCTABannerProps) {
     });
 
     const layerConfig = connection
-      ? { ...DEFAULT_LAYER_CONFIG, connection_id: connection.id }
+      ? {
+          ...DEFAULT_LAYER_CONFIG,
+          connection_id: connection.id,
+          colormap:
+            connection.preferred_colormap ?? DEFAULT_LAYER_CONFIG.colormap,
+          ...(connection.preferred_colormap_reversed != null
+            ? { colormap_reversed: connection.preferred_colormap_reversed }
+            : {}),
+        }
       : dataset
-        ? { ...DEFAULT_LAYER_CONFIG, dataset_id: dataset.id }
+        ? {
+            ...DEFAULT_LAYER_CONFIG,
+            dataset_id: dataset.id,
+            colormap:
+              dataset.preferred_colormap ?? DEFAULT_LAYER_CONFIG.colormap,
+            ...(dataset.preferred_colormap_reversed != null
+              ? { colormap_reversed: dataset.preferred_colormap_reversed }
+              : {}),
+          }
         : DEFAULT_LAYER_CONFIG;
 
     const mapChapter = createChapter({

--- a/frontend/src/components/__tests__/MapSidePanel.test.tsx
+++ b/frontend/src/components/__tests__/MapSidePanel.test.tsx
@@ -52,6 +52,8 @@ const mockItem: MapItem = {
   categories: null,
   timesteps: [],
   renderMode: null,
+  preferredColormap: null,
+  preferredColormapReversed: null,
   dataset: null,
   connection: null,
 };

--- a/frontend/src/components/__tests__/RasterSidebarControls.test.tsx
+++ b/frontend/src/components/__tests__/RasterSidebarControls.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ChakraProvider } from "@chakra-ui/react";
 import { system } from "../../theme";
 import { RasterSidebarControls } from "../RasterSidebarControls";
@@ -29,6 +29,10 @@ function renderCtrl(
       <RasterSidebarControls {...defaultProps} {...props} />
     </ChakraProvider>
   );
+}
+
+function renderWithChakra(ui: React.ReactElement) {
+  return render(<ChakraProvider value={system}>{ui}</ChakraProvider>);
 }
 
 describe("RasterSidebarControls shared prop", () => {
@@ -172,5 +176,103 @@ describe("RasterSidebarControls rescale + flip", () => {
     fireEvent.change(min, { target: { value: "" } });
     fireEvent.blur(min);
     expect(onRescaleChange).toHaveBeenCalledWith(null, 50);
+  });
+});
+
+describe("RasterSidebarControls — save as default", () => {
+  const baseProps = {
+    opacity: 0.8,
+    onOpacityChange: vi.fn(),
+    colormapName: "terrain",
+    onColormapChange: vi.fn(),
+    showColormap: true,
+    selectedBand: "rgb" as const,
+    onBandChange: vi.fn(),
+    showBands: false,
+    rescaleMin: null,
+    rescaleMax: null,
+    datasetMin: -5627.7,
+    datasetMax: 3203.7,
+    onRescaleChange: vi.fn(),
+    colormapReversed: false,
+    onColormapReversedChange: vi.fn(),
+  };
+
+  it("renders the save-as-default button when ownable and preference differs", () => {
+    renderWithChakra(
+      <RasterSidebarControls
+        {...baseProps}
+        savePreferredColormap={{
+          currentSavedColormap: "viridis",
+          currentSavedReversed: false,
+          onSave: vi.fn(),
+          saving: false,
+        }}
+      />
+    );
+    const btn = screen.getByRole("button", { name: /save as default/i });
+    expect(btn).toBeTruthy();
+    expect(btn.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("disables the button with a Saved label when preference matches current state", () => {
+    renderWithChakra(
+      <RasterSidebarControls
+        {...baseProps}
+        colormapName="viridis"
+        savePreferredColormap={{
+          currentSavedColormap: "viridis",
+          currentSavedReversed: false,
+          onSave: vi.fn(),
+          saving: false,
+        }}
+      />
+    );
+    const btn = screen.getByRole("button", { name: /saved/i });
+    expect(btn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("hides the button when savePreferredColormap prop is undefined", () => {
+    renderWithChakra(<RasterSidebarControls {...baseProps} />);
+    expect(
+      screen.queryByRole("button", { name: /save as default/i })
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: /saved/i })).toBeNull();
+  });
+
+  it("hides the button when shared=true", () => {
+    renderWithChakra(
+      <RasterSidebarControls
+        {...baseProps}
+        shared
+        savePreferredColormap={{
+          currentSavedColormap: null,
+          currentSavedReversed: null,
+          onSave: vi.fn(),
+          saving: false,
+        }}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /save as default/i })
+    ).toBeNull();
+  });
+
+  it("calls onSave when clicked", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    renderWithChakra(
+      <RasterSidebarControls
+        {...baseProps}
+        savePreferredColormap={{
+          currentSavedColormap: "viridis",
+          currentSavedReversed: false,
+          onSave,
+          saving: false,
+        }}
+      />
+    );
+    const btn = screen.getByRole("button", { name: /save as default/i });
+    fireEvent.click(btn);
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
   });
 });

--- a/frontend/src/components/details/__tests__/stepContent.test.ts
+++ b/frontend/src/components/details/__tests__/stepContent.test.ts
@@ -254,6 +254,8 @@ const geoparquetConnection: Connection = {
   file_size: null,
   is_shared: false,
   created_at: "2026-04-15T00:00:00Z",
+  preferred_colormap: null,
+  preferred_colormap_reversed: null,
 };
 
 describe("getConnectionStepContent (geoparquet)", () => {
@@ -291,6 +293,8 @@ describe("getConnectionStepContent (geoparquet)", () => {
       categories: null,
       is_shared: false,
       created_at: "2026-04-15T00:00:00Z",
+      preferred_colormap: null,
+      preferred_colormap_reversed: null,
     };
     const source = getConnectionStepContent(conn, 1);
     expect(source?.tools?.some((t) => /tippecanoe/i.test(t.name))).toBe(true);
@@ -322,6 +326,8 @@ function buildGeoParquetConn(overrides: Partial<Connection> = {}): Connection {
     file_size: null,
     is_shared: false,
     created_at: "2026-04-15T00:00:00Z",
+    preferred_colormap: null,
+    preferred_colormap_reversed: null,
     ...overrides,
   };
 }

--- a/frontend/src/hooks/__tests__/useLayerBuilder.test.ts
+++ b/frontend/src/hooks/__tests__/useLayerBuilder.test.ts
@@ -39,6 +39,8 @@ function makeItem(overrides: Partial<MapItem> = {}): MapItem {
     isTemporal: false,
     timesteps: [],
     renderMode: null,
+    preferredColormap: null,
+    preferredColormapReversed: null,
     dataset: null,
     connection: null,
     ...overrides,
@@ -170,6 +172,8 @@ describe("client-side COG render dispatch", () => {
       is_shared: false,
       source_url: null,
       expires_at: null,
+      preferred_colormap: null,
+      preferred_colormap_reversed: null,
       ...overrides,
     };
   }
@@ -252,6 +256,8 @@ function makeConnectionItem(overrides: Partial<MapItem> = {}): MapItem {
     file_size: 10 * 1024 * 1024,
     created_at: "2026-04-17T00:00:00Z",
     is_shared: false,
+    preferred_colormap: null,
+    preferred_colormap_reversed: null,
   };
   return makeItem({
     source: "connection",

--- a/frontend/src/hooks/__tests__/useMapControls.test.ts
+++ b/frontend/src/hooks/__tests__/useMapControls.test.ts
@@ -405,6 +405,32 @@ describe("useMapControls — preferred colormap precedence", () => {
     expect(result.current.colormapName).toBe("viridis");
     expect(result.current.colormapReversed).toBe(false);
   });
+
+  it("preserves in-session control state when item.preferredColormap changes (save+refresh)", () => {
+    const initial = makeItem({ preferredColormap: null, preferredColormapReversed: null });
+    const { result, rerender } = renderHook(({ item }) => useMapControls(item), {
+      initialProps: { item: initial },
+    });
+
+    act(() => {
+      result.current.setOpacity(0.5);
+      result.current.setRescale(10, 100);
+      result.current.setColormapReversed(true);
+    });
+
+    const refreshed = makeItem({
+      id: initial.id,
+      preferredColormap: "terrain",
+      preferredColormapReversed: true,
+    });
+    rerender({ item: refreshed });
+
+    expect(result.current.opacity).toBe(0.5);
+    expect(result.current.rescaleMin).toBe(10);
+    expect(result.current.rescaleMax).toBe(100);
+    expect(result.current.colormapReversed).toBe(true);
+    expect(result.current.colormapName).toBe("viridis");
+  });
 });
 
 describe("client render size caps", () => {

--- a/frontend/src/hooks/__tests__/useMapControls.test.ts
+++ b/frontend/src/hooks/__tests__/useMapControls.test.ts
@@ -407,10 +407,16 @@ describe("useMapControls — preferred colormap precedence", () => {
   });
 
   it("preserves in-session control state when item.preferredColormap changes (save+refresh)", () => {
-    const initial = makeItem({ preferredColormap: null, preferredColormapReversed: null });
-    const { result, rerender } = renderHook(({ item }) => useMapControls(item), {
-      initialProps: { item: initial },
+    const initial = makeItem({
+      preferredColormap: null,
+      preferredColormapReversed: null,
     });
+    const { result, rerender } = renderHook(
+      ({ item }) => useMapControls(item),
+      {
+        initialProps: { item: initial },
+      }
+    );
 
     act(() => {
       result.current.setOpacity(0.5);

--- a/frontend/src/hooks/__tests__/useMapControls.test.ts
+++ b/frontend/src/hooks/__tests__/useMapControls.test.ts
@@ -358,6 +358,55 @@ describe("useMapControls renderMode precedence", () => {
   });
 });
 
+describe("useMapControls — preferred colormap precedence", () => {
+  it("uses item.preferredColormap when no URL or localStorage override is set", () => {
+    const item = makeItem({
+      preferredColormap: "terrain",
+      preferredColormapReversed: false,
+    });
+    const { result } = renderHook(() => useMapControls(item));
+    expect(result.current.colormapName).toBe("terrain");
+    expect(result.current.colormapReversed).toBe(false);
+  });
+
+  it("uses item.preferredColormapReversed=true when set", () => {
+    const item = makeItem({
+      preferredColormap: "plasma",
+      preferredColormapReversed: true,
+    });
+    const { result } = renderHook(() => useMapControls(item));
+    expect(result.current.colormapName).toBe("plasma");
+    expect(result.current.colormapReversed).toBe(true);
+  });
+
+  it("localStorage/URL override wins over item.preferredColormap", () => {
+    const item = makeItem({
+      preferredColormap: "terrain",
+      preferredColormapReversed: false,
+    });
+    const overrides = {
+      itemId: item.id,
+      rescaleMin: null,
+      rescaleMax: null,
+      colormapReversed: true,
+      colormapName: "inferno",
+    };
+    const { result } = renderHook(() => useMapControls(item, overrides));
+    expect(result.current.colormapName).toBe("inferno");
+    expect(result.current.colormapReversed).toBe(true);
+  });
+
+  it("falls back to viridis when item has no preferredColormap", () => {
+    const item = makeItem({
+      preferredColormap: null,
+      preferredColormapReversed: null,
+    });
+    const { result } = renderHook(() => useMapControls(item));
+    expect(result.current.colormapName).toBe("viridis");
+    expect(result.current.colormapReversed).toBe(false);
+  });
+});
+
 describe("client render size caps", () => {
   function itemWithSize(
     size: number,

--- a/frontend/src/hooks/__tests__/useMapControls.test.ts
+++ b/frontend/src/hooks/__tests__/useMapControls.test.ts
@@ -28,6 +28,8 @@ function makeItem(overrides: Partial<MapItem> = {}): MapItem {
     isTemporal: false,
     timesteps: [],
     renderMode: null,
+    preferredColormap: null,
+    preferredColormapReversed: null,
     dataset: null,
     connection: null,
     ...overrides,
@@ -229,6 +231,8 @@ describe("useMapControls", () => {
         file_size: 10 * 1024 * 1024, // 10 MB
         created_at: "2026-04-17T00:00:00Z",
         is_shared: false,
+        preferred_colormap: null,
+        preferred_colormap_reversed: null,
       },
     });
     const { result } = renderHook(() => useMapControls(conn));
@@ -263,6 +267,8 @@ describe("useMapControls", () => {
         file_size: 10 * 1024 * 1024 * 1024, // 10 GB
         created_at: "2026-04-17T00:00:00Z",
         is_shared: false,
+        preferred_colormap: null,
+        preferred_colormap_reversed: null,
       },
     });
     const { result } = renderHook(() => useMapControls(conn));
@@ -298,6 +304,8 @@ describe("useMapControls", () => {
         file_size: null,
         created_at: "2026-04-17T00:00:00Z",
         is_shared: false,
+        preferred_colormap: null,
+        preferred_colormap_reversed: null,
       },
     });
     const { result } = renderHook(() => useMapControls(conn));
@@ -379,6 +387,8 @@ describe("client render size caps", () => {
       isTemporal: false,
       timesteps: [],
       renderMode: null,
+      preferredColormap: null,
+      preferredColormapReversed: null,
       dataset: {
         id: "ds-1",
         filename: "large.tif",

--- a/frontend/src/hooks/__tests__/useMapData.test.ts
+++ b/frontend/src/hooks/__tests__/useMapData.test.ts
@@ -62,6 +62,8 @@ const MOCK_DATASET: Dataset = {
   render_mode: null,
   source_url: null,
   expires_at: null,
+  preferred_colormap: null,
+  preferred_colormap_reversed: null,
 };
 
 const MOCK_CONNECTION: Connection = {
@@ -87,6 +89,8 @@ const MOCK_CONNECTION: Connection = {
   file_size: null,
   is_shared: false,
   render_mode: null,
+  preferred_colormap: null,
+  preferred_colormap_reversed: null,
 };
 
 beforeEach(() => {
@@ -292,6 +296,24 @@ describe("datasetToMapItem", () => {
       datasetToMapItem({ ...MOCK_DATASET, render_mode: "client" }).renderMode
     ).toBe("client");
   });
+  it("copies preferred_colormap and preferred_colormap_reversed when set", () => {
+    const item = datasetToMapItem({
+      ...MOCK_DATASET,
+      preferred_colormap: "terrain",
+      preferred_colormap_reversed: false,
+    });
+    expect(item.preferredColormap).toBe("terrain");
+    expect(item.preferredColormapReversed).toBe(false);
+  });
+  it("passes preferred_colormap nulls through", () => {
+    const item = datasetToMapItem({
+      ...MOCK_DATASET,
+      preferred_colormap: null,
+      preferred_colormap_reversed: null,
+    });
+    expect(item.preferredColormap).toBeNull();
+    expect(item.preferredColormapReversed).toBeNull();
+  });
 });
 
 describe("connectionToMapItem", () => {
@@ -315,5 +337,14 @@ describe("connectionToMapItem", () => {
       connectionToMapItem({ ...MOCK_CONNECTION, render_mode: "client" })
         .renderMode
     ).toBe("client");
+  });
+  it("copies preferred_colormap and preferred_colormap_reversed when set", () => {
+    const item = connectionToMapItem({
+      ...MOCK_CONNECTION,
+      preferred_colormap: "plasma",
+      preferred_colormap_reversed: true,
+    });
+    expect(item.preferredColormap).toBe("plasma");
+    expect(item.preferredColormapReversed).toBe(true);
   });
 });

--- a/frontend/src/hooks/useMapControls.ts
+++ b/frontend/src/hooks/useMapControls.ts
@@ -119,14 +119,11 @@ export function useMapControls(
     } else {
       setRenderMode("server");
     }
-  }, [
-    item?.id,
-    item?.dataType,
-    item?.renderMode,
-    eligibility.canRender,
-    itemColormap,
-    itemReversed,
-  ]);
+    // item.preferredColormap / preferredColormapReversed intentionally omitted:
+    // re-running on dataset refresh would wipe in-session opacity/rescale/
+    // categorical/reversed state. The lazy useState initializers already apply
+    // preferred-colormap precedence at mount.
+  }, [item?.id, item?.dataType, item?.renderMode, eligibility.canRender]);
 
   const setRescale = (min: number | null, max: number | null) => {
     setRescaleMin(min);

--- a/frontend/src/hooks/useMapControls.ts
+++ b/frontend/src/hooks/useMapControls.ts
@@ -52,10 +52,16 @@ export function useMapControls(
   const seedMatches =
     !!initialOverrides && item?.id === initialOverrides.itemId;
 
+  const itemColormap = item?.preferredColormap ?? null;
+  const itemReversed = item?.preferredColormapReversed ?? null;
+
   const [opacity, setOpacity] = useState(0.8);
-  const [colormapName, setColormapName] = useState(
-    seedMatches ? (initialOverrides!.colormapName ?? "viridis") : "viridis"
-  );
+  const [colormapName, setColormapName] = useState<string>(() => {
+    if (seedMatches && initialOverrides!.colormapName) {
+      return initialOverrides!.colormapName;
+    }
+    return itemColormap ?? "viridis";
+  });
   const [selectedBand, setSelectedBand] = useState<"rgb" | number>("rgb");
   const [renderMode, setRenderMode] = useState<RenderMode>("server");
   const [categoricalOverride, setCategoricalOverride] = useState<
@@ -67,9 +73,12 @@ export function useMapControls(
   const [rescaleMax, setRescaleMax] = useState<number | null>(
     seedMatches ? initialOverrides!.rescaleMax : null
   );
-  const [colormapReversed, setColormapReversed] = useState<boolean>(
-    seedMatches ? initialOverrides!.colormapReversed : false
-  );
+  const [colormapReversed, setColormapReversed] = useState<boolean>(() => {
+    if (seedMatches) {
+      return initialOverrides!.colormapReversed;
+    }
+    return itemReversed ?? false;
+  });
 
   const eligibility = useMemo(
     () => evaluateClientRenderEligibility(item ?? null),
@@ -82,15 +91,15 @@ export function useMapControls(
     setCategoricalOverride(null);
 
     if (initialOverrides && item?.id === initialOverrides.itemId) {
-      setColormapName(initialOverrides.colormapName ?? "viridis");
+      setColormapName(initialOverrides.colormapName ?? itemColormap ?? "viridis");
       setRescaleMin(initialOverrides.rescaleMin);
       setRescaleMax(initialOverrides.rescaleMax);
       setColormapReversed(initialOverrides.colormapReversed);
     } else {
-      setColormapName("viridis");
+      setColormapName(itemColormap ?? "viridis");
       setRescaleMin(null);
       setRescaleMax(null);
-      setColormapReversed(false);
+      setColormapReversed(itemReversed ?? false);
     }
 
     if (item?.dataType === "vector") {
@@ -110,7 +119,14 @@ export function useMapControls(
     } else {
       setRenderMode("server");
     }
-  }, [item?.id, item?.dataType, item?.renderMode, eligibility.canRender]);
+  }, [
+    item?.id,
+    item?.dataType,
+    item?.renderMode,
+    eligibility.canRender,
+    itemColormap,
+    itemReversed,
+  ]);
 
   const setRescale = (min: number | null, max: number | null) => {
     setRescaleMin(min);

--- a/frontend/src/hooks/useMapControls.ts
+++ b/frontend/src/hooks/useMapControls.ts
@@ -91,7 +91,9 @@ export function useMapControls(
     setCategoricalOverride(null);
 
     if (initialOverrides && item?.id === initialOverrides.itemId) {
-      setColormapName(initialOverrides.colormapName ?? itemColormap ?? "viridis");
+      setColormapName(
+        initialOverrides.colormapName ?? itemColormap ?? "viridis"
+      );
       setRescaleMin(initialOverrides.rescaleMin);
       setRescaleMax(initialOverrides.rescaleMax);
       setColormapReversed(initialOverrides.colormapReversed);

--- a/frontend/src/hooks/useMapData.ts
+++ b/frontend/src/hooks/useMapData.ts
@@ -29,6 +29,8 @@ export function datasetToMapItem(ds: Dataset): MapItem {
     isTemporal: ds.is_temporal,
     timesteps: ds.timesteps,
     renderMode: ds.render_mode ?? null,
+    preferredColormap: ds.preferred_colormap ?? null,
+    preferredColormapReversed: ds.preferred_colormap_reversed ?? null,
     dataset: ds,
     connection: null,
   };
@@ -67,6 +69,8 @@ export function connectionToMapItem(conn: Connection): MapItem {
     isTemporal: false,
     timesteps: [],
     renderMode: conn.render_mode ?? null,
+    preferredColormap: conn.preferred_colormap ?? null,
+    preferredColormapReversed: conn.preferred_colormap_reversed ?? null,
     dataset: null,
     connection: conn,
   };

--- a/frontend/src/hooks/useStoryEditor.ts
+++ b/frontend/src/hooks/useStoryEditor.ts
@@ -106,26 +106,31 @@ export function useStoryEditor() {
     if (id || story) return;
     async function createNew() {
       try {
-        const draft = createStory(datasetIdParam);
+        let fetchedDataset: Dataset | null = null;
         if (datasetIdParam) {
           const resp = await workspaceFetch(
             `${config.apiBase}/api/datasets/${datasetIdParam}`
           );
           if (resp.ok) {
-            const data: Dataset = await resp.json();
-            setDataset(data);
-            if (data.bounds) {
-              const cam = cameraFromBounds(data.bounds);
-              draft.chapters[0].map_state = {
-                center: [cam.longitude, cam.latitude],
-                zoom: cam.zoom,
-                bearing: 0,
-                pitch: 0,
-                basemap: "streets",
-              };
-              setCamera(cam);
-            }
+            fetchedDataset = await resp.json();
+            setDataset(fetchedDataset);
           }
+        }
+        const draft = createStory(datasetIdParam, {
+          preferredColormap: fetchedDataset?.preferred_colormap ?? null,
+          preferredColormapReversed:
+            fetchedDataset?.preferred_colormap_reversed ?? null,
+        });
+        if (fetchedDataset?.bounds) {
+          const cam = cameraFromBounds(fetchedDataset.bounds);
+          draft.chapters[0].map_state = {
+            center: [cam.longitude, cam.latitude],
+            zoom: cam.zoom,
+            bearing: 0,
+            pitch: 0,
+            basemap: "streets",
+          };
+          setCamera(cam);
         }
         const saved = await createStoryOnServer(draft);
         setStory(saved);
@@ -269,6 +274,12 @@ export function useStoryEditor() {
     const maxOrder = Math.max(...(story?.chapters.map((c) => c.order) ?? [0]));
     const inheritedDatasetId =
       activeChapter?.layer_config.dataset_id ?? story?.dataset_id ?? "";
+    const inheritedDataset = inheritedDatasetId
+      ? datasetMap.get(inheritedDatasetId)
+      : undefined;
+    const preferredColormap = inheritedDataset?.preferred_colormap ?? null;
+    const preferredColormapReversed =
+      inheritedDataset?.preferred_colormap_reversed ?? null;
     const newCh = createChapter({
       order: maxOrder + 1,
       title: `Chapter ${(story?.chapters.length ?? 0) + 1}`,
@@ -279,7 +290,14 @@ export function useStoryEditor() {
         pitch: camera.pitch,
         basemap,
       },
-      layer_config: { ...DEFAULT_LAYER_CONFIG, dataset_id: inheritedDatasetId },
+      layer_config: {
+        ...DEFAULT_LAYER_CONFIG,
+        dataset_id: inheritedDatasetId,
+        colormap: preferredColormap ?? DEFAULT_LAYER_CONFIG.colormap,
+        ...(preferredColormapReversed != null
+          ? { colormap_reversed: preferredColormapReversed }
+          : {}),
+      },
     });
     updateStory((s) => ({ ...s, chapters: [...s.chapters, newCh] }));
     setActiveChapterId(newCh.id);

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { workspaceFetch, setWorkspaceId } from "../api";
+import { workspaceFetch, setWorkspaceId, datasetsApi, connectionsApi } from "../api";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -32,5 +32,73 @@ describe("workspaceFetch", () => {
     await workspaceFetch("/api/upload", { method: "POST", body });
     const [, init] = mockFetch.mock.calls[0];
     expect(init.headers.get("X-Workspace-Id")).toBe("test1234");
+  });
+});
+
+describe("datasetsApi.setPreferredColormap", () => {
+  it("PATCHes /api/datasets/{id}/colormap with the payload", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        preferred_colormap: "terrain",
+        preferred_colormap_reversed: false,
+      }),
+    });
+    const result = await datasetsApi.setPreferredColormap("abc", {
+      preferredColormap: "terrain",
+      preferredColormapReversed: false,
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain("/api/datasets/abc/colormap");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({
+      preferred_colormap: "terrain",
+      preferred_colormap_reversed: false,
+    });
+    expect((result as Record<string, unknown>).preferred_colormap).toBe(
+      "terrain"
+    );
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => "Forbidden",
+      json: async () => ({ detail: "Forbidden" }),
+    });
+    await expect(
+      datasetsApi.setPreferredColormap("abc", {
+        preferredColormap: "terrain",
+        preferredColormapReversed: false,
+      })
+    ).rejects.toThrow();
+  });
+});
+
+describe("connectionsApi.setPreferredColormap", () => {
+  it("PATCHes /api/connections/{id}/colormap with the payload", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        preferred_colormap: "plasma",
+        preferred_colormap_reversed: true,
+      }),
+    });
+    const result = await connectionsApi.setPreferredColormap("xyz", {
+      preferredColormap: "plasma",
+      preferredColormapReversed: true,
+    });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toContain("/api/connections/xyz/colormap");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({
+      preferred_colormap: "plasma",
+      preferred_colormap_reversed: true,
+    });
+    expect((result as unknown as Record<string, unknown>).preferred_colormap).toBe(
+      "plasma"
+    );
   });
 });

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { workspaceFetch, setWorkspaceId, datasetsApi, connectionsApi } from "../api";
+import {
+  workspaceFetch,
+  setWorkspaceId,
+  datasetsApi,
+  connectionsApi,
+} from "../api";
 
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
@@ -97,8 +102,8 @@ describe("connectionsApi.setPreferredColormap", () => {
       preferred_colormap: "plasma",
       preferred_colormap_reversed: true,
     });
-    expect((result as unknown as Record<string, unknown>).preferred_colormap).toBe(
-      "plasma"
-    );
+    expect(
+      (result as unknown as Record<string, unknown>).preferred_colormap
+    ).toBe("plasma");
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -110,6 +110,26 @@ export const connectionsApi = {
       return r.json();
     });
   },
+
+  setPreferredColormap(
+    id: string,
+    payload: {
+      preferredColormap: string | null;
+      preferredColormapReversed: boolean | null;
+    }
+  ): Promise<Connection> {
+    return workspaceFetch(`/api/connections/${id}/colormap`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        preferred_colormap: payload.preferredColormap,
+        preferred_colormap_reversed: payload.preferredColormapReversed,
+      }),
+    }).then(async (r) => {
+      if (!r.ok) throw new Error(await readErrorDetail(r));
+      return r.json();
+    });
+  },
 };
 
 export const datasetsApi = {
@@ -131,6 +151,26 @@ export const datasetsApi = {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ render_mode: mode }),
+    }).then(async (r) => {
+      if (!r.ok) throw new Error(await readErrorDetail(r));
+      return r.json();
+    });
+  },
+
+  setPreferredColormap(
+    id: string,
+    payload: {
+      preferredColormap: string | null;
+      preferredColormapReversed: boolean | null;
+    }
+  ): Promise<Record<string, unknown>> {
+    return workspaceFetch(`/api/datasets/${id}/colormap`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        preferred_colormap: payload.preferredColormap,
+        preferred_colormap_reversed: payload.preferredColormapReversed,
+      }),
     }).then(async (r) => {
       if (!r.ok) throw new Error(await readErrorDetail(r));
       return r.json();

--- a/frontend/src/lib/connections/__tests__/tileUrl.test.ts
+++ b/frontend/src/lib/connections/__tests__/tileUrl.test.ts
@@ -25,6 +25,8 @@ function makeConnection(overrides: Partial<Connection>): Connection {
     feature_count: null,
     file_size: null,
     is_shared: false,
+    preferred_colormap: null,
+    preferred_colormap_reversed: null,
     ...overrides,
   };
 }

--- a/frontend/src/lib/layers/__tests__/clientRenderEligibility.test.ts
+++ b/frontend/src/lib/layers/__tests__/clientRenderEligibility.test.ts
@@ -27,6 +27,8 @@ function rasterDatasetItem(overrides: Partial<MapItem> = {}): MapItem {
     isTemporal: false,
     timesteps: [],
     renderMode: null,
+    preferredColormap: null,
+    preferredColormapReversed: null,
     dataset: { converted_file_size: 100 * 1024 * 1024 } as never,
     connection: null,
     ...overrides,

--- a/frontend/src/lib/layers/__tests__/resolveRasterLayers.test.ts
+++ b/frontend/src/lib/layers/__tests__/resolveRasterLayers.test.ts
@@ -38,6 +38,8 @@ function continuousItem(overrides: Partial<MapItem> = {}): MapItem {
     isTemporal: false,
     timesteps: [],
     renderMode: null,
+    preferredColormap: null,
+    preferredColormapReversed: null,
     dataset: { converted_file_size: 100 * 1024 * 1024 } as never,
     connection: null,
     ...overrides,

--- a/frontend/src/lib/story/__tests__/rendering.test.ts
+++ b/frontend/src/lib/story/__tests__/rendering.test.ts
@@ -58,6 +58,8 @@ const BASE_DATASET: Dataset = {
   is_shared: false,
   source_url: null,
   expires_at: null,
+  preferred_colormap: null,
+  preferred_colormap_reversed: null,
 };
 
 const TEMPORAL_DATASET: Dataset = {
@@ -233,6 +235,8 @@ const BASE_CONNECTION: Connection = {
   feature_count: null,
   file_size: null,
   is_shared: false,
+  preferred_colormap: null,
+  preferred_colormap_reversed: null,
 };
 
 describe("buildLayersForChapter — connection COG rescale and colormap_reversed", () => {

--- a/frontend/src/lib/story/__tests__/types.test.ts
+++ b/frontend/src/lib/story/__tests__/types.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createChapter, createStory, DEFAULT_LAYER_CONFIG } from "../types";
+
+describe("createChapter — preferred colormap snapshot", () => {
+  it("uses DEFAULT_LAYER_CONFIG.colormap when no preferred colormap is provided", () => {
+    const ch = createChapter();
+    expect(ch.layer_config.colormap).toBe(DEFAULT_LAYER_CONFIG.colormap);
+  });
+
+  it("accepts an explicit layer_config override (backward compat)", () => {
+    const ch = createChapter({
+      layer_config: {
+        ...DEFAULT_LAYER_CONFIG,
+        colormap: "plasma",
+      },
+    });
+    expect(ch.layer_config.colormap).toBe("plasma");
+  });
+});
+
+describe("createStory — first chapter picks up preferred colormap", () => {
+  it("snapshots preferredColormap into the first chapter's layer_config", () => {
+    const story = createStory("ds-abc", {
+      preferredColormap: "terrain",
+      preferredColormapReversed: false,
+    });
+    expect(story.chapters[0].layer_config.colormap).toBe("terrain");
+    expect(story.chapters[0].layer_config.colormap_reversed).toBe(false);
+    expect(story.chapters[0].layer_config.dataset_id).toBe("ds-abc");
+  });
+
+  it("falls back to DEFAULT_LAYER_CONFIG when no preference is provided", () => {
+    const story = createStory("ds-abc");
+    expect(story.chapters[0].layer_config.colormap).toBe(
+      DEFAULT_LAYER_CONFIG.colormap
+    );
+    expect(story.chapters[0].layer_config.colormap_reversed).toBe(undefined);
+  });
+});

--- a/frontend/src/lib/story/types.ts
+++ b/frontend/src/lib/story/types.ts
@@ -92,15 +92,29 @@ export function createChapter(overrides: Partial<Chapter> = {}): Chapter {
   };
 }
 
+export interface CreateStoryOptions {
+  preferredColormap?: string | null;
+  preferredColormapReversed?: boolean | null;
+}
+
 export function createStory(
   datasetId?: string | null,
-  overrides: Partial<Story> = {}
+  overrides: Partial<Story> & CreateStoryOptions = {}
 ): Story {
+  const { preferredColormap, preferredColormapReversed, ...storyOverrides } =
+    overrides;
   const chapter = datasetId
     ? createChapter({
         order: 0,
         title: "Chapter 1",
-        layer_config: { ...DEFAULT_LAYER_CONFIG, dataset_id: datasetId },
+        layer_config: {
+          ...DEFAULT_LAYER_CONFIG,
+          dataset_id: datasetId,
+          colormap: preferredColormap ?? DEFAULT_LAYER_CONFIG.colormap,
+          ...(preferredColormapReversed != null
+            ? { colormap_reversed: preferredColormapReversed }
+            : {}),
+        },
       })
     : createChapter({
         order: 0,
@@ -118,6 +132,6 @@ export function createStory(
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     published: false,
-    ...overrides,
+    ...storyOverrides,
   };
 }

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -137,6 +137,37 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
     [controls.setRenderMode, controls.renderMode, item, shared]
   );
 
+  const [savingPreferredColormap, setSavingPreferredColormap] = useState(false);
+
+  const handleSavePreferredColormap = useCallback(async () => {
+    if (!item) return;
+    setSavingPreferredColormap(true);
+    try {
+      const payload = {
+        preferredColormap: controls.colormapName,
+        preferredColormapReversed: controls.colormapReversed,
+      };
+      if (item.source === "connection") {
+        await connectionsApi.setPreferredColormap(item.id, payload);
+      } else {
+        await datasetsApi.setPreferredColormap(item.id, payload);
+      }
+      refresh();
+      toaster.create({
+        title: "Default colormap saved",
+        type: "success",
+      });
+    } catch (err) {
+      toaster.create({
+        title: "Failed to save default colormap",
+        description: (err as Error).message,
+        type: "error",
+      });
+    } finally {
+      setSavingPreferredColormap(false);
+    }
+  }, [item, controls.colormapName, controls.colormapReversed, refresh]);
+
   // --- Camera ---
   const [camera, setCamera] = useState<CameraState>(DEFAULT_CAMERA);
   const [basemap, setBasemap] = useState("streets");
@@ -734,6 +765,16 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
               }
               onDatasetUpdated={refresh}
               shared={shared}
+              savePreferredColormap={
+                !shared && item?.dataType === "raster" && !item?.dataset?.is_example
+                  ? {
+                      currentSavedColormap: item?.preferredColormap ?? null,
+                      currentSavedReversed: item?.preferredColormapReversed ?? null,
+                      onSave: handleSavePreferredColormap,
+                      saving: savingPreferredColormap,
+                    }
+                  : undefined
+              }
             />
           </Box>
         </Flex>

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -766,10 +766,13 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
               onDatasetUpdated={refresh}
               shared={shared}
               savePreferredColormap={
-                !shared && item?.dataType === "raster" && !item?.dataset?.is_example
+                !shared &&
+                item?.dataType === "raster" &&
+                !item?.dataset?.is_example
                   ? {
                       currentSavedColormap: item?.preferredColormap ?? null,
-                      currentSavedReversed: item?.preferredColormapReversed ?? null,
+                      currentSavedReversed:
+                        item?.preferredColormapReversed ?? null,
                       onSave: handleSavePreferredColormap,
                       saving: savingPreferredColormap,
                     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -69,6 +69,8 @@ export interface Dataset {
   is_example?: boolean;
   is_shared: boolean;
   render_mode?: "client" | "server" | null;
+  preferred_colormap: string | null;
+  preferred_colormap_reversed: boolean | null;
   source_url: string | null;
   expires_at: string | null;
 }
@@ -102,6 +104,8 @@ export interface Connection {
   file_size: number | null;
   is_shared: boolean;
   render_mode?: "client" | "server" | null;
+  preferred_colormap: string | null;
+  preferred_colormap_reversed: boolean | null;
   created_at: string;
 }
 
@@ -183,6 +187,8 @@ export interface MapItem {
   isTemporal: boolean;
   timesteps: Timestep[];
   renderMode: "client" | "server" | null;
+  preferredColormap: string | null;
+  preferredColormapReversed: boolean | null;
   dataset: Dataset | null;
   connection: Connection | null;
 }


### PR DESCRIPTION
## Summary
- `useMapControls` initial state now honors `dataset.preferred_colormap` / `preferred_colormap_reversed` via three-tier precedence (URL/localStorage → item preference → viridis fallback).
- Owner-only "Save as default" button on the raster controls panel persists the current colormap + reversed state to the dataset/connection via the new `PATCH /api/{datasets,connections}/{id}/colormap` endpoints. Hidden on shared maps, example datasets, and vector items.
- Story editor snapshots the dataset's preferred colormap into each new chapter (`createStory`, `addChapter`, and the `StoryCTABanner` "Create story" path).
- Builds on the backend shipped in #344. Resolves the bathymetry rendering discrepancy between the GEBCO example story (uses `terrain`) and the generic map page (previously hardcoded `viridis`).

Spec: `~/Obsidian/Project Docs/CNG Sandbox/specs/2026-04-24-dataset-preferred-colormap-design.md`.
Plan: `~/Obsidian/Project Docs/CNG Sandbox/plans/2026-04-24-dataset-preferred-colormap-frontend.md`.

## Notable deviations from the plan

- **`useMapControls` deps array** — the plan added `itemColormap` / `itemReversed` to the reset `useEffect` deps. That caused save+refresh to wipe in-session opacity/rescale/categorical/reversed state. Fixed in `92cb804`: deps reverted to the original four; the lazy `useState` initializers already apply preferred-colormap precedence at mount, so behavior is preserved on the happy path. Regression test added.
- **`<Button variant="plain">` instead of `<Text as="button">`** — Chakra v3's `Text` prop types don't include `type`. The "Save as default" button uses a Chakra `<Button variant="plain">` modeled after `MarkAsContinuousLink.tsx`, with `_hover={{ color: matchesSaved ? "brand.textSecondary" : "brand.brown" }}` for affordance.
- **`StoryCTABanner` `mapChapter`** — its `layerConfig` is built directly (bypassing `createStory`'s auto-built first chapter), so the snapshot now happens at the `layerConfig` construction site rather than via `createStory` overrides. Both `dataset.preferred_colormap` and `connection.preferred_colormap` branches snapshot.

## Known follow-ups (not in this PR)

- `handleDatasetReady` (in `useStoryEditor`) and `NarrativeEditor.handleDataSelect` swap a chapter's `dataset_id`/`connection_id` without refreshing `colormap`. This may be intentional (preserves user-set colormap on chapter edit) but worth a deliberate decision.
- `useRasterOverrides`'s "all-default" check in localStorage hardcodes `"viridis"`. With preferred colormaps, that comparison is stale — the user's preferred colormap won't trigger localStorage clearing. Functionally fine, just stale data.

## Test plan
- [ ] Frontend tests pass: `cd frontend && npx vitest run` (499/499 ✓)
- [ ] Type check passes: `cd frontend && npx tsc --noEmit` (clean ✓)
- [ ] GEBCO map page renders with `terrain` out of the box (after clearing localStorage for the item)
- [ ] "Save as default" round-trip on a user-owned raster survives browser reload
- [ ] In-session opacity/rescale/categorical/reversed are preserved across save+refresh (regression covered by `useMapControls.test.ts`)
- [ ] New story chapters on a preferred-colormap dataset inherit the preferred colormap; changing one chapter's colormap doesn't leak into the next
- [ ] Shared map view does not render the "Save as default" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save preferred colormap: a "Save as default" button in raster sidebar lets you persist colormap and reversed setting for datasets/connections; shows “Saved”/“Saving…” and disables appropriately.
  * Persisted preferences are applied when building map layers, story chapters, and on subsequent visits.

* **Tests**
  * Added/updated tests to cover save UI, persistence behavior, and mapping of preferred-colormap fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->