### PR TITLE
fix(frontend): normalize geographic-CRS units in inline EPSG registry

### DIFF
--- a/frontend/src/lib/layers/epsg/__tests__/parseSubset.test.ts
+++ b/frontend/src/lib/layers/epsg/__tests__/parseSubset.test.ts
@@ -31,4 +31,21 @@ describe("parseSubsetCsv", () => {
     expect(map.has(5070)).toBe(true);
     expect(map.has(2154)).toBe(true);
   });
+
+  it("normalizes geographic-CRS units to 'degree' (wkt-parser returns 'unknown' for WKT2 GEOGCRS)", () => {
+    // Real EPSG:4326 WKT2 from subset.csv. Without normalization, wkt-parser
+    // emits units: "unknown", which propagates through cngEpsgResolver and
+    // crashes generateTileMatrixSet → metersPerUnit on every geographic COG.
+    const csv = `4326|GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)",ID["EPSG",1166]],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1,ID["EPSG",9001]],ID["EPSG",7030]],ENSEMBLEACCURACY[2],ID["EPSG",6326]],CS[ellipsoidal,2,ID["EPSG",6422]],AXIS["Geodetic latitude (Lat)",north],AXIS["Geodetic longitude (Lon)",east],ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9102]],ID["EPSG",4326]]`;
+    const def = parseSubsetCsv(csv).get(4326)!;
+    expect(def.projName).toBe("longlat");
+    expect(def.units).toBe("degree");
+  });
+
+  it("leaves projected-CRS units alone", () => {
+    // EPSG:5070 (NAD83 / Conus Albers) — uses metres. Must not be rewritten.
+    const csv = `5070|PROJCRS["NAD83 / Conus Albers",BASEGEOGCRS["NAD83",DATUM["North American Datum 1983",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4269]],CONVERSION["Conus Albers",METHOD["Albers Equal Area",ID["EPSG",9822]],PARAMETER["Latitude of false origin",23,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",-96,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",29.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",45.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Latitude of false origin",23,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8826]],PARAMETER["Longitude of false origin",-96,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],ID["EPSG",5070]]`;
+    const def = parseSubsetCsv(csv).get(5070)!;
+    expect(def.units).not.toBe("degree");
+  });
 });

--- a/frontend/src/lib/layers/epsg/__tests__/resolver.test.ts
+++ b/frontend/src/lib/layers/epsg/__tests__/resolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { EpsgResolver } from "@developmentseed/proj";
+import { metersPerUnit } from "@developmentseed/proj";
 import { createCngEpsgResolver } from "../resolver";
 
 describe("cngEpsgResolver", () => {
@@ -14,6 +15,19 @@ describe("cngEpsgResolver", () => {
     const def = await resolver(5070);
     expect(def).toBeDefined();
     expect(networkResolver).not.toHaveBeenCalled();
+  });
+
+  it("returns an EPSG:4326 definition compatible with metersPerUnit", async () => {
+    // Regression: wkt-parser produces `units: "unknown"` for the WKT2
+    // GEOGCRS form in subset.csv, which crashes generateTileMatrixSet
+    // when rendering a geographic-CRS COG client-side.
+    const resolver = createCngEpsgResolver(networkResolver);
+    const def = await resolver(4326);
+    expect(def.units).toBe("degree");
+    const semiMajorAxis = def.a ?? def.datum?.a;
+    expect(() =>
+      metersPerUnit(def.units as "degree", { semiMajorAxis })
+    ).not.toThrow();
   });
 
   it("resolves a UTM zone (32614) without invoking the network resolver", async () => {

--- a/frontend/src/lib/layers/epsg/parseSubset.ts
+++ b/frontend/src/lib/layers/epsg/parseSubset.ts
@@ -22,7 +22,20 @@ export function parseSubsetCsv(
       );
     }
     const wkt = line.slice(sepIdx + 1);
-    map.set(code, parseWkt(wkt));
+    map.set(code, normalizeProjection(parseWkt(wkt)));
   }
   return map;
+}
+
+// wkt-parser doesn't recognize WKT2 ANGLEUNIT and returns `units: "unknown"`
+// for geographic CRSes. Downstream consumers (e.g. metersPerUnit in
+// @developmentseed/proj) require "degree" — without this fix, every
+// EPSG:4326 COG that hits the client render path crashes.
+function normalizeProjection(
+  def: ProjectionDefinition
+): ProjectionDefinition {
+  if (def.projName === "longlat" && def.units !== "degree") {
+    return { ...def, units: "degree" };
+  }
+  return def;
 }

--- a/frontend/src/lib/layers/epsg/parseSubset.ts
+++ b/frontend/src/lib/layers/epsg/parseSubset.ts
@@ -31,9 +31,7 @@ export function parseSubsetCsv(
 // for geographic CRSes. Downstream consumers (e.g. metersPerUnit in
 // @developmentseed/proj) require "degree" — without this fix, every
 // EPSG:4326 COG that hits the client render path crashes.
-function normalizeProjection(
-  def: ProjectionDefinition
-): ProjectionDefinition {
+function normalizeProjection(def: ProjectionDefinition): ProjectionDefinition {
   if (def.projName === "longlat" && def.units !== "degree") {
     return { ...def, units: "degree" };
   }


### PR DESCRIPTION
## Summary

- Categorical EPSG:4326 COGs that hit the client-side render path crashed with `Unsupported CRS units: unknown when computing metersPerUnit` (e.g. dataset `f886aca8-65ef-435b-b233-305c84211faa`).
- Root cause: `wkt-parser` doesn't recognize WKT2 `ANGLEUNIT[...]`, so the WGS 84 entry in [subset.csv](frontend/src/lib/layers/epsg/subset.csv) parsed with `units: "unknown"`. That propagated through `cngEpsgResolver(4326)` into `generateTileMatrixSet → metersPerUnit`.
- Fix: post-process every parsed entry in [parseSubset.ts](frontend/src/lib/layers/epsg/parseSubset.ts) — if the projection is `longlat` and units aren't already `"degree"`, set them. WKT1 entries are unaffected; projected CRSes are unaffected.

## Test plan

- [x] `npx vitest run` (552 passing → still green; 6 EPSG-resolver tests; 6 parseSubset tests)
- [x] `npx tsc --noEmit` clean
- [x] New `parseSubsetCsv` regression: real WGS 84 WKT2 GEOGCRS line → `units === "degree"`; projected EPSG:5070 untouched
- [x] New resolver chain test: `cngEpsgResolver(4326)` returns a definition that `metersPerUnit` accepts
- [ ] Manual map render of a categorical EPSG:4326 dataset — Vite proxy → prod returned 502 (Cloudflare host check), so manual smoke skipped in favor of the chain test that exercises the exact failure path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed coordinate system handling to properly normalize geographic reference systems with correct unit values.

* **Tests**
  * Added test coverage for geographic and projected coordinate system unit normalization and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->