### PR TITLE
fix(ingestion): align validator with source-CRS-preserving pipeline

### DIFF
--- a/geo-conversions/geotiff-to-cog/SKILL.md
+++ b/geo-conversions/geotiff-to-cog/SKILL.md
@@ -18,13 +18,13 @@ When you have a GeoTIFF file and need to convert it to a Cloud-Optimized GeoTIFF
 
 ## Quickstart
 
-Convert a file using GDAL CLI tools and validate the result:
+Convert a file using GDAL CLI tools and validate the result. The output should preserve the source CRS — both the client-side renderer (`deck.gl-geotiff` ≥ 0.5) and the server-side tiler (`titiler-pgstac`) handle non-Mercator COGs natively, so warping on ingest only resamples pixels unnecessarily and discards the native grid.
 
-    # If already EPSG:4326:
+    # Preserve source CRS (recommended):
+    gdalwarp -of COG -co COMPRESS=DEFLATE input.tif output_cog.tif
+
+    # Equivalent for already-tiled inputs:
     gdal_translate -of COG -co COMPRESS=DEFLATE input.tif output_cog.tif
-
-    # If in a different CRS (reproject to EPSG:4326):
-    gdalwarp -t_srs EPSG:4326 -of COG -co COMPRESS=DEFLATE input.tif output_cog.tif
 
     # Validate the result:
     pip install rasterio rio-cogeo numpy
@@ -43,10 +43,12 @@ When both `--input` and `--output` are omitted, runs a self-test that generates 
 
 ## Known complexity
 
-- **CRS:** If the input GeoTIFF is not in EPSG:4326, use `gdalwarp` instead of `gdal_translate` to reproject. The output should always be EPSG:4326.
+- **CRS preservation:** The pipeline does NOT reproject to EPSG:4326. Output COGs keep the source CRS (e.g. EPSG:5070 for NLCD, UTM zones for Sentinel scenes). Validators must compare input CRS to output CRS, not to a fixed EPSG:4326. See `check_crs_preserved` in `scripts/validate.py`.
 
 ## Known failure modes
 
+- **Validator hard-coded to EPSG:4326 after pipeline switched to source-CRS preservation**: An older `check_crs_4326` ran unconditionally on the converted COG, expecting `output.crs == EPSG:4326`. After the ingest pipeline stopped warping (PR #353), every projected input (e.g. NLCD EPSG:5070) failed validation with `Expected EPSG:4326, got <PROJCS WKT>`. Fix: replaced with `check_crs_preserved(input, output)`, which asserts the output CRS equals the input CRS. The bounds, dimensions, nodata, and pixel-fidelity checks now also run unconditionally — together they catch any unintended reprojection automatically.
+- **Overview-count check too strict for very large rasters**: The `check_overviews` formula `floor(log2(max_dim / blocksize))` predicts ≥ 8 levels for a 160000×105000 raster at blocksize 512, but GDAL's COG driver caps overview generation in practice and produces fewer levels for jumbo images. This is normal — the COG is still valid. Fix: moved `check_overviews` to `run_advisory_checks` so a low overview count surfaces as an informational warning instead of failing the pipeline.
 - Writing tiled GeoTIFFs with overviews directly via `rasterio.open()` does NOT produce valid COGs — the IFD ordering will be wrong. Must use `rio-cogeo`'s `cog_translate` function.
 - **Projected CRS bounds not compatible with STAC**: COGs with projected CRS (e.g. UTM, Albers) have bounds in meters, not degrees. STAC requires WGS84 bounding boxes. Downstream ingest must reproject bounds via `rasterio.warp.transform_bounds(src.crs, "EPSG:4326", *src.bounds)`. Without this, titiler-pgstac returns 204 (empty tiles) because the STAC item bbox doesn't intersect any web mercator tiles. The validate script now warns about this.
 - **Polar CRS datasets produce out-of-range WGS84 bounds**: Polar projections (e.g. EPSG:3412 South Polar Stereographic, EPSG:3413 North Polar Stereographic) produce WGS84 bounds where `south=-90` or `north=90` after `transform_bounds`. Web Mercator is undefined at the poles (latitude maps to ±infinity). Passing these bounds directly to `WebMercatorViewport.fitBounds` in deck.gl produces NaN viewport values, causing the map layer to fail silently — no tiles are ever requested, the map appears blank with no console error about tiles. Fix: clamp bounds to `±85.051129°` (the valid Mercator range) before calling `fitBounds`. The validate script now flags this with `check_mercator_bounds`.
@@ -56,6 +58,7 @@ When both `--input` and `--output` are omitted, runs a self-test that generates 
 
 ## Changelog
 
+- 2026-04-27: Replaced `check_crs_4326` with `check_crs_preserved(input, output)` to match the pipeline's source-CRS-preserving behavior (PR #353). Run bounds, dimensions, nodata, and pixel-fidelity checks unconditionally so any unintended reprojection trips multiple checks. Demoted `check_overviews` to advisory because GDAL's COG driver caps overview levels for very large rasters (e.g. NLCD 160000×105000), making the simple log2 formula too strict.
 - 2026-03-30: Add automatic reprojection to EPSG:4326 for projected input GeoTIFFs. Use shared `reproject_to_cog` module. Add projected self-test.
 - 2026-03-27: Added `check_rendering_metadata` advisory check — reports band count, dtype, and recommended rescale range for tile server colormap rendering. Documented colormap/rescale failure modes.
 - 2026-03-14: Added `check_mercator_bounds` to flag polar datasets whose WGS84 bounds exceed ±85.051129°. Documented that downstream map viewers (deck.gl `WebMercatorViewport`) must clamp bounds before `fitBounds`.

--- a/geo-conversions/geotiff-to-cog/scripts/validate.py
+++ b/geo-conversions/geotiff-to-cog/scripts/validate.py
@@ -321,13 +321,31 @@ def generate_projected_geotiff(path: str):
         dst.write(data, 1)
 
 
-def check_crs_4326(output_path: str) -> CheckResult:
-    """Check that the output COG is in EPSG:4326."""
-    with rasterio.open(output_path) as dst:
-        epsg = dst.crs.to_epsg() if dst.crs else None
-        if epsg == 4326:
-            return CheckResult("CRS EPSG:4326", True, "EPSG:4326")
-        return CheckResult("CRS EPSG:4326", False, f"Expected EPSG:4326, got {dst.crs}")
+def check_crs_preserved(input_path: str, output_path: str) -> CheckResult:
+    """Check that the output COG preserves the source CRS.
+
+    The pipeline no longer reprojects to EPSG:4326 — both the client-side
+    renderer (deck.gl-geotiff) and the server-side tiler (titiler-pgstac)
+    handle non-Mercator COGs natively. This check asserts that the
+    conversion did not silently warp the data into a different CRS, which
+    would change the pixel grid and resample values.
+    """
+    with rasterio.open(input_path) as src, rasterio.open(output_path) as dst:
+        if src.crs is None and dst.crs is None:
+            return CheckResult("CRS preserved", True, "Both input and output have no CRS")
+        if src.crs is None or dst.crs is None:
+            return CheckResult(
+                "CRS preserved",
+                False,
+                f"CRS presence mismatch: input={src.crs}, output={dst.crs}",
+            )
+        if src.crs == dst.crs:
+            return CheckResult("CRS preserved", True, f"{src.crs}")
+        return CheckResult(
+            "CRS preserved",
+            False,
+            f"Output CRS differs from source: input={src.crs}, output={dst.crs}",
+        )
 
 
 def run_self_test() -> bool:
@@ -392,31 +410,24 @@ def run_checks(input_path: str, output_path: str) -> list[CheckResult]:
     These checks verify that the COG faithfully preserves the source data.
     A failed check here means the conversion produced incorrect output.
 
+    The pipeline preserves the source CRS, so bounds, dimensions, nodata,
+    and pixel values must round-trip identically — any unintended
+    reprojection trips at least the CRS check and the bounds/dimensions/
+    pixel-fidelity checks together.
+
     Advisory checks (downstream compatibility notes that don't indicate data
     corruption) are in run_advisory_checks and are NOT included here so that
     pipeline callers can treat failures as hard errors without false positives.
     """
-    with rasterio.open(input_path) as src:
-        input_is_4326 = src.crs and src.crs.to_epsg() == 4326
-
-    checks = [
+    return [
         check_cog_valid(output_path),
-        check_crs_4326(output_path),
-    ]
-
-    if input_is_4326:
-        checks.extend([
-            check_bounds_match(input_path, output_path),
-            check_dimensions_match(input_path, output_path),
-            check_pixel_fidelity(input_path, output_path),
-            check_nodata_match(input_path, output_path),
-        ])
-
-    checks.extend([
+        check_crs_preserved(input_path, output_path),
+        check_bounds_match(input_path, output_path),
+        check_dimensions_match(input_path, output_path),
+        check_pixel_fidelity(input_path, output_path),
+        check_nodata_match(input_path, output_path),
         check_band_count(input_path, output_path),
-        check_overviews(output_path),
-    ])
-    return checks
+    ]
 
 
 def run_advisory_checks(input_path: str, output_path: str) -> list[CheckResult]:
@@ -426,8 +437,14 @@ def run_advisory_checks(input_path: str, output_path: str) -> list[CheckResult]:
     characteristics that require special handling by downstream consumers
     (e.g. STAC ingest, web map viewers). Failed advisory checks are shown to
     users as informational warnings, not as pipeline errors.
+
+    `check_overviews` is advisory because GDAL's COG driver caps the number
+    of overview levels for very large rasters (hundreds of thousands of
+    pixels per side); fewer levels than the simple log2 formula predicts
+    is normal and does not indicate data corruption.
     """
     return [
+        check_overviews(output_path),
         check_wgs84_bounds(output_path),
         check_mercator_bounds(output_path),
         check_band_metadata(input_path, output_path),

--- a/geo-conversions/geotiff-to-cog/scripts/validate.py
+++ b/geo-conversions/geotiff-to-cog/scripts/validate.py
@@ -83,6 +83,13 @@ def check_pixel_fidelity(input_path: str, output_path: str, n: int = 1000,
                           tolerance: float = 1e-4) -> CheckResult:
     """Sample random pixels and compare values."""
     with rasterio.open(input_path) as src, rasterio.open(output_path) as dst:
+        if src.width != dst.width or src.height != dst.height:
+            return CheckResult(
+                "Pixel fidelity",
+                False,
+                f"Dimensions differ (source={src.width}x{src.height}, "
+                f"output={dst.width}x{dst.height}); per-pixel comparison skipped",
+            )
         rng = np.random.default_rng(42)
         rows = rng.integers(0, src.height, size=n)
         cols = rng.integers(0, src.width, size=n)
@@ -377,30 +384,17 @@ def run_self_test() -> bool:
         print("Validating...")
         all_passed = run_validation(input_path, output_path)
 
-    # Test 2: Projected GeoTIFF
+    # Test 2: Projected GeoTIFF — output should preserve source CRS, not warp to 4326.
     print("\n--- Test 2: Projected GeoTIFF (EPSG:5070) ---")
     with tempfile.TemporaryDirectory() as tmpdir:
         proj_input = os.path.join(tmpdir, "test_projected.tif")
         proj_output = os.path.join(tmpdir, "test_projected_cog.tif")
         print("Generating synthetic EPSG:5070 GeoTIFF...")
         generate_projected_geotiff(proj_input)
-        print("Converting to COG (should reproject to EPSG:4326)...")
+        print("Converting to COG (should preserve source CRS)...")
         convert_mod.convert(proj_input, proj_output, verbose=True)
         print("Validating...")
-        with rasterio.open(proj_output) as dst:
-            epsg = dst.crs.to_epsg() if dst.crs else None
-            if epsg != 4326:
-                print(f"FAIL: Expected EPSG:4326, got {dst.crs}")
-                all_passed = False
-            else:
-                is_valid, _, _ = cog_validate(proj_output)
-                if not is_valid:
-                    print("FAIL: Output is not a valid COG")
-                    all_passed = False
-                else:
-                    b = dst.bounds
-                    print(f"PASS: Valid COG in EPSG:4326 ({b.left:.2f}, {b.bottom:.2f}, "
-                          f"{b.right:.2f}, {b.top:.2f})")
+        all_passed = run_validation(proj_input, proj_output) and all_passed
     return all_passed
 
 

--- a/ingestion/src/services/pipeline.py
+++ b/ingestion/src/services/pipeline.py
@@ -36,7 +36,7 @@ from src.services.storage import StorageService
 logger = logging.getLogger(__name__)
 
 VALIDATION_CHECK_COUNTS: dict[FormatPair, int] = {
-    FormatPair.GEOTIFF_TO_COG: 8,
+    FormatPair.GEOTIFF_TO_COG: 7,
     FormatPair.NETCDF_TO_COG: 8,
     FormatPair.HDF5_TO_COG: 7,
     FormatPair.GEOJSON_TO_GEOPARQUET: 10,


### PR DESCRIPTION
## Summary

NLCD upload (and any other projected GeoTIFF — Sentinel UTM, projected Albers, etc.) was failing with `Validation failed: CRS EPSG:4326: Expected EPSG:4326, got PROJCS["AEA WGS84"...]`.

[PR #353](https://github.com/aboydnw/cng-sandbox/pull/353) stopped warping every GeoTIFF to EPSG:4326 on ingest because both `deck.gl-geotiff` (≥ 0.5) and `titiler-pgstac` reproject non-Mercator COGs natively. The validator in `geo-conversions/geotiff-to-cog/scripts/validate.py` was not updated and still ran `check_crs_4326(output_path)` unconditionally, so every projected input fails the moment ingest works correctly.

## Changes

- **Replace `check_crs_4326`** → `check_crs_preserved(input, output)`. Asserts the output CRS equals the source CRS instead of a fixed EPSG:4326.
- **Run preservation checks unconditionally**. Bounds, dimensions, nodata, and pixel-fidelity checks were gated on `input_is_4326` because the old pipeline warped non-4326 inputs and those properties wouldn't match. With source-CRS preservation they always should — and running them all means an unintended reprojection trips CRS + bounds + dimensions + pixel-fidelity together. Catches the regression case automatically; no visual inspection required.
- **Demote `check_overviews` to advisory**. GDAL's COG driver caps overview generation for jumbo rasters (NLCD CONUS C1V1 is 160000×105000 — got 6 levels, simple `floor(log2(160000/512))` formula expected ≥ 8). A low overview count for huge inputs is informational, not data corruption.
- **Update `VALIDATION_CHECK_COUNTS[FormatPair.GEOTIFF_TO_COG]`** from 8 to 7 (overviews moved out of `run_checks`).
- **Skill feedback loop** ([CLAUDE.md](CLAUDE.md)): document the failure mode, the new check, and the overview-formula caveat in `geo-conversions/geotiff-to-cog/SKILL.md` Known failure modes + Changelog. Update Quickstart so the documented `gdalwarp` invocation no longer hard-codes `-t_srs EPSG:4326`.

## Why automatic detection of unintended reprojection now works

The combined check set is robust: a silent warp changes pixel grid, bounds, and values simultaneously. Sample run (synthetic EPSG:5070 input, deliberately warped output to EPSG:4326):

```
[FAIL] CRS preserved: Output CRS differs from source: input=EPSG:5070, output=EPSG:4326
[FAIL] Bounds preserved: left: source=1000000.0, output=-84.78
[FAIL] Dimensions: Source: 2048x2048, Output: 2608x2069
[FAIL] Pixel fidelity: Band 1: 998/1000 integer pixels differ
```

Four independent failures from one bug — the user never has to discover it visually.

## Scope notes

- Only touches the **geotiff-to-cog** skill. `hdf5-to-cog` and `netcdf-to-cog` converters still warp to EPSG:4326 (their `convert.py` enforces it), so their `check_crs_4326` is still correct and untouched.
- A separate frontend issue surfaced during diagnosis: NLCD's embedded WKT (`PROJCS["AEA WGS84"...]` with no AUTHORITY tag on the PROJCS) triggers `Unsupported CRS units: unknown when computing metersPerUnit` in `deck.gl-geotiff`. That blocks rendering of already-uploaded NLCD datasets but does not block this re-upload path. Deferred to a separate PR.

## Test plan

- [x] `uv run pytest` in `ingestion/` — 538 passed, 9 skipped, **same 4 pre-existing failures as `main`** (S3 metadata-endpoint test failures + `netcdf_to_cog` import error in temporal extraction; all unrelated to this branch).
- [x] End-to-end sanity test against the new validator with a synthetic EPSG:5070 raster and `cog_translate` (preserves CRS): all 7 core checks pass.
- [x] Sanity test with an artificially warped output: 4 of 7 core checks fail (CRS, Bounds, Dimensions, Pixel fidelity) — auto-detection works.
- [ ] Pending: real NLCD upload through the worktree stack to confirm the original blocker is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GeoTIFF→COG conversion now preserves the input CRS; validation verifies CRS preservation.

* **Improvements**
  * Validation always runs key checks (bounds/dimensions/pixel fidelity/nodata) for all inputs; overview checks are advisory for very large rasters.
  * Validation reporting adjusted to reflect one fewer expected check for this conversion path.

* **Bug Fixes**
  * Pixel-fidelity check now guards against differing source/output dimensions and skips unsafe per-pixel comparisons.

* **Documentation**
  * Quickstart, known-behavior guidance, and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->