### PR TITLE
fix(ingestion): pass R2_PUBLIC_URL through to ingestion service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,6 +152,7 @@ services:
       AWS_HTTPS: "YES"
       AWS_VIRTUAL_HOSTING: "FALSE"
       GDAL_CACHEMAX: "512"
+      R2_PUBLIC_URL: ${R2_PUBLIC_URL}
       STAC_API_URL: http://stac-api:8080
       RASTER_TILER_URL: http://raster-tiler:80
       VECTOR_TILER_URL: http://vector-tiler:80


### PR DESCRIPTION
## Summary
- Image chapters render as broken images because uploaded asset URLs are stored as relative paths (`/story-assets/<ws>/<id>/original.jpg`) instead of absolute R2 URLs.
- Root cause: [`ingestion/src/routes/story_assets.py`](ingestion/src/routes/story_assets.py#L48-L50) prepends `os.environ.get("R2_PUBLIC_URL", "")` to every asset key, but the env var is missing from the `ingestion` service block in [`docker-compose.yml`](docker-compose.yml). It's already passed to `frontend` (for the `/storage` proxy) and `caddy`, just not ingestion.
- The browser then hits the relative path against Vite, which has no proxy rule for `/story-assets/`, so the SPA fallback returns `index.html` (`Content-Type: text/html`) and the `<img>` fails to render.
- Fix is one line: add `R2_PUBLIC_URL: ${R2_PUBLIC_URL}` to the ingestion environment block.

Reproduced against PR #362's image chapter in the story `4df6f8c1-3885-486c-a18d-695f62603ab0`:
```
$ curl -sI http://localhost:5185/story-assets/.../original.jpg
HTTP/1.1 200 OK
Content-Type: text/html  ← SPA fallback, not the image
```

## Test plan
- [ ] After deploy: upload a new image chapter, confirm `url` in `GET /api/stories/<id>` is absolute (`https://pub-*.r2.dev/story-assets/...`) and renders in the reader.
- [ ] Existing chapters with relative URLs need to be re-uploaded — they're not auto-migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service deployment configuration to support a new environment variable for external resource access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->