### PR TITLE
fix(frontend): use no-overlap tile refinement to prevent flashing on translucent rasters

### DIFF
--- a/frontend/src/lib/layers/__tests__/rasterTileLayer.test.ts
+++ b/frontend/src/lib/layers/__tests__/rasterTileLayer.test.ts
@@ -19,6 +19,16 @@ describe("buildRasterTileLayers", () => {
     expect(layers[0].id).toBe("raster-tile-0");
   });
 
+  it("uses no-overlap refinement strategy to avoid flashing at low opacity", () => {
+    const layers = buildRasterTileLayers({
+      tileUrl: "/raster/tiles/{z}/{x}/{y}.png?colormap_name=viridis",
+      opacity: 0.5,
+      isTemporalActive: false,
+    });
+    const props = layers[0].props as { refinementStrategy?: string };
+    expect(props.refinementStrategy).toBe("no-overlap");
+  });
+
   it("uses custom id for non-temporal layer", () => {
     const layers = buildRasterTileLayers({
       id: "raster-layer-viridis-1",

--- a/frontend/src/lib/layers/rasterPMTilesLayer.ts
+++ b/frontend/src/lib/layers/rasterPMTilesLayer.ts
@@ -28,6 +28,7 @@ export function buildRasterPMTilesLayer({
     data: `${absoluteUrl}/{z}/{x}/{y}.png`,
     opacity,
     tileSize: 256,
+    refinementStrategy: "no-overlap",
     ...(minZoom !== undefined && { minZoom }),
     ...(maxZoom !== undefined && { maxZoom }),
     fetch: async (url: string) => {

--- a/frontend/src/lib/maptool/COGLayer.ts
+++ b/frontend/src/lib/maptool/COGLayer.ts
@@ -30,6 +30,7 @@ export function createCOGLayer({
     opacity,
     visible,
     tileSize: 256,
+    refinementStrategy: "no-overlap",
     ...(bounds ? { extent: bounds } : {}),
     ...(onViewportLoad ? { onViewportLoad } : {}),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

- Set deck.gl `TileLayer.refinementStrategy` to `\"no-overlap\"` on the client-side COG layer and the PMTiles raster layer.
- Default strategy (`best-available`) renders both parent and child tiles while children load. At opacity < 1 (e.g. the default story-chapter opacity of 0.8), the alpha stack flashes during pan/zoom.
- `no-overlap` hides the parent as soon as a child is rendered, eliminating the flash.

Reported by a developer on https://cngsandbox.org/map/912564d7-aa10-4482-a85f-65878bfcb6a3, referencing https://deck.gl/docs/api-reference/geo-layers/tile-layer#refinementstrategy

### Trade-off

`no-overlap` may show slightly more visible loading gaps at full opacity (parent won't fill in while children load), but for raster overlays the trade is favorable because: (1) most layers in CNG are translucent overlays (default chapter opacity 0.8), (2) flashing is much more disruptive than a brief loading gap.

## Test plan
- [x] Unit test: `buildRasterTileLayers` returns a TileLayer with `refinementStrategy: \"no-overlap\"`
- [x] `tsc --noEmit` clean
- [x] Full vitest suite (554 tests) passes
- [x] eslint clean
- [ ] Visual check on a low-opacity client-rendered raster (could not run end-to-end locally — no client-rendered datasets on the local stack; recommend smoke-testing the deployed PR build on the dataset linked above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of raster tile layers to eliminate tile overlap issues
  * Enhanced tile refinement behavior for PMTiles and Cloud Optimized GeoTIFFs (COG) layers

* **Tests**
  * Added test coverage for tile layer refinement behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->