### PR TITLE
fix(frontend): count client-rendered fetches in data-fetched metric

### DIFF
--- a/frontend/src/hooks/useTileTransferSize.test.ts
+++ b/frontend/src/hooks/useTileTransferSize.test.ts
@@ -39,18 +39,61 @@ describe("useTileTransferSize", () => {
   });
 
   it("returns null when no matching entries exist yet", () => {
-    const { result } = renderHook(() => useTileTransferSize("/pmtiles/"));
+    const { result } = renderHook(() => useTileTransferSize(["/pmtiles/"]));
     expect(result.current).toBeNull();
   });
 
-  it("sums transferSize for unique entries matching the prefix", () => {
+  it("returns null when prefix list is empty", () => {
+    vi.spyOn(performance, "getEntriesByType").mockReturnValue([
+      makeEntry("http://localhost/pmtiles/tile-a", 100),
+    ]);
+    const { result } = renderHook(() => useTileTransferSize([]));
+    expect(result.current).toBeNull();
+  });
+
+  it("sums transferSize for entries matching the prefix", () => {
     vi.spyOn(performance, "getEntriesByType").mockReturnValue([
       makeEntry("http://localhost/pmtiles/datasets/abc/tile-a", 1024),
       makeEntry("http://localhost/pmtiles/datasets/abc/tile-b", 512),
       makeEntry("http://localhost/raster/tiles/0/0/0.png", 2048),
     ]);
-    const { result } = renderHook(() => useTileTransferSize("/pmtiles/"));
+    const { result } = renderHook(() => useTileTransferSize(["/pmtiles/"]));
     expect(result.current).toBe(1536);
+  });
+
+  it("matches entries against any prefix in the list", () => {
+    vi.spyOn(performance, "getEntriesByType").mockReturnValue([
+      makeEntry("http://localhost/pmtiles/tile-a", 100),
+      makeEntry("http://localhost/cog/dataset.tif", 500),
+      makeEntry("http://localhost/raster/tiles/0/0/0.png", 999),
+    ]);
+    const { result } = renderHook(() =>
+      useTileTransferSize(["/pmtiles/", "/cog/dataset.tif"])
+    );
+    expect(result.current).toBe(600);
+  });
+
+  it("accumulates repeated fetches of the same URL (e.g. COG range requests)", () => {
+    vi.spyOn(performance, "getEntriesByType").mockReturnValue([
+      makeEntry("http://localhost/cog/dataset.tif", 1024),
+      makeEntry("http://localhost/cog/dataset.tif", 2048),
+      makeEntry("http://localhost/cog/dataset.tif", 4096),
+    ]);
+    const { result } = renderHook(() =>
+      useTileTransferSize(["/cog/dataset.tif"])
+    );
+    expect(result.current).toBe(7168);
+  });
+
+  it("matches absolute URL prefixes (cross-origin R2 fetches)", () => {
+    vi.spyOn(performance, "getEntriesByType").mockReturnValue([
+      makeEntry("https://r2.example.com/datasets/abc.tif", 1000),
+      makeEntry("https://r2.example.com/datasets/abc.tif", 2000),
+    ]);
+    const { result } = renderHook(() =>
+      useTileTransferSize(["https://r2.example.com/datasets/abc.tif"])
+    );
+    expect(result.current).toBe(3000);
   });
 
   it("updates when the observer fires with new entries", () => {
@@ -58,7 +101,7 @@ describe("useTileTransferSize", () => {
       makeEntry("http://localhost/pmtiles/tile-a", 100),
     ]);
 
-    const { result } = renderHook(() => useTileTransferSize("/pmtiles/"));
+    const { result } = renderHook(() => useTileTransferSize(["/pmtiles/"]));
     expect(result.current).toBe(100);
 
     act(() => {
@@ -72,40 +115,17 @@ describe("useTileTransferSize", () => {
     expect(result.current).toBe(300);
   });
 
-  it("deduplicates repeated fetches of the same tile URL", () => {
-    vi.spyOn(performance, "getEntriesByType").mockReturnValue([
-      makeEntry("http://localhost/pmtiles/tile-a", 100),
-    ]);
-
-    const { result } = renderHook(() => useTileTransferSize("/pmtiles/"));
-    expect(result.current).toBe(100);
-
-    act(() => {
-      observerCallback(
-        {
-          getEntries: () => [
-            makeEntry("http://localhost/pmtiles/tile-a", 100),
-            makeEntry("http://localhost/pmtiles/tile-b", 200),
-          ],
-        } as unknown as PerformanceObserverEntryList,
-        {} as PerformanceObserver
-      );
-    });
-    // tile-a was already counted, only tile-b is new
-    expect(result.current).toBe(300);
-  });
-
   it("returns 0 (not null) when entries exist but all have transferSize 0 (Timing-Allow-Origin not set)", () => {
     vi.spyOn(performance, "getEntriesByType").mockReturnValue([
       makeEntry("http://localhost/pmtiles/x", 0),
     ]);
-    const { result } = renderHook(() => useTileTransferSize("/pmtiles/"));
+    const { result } = renderHook(() => useTileTransferSize(["/pmtiles/"]));
     // entries exist but report 0 bytes → 0, not null (null = no entries at all)
     expect(result.current).toBe(0);
   });
 
   it("disconnects the observer on unmount", () => {
-    const { unmount } = renderHook(() => useTileTransferSize("/pmtiles/"));
+    const { unmount } = renderHook(() => useTileTransferSize(["/pmtiles/"]));
     unmount();
     expect(mockDisconnect).toHaveBeenCalledOnce();
   });

--- a/frontend/src/hooks/useTileTransferSize.ts
+++ b/frontend/src/hooks/useTileTransferSize.ts
@@ -1,33 +1,55 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo } from "react";
 
 /**
- * Accumulates tile bytes fetched since mount by observing PerformanceResourceTiming
- * entries whose URL starts with the given prefix.
+ * Accumulates bytes fetched since mount by observing PerformanceResourceTiming
+ * entries whose URL starts with any of the given prefixes.
+ *
+ * Each prefix is resolved against `window.location.origin`, so callers may pass
+ * either a path (e.g. `/pmtiles/`) or an absolute URL (e.g. `https://r2.example/ds.tif`).
+ * This lets the metric cover both server-side tile requests (proxied paths) and
+ * client-side rendering (direct R2 fetches for COGs and GeoParquet).
+ *
+ * Range requests against the same URL produce multiple PerformanceResourceTiming
+ * entries — they're all counted because dedup is by entry identity, not URL.
  *
  * Returns:
- *   null  — no matching tile requests have been made yet
- *   0     — tile requests exist but all report transferSize=0 (Timing-Allow-Origin not set)
+ *   null  — no matching requests have been made yet
+ *   0     — matching requests exist but all report transferSize=0 (Timing-Allow-Origin not set)
  *   > 0   — bytes fetched so far
  */
-export function useTileTransferSize(tileUrlPrefix: string): number | null {
+export function useTileTransferSize(prefixes: string[]): number | null {
+  const prefixKey = prefixes.join("|");
+  const resolvedPrefixes = useMemo(
+    () =>
+      prefixes
+        .filter((p) => p.length > 0)
+        .map((p) => new URL(p, window.location.origin).toString()),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [prefixKey]
+  );
+
   const [bytes, setBytes] = useState<number | null>(null);
-  const accumulatorRef = useRef({ total: 0, count: 0 });
 
   useEffect(() => {
-    const prefix = window.location.origin + tileUrlPrefix;
+    if (resolvedPrefixes.length === 0) {
+      setBytes(null);
+      return;
+    }
+
     const acc = { total: 0, count: 0 };
-    const seen = new Set<string>();
-    accumulatorRef.current = acc;
+    const seen = new WeakSet<PerformanceResourceTiming>();
+
+    const matches = (url: string) =>
+      resolvedPrefixes.some((p) => url.startsWith(p));
 
     const addEntry = (e: PerformanceResourceTiming): boolean => {
-      if (!e.name.startsWith(prefix) || seen.has(e.name)) return false;
-      seen.add(e.name);
+      if (seen.has(e) || !matches(e.name)) return false;
+      seen.add(e);
       acc.total += e.transferSize;
       acc.count++;
       return true;
     };
 
-    // Scan any entries already in the buffer
     const existing = performance.getEntriesByType(
       "resource"
     ) as PerformanceResourceTiming[];
@@ -46,7 +68,7 @@ export function useTileTransferSize(tileUrlPrefix: string): number | null {
     observer.observe({ type: "resource", buffered: false });
 
     return () => observer.disconnect();
-  }, [tileUrlPrefix]);
+  }, [resolvedPrefixes]);
 
   return bytes;
 }

--- a/frontend/src/hooks/useTileTransferSize.ts
+++ b/frontend/src/hooks/useTileTransferSize.ts
@@ -24,7 +24,6 @@ export function useTileTransferSize(prefixes: string[]): number | null {
       prefixes
         .filter((p) => p.length > 0)
         .map((p) => new URL(p, window.location.origin).toString()),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [prefixKey]
   );
 

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -188,10 +188,18 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
   const [reportCardOpen, setReportCardOpen] = useState(false);
 
   // --- Tile transfer size ---
-  const tileUrlPrefix = item?.dataset?.tile_url
-    ? getTileUrlPrefix(item.dataset.tile_url)
-    : "";
-  const bytesTransferred = useTileTransferSize(tileUrlPrefix);
+  // Watch tile-proxy paths plus direct cog/parquet URLs so the metric covers
+  // both server-side tiling and client-side rendering.
+  const transferPrefixes = useMemo(() => {
+    const prefixes: string[] = [];
+    if (item?.dataset?.tile_url) {
+      prefixes.push(getTileUrlPrefix(item.dataset.tile_url));
+    }
+    if (item?.cogUrl) prefixes.push(item.cogUrl);
+    if (item?.parquetUrl) prefixes.push(item.parquetUrl);
+    return prefixes;
+  }, [item?.dataset?.tile_url, item?.cogUrl, item?.parquetUrl]);
+  const bytesTransferred = useTileTransferSize(transferPrefixes);
 
   // --- Temporal ---
   const ds = item?.dataset;


### PR DESCRIPTION
## Summary

The conversion summary's "data fetched" metric only watched the tile
proxy prefix (e.g. `/pmtiles/`, `/raster/`). Client-side rendered
COGs and GeoParquet fetch directly from R2 (or `/cog/...`) and bypass
that prefix, so the metric reported "0 B fetched" even after the
browser pulled megabytes of data.

- `useTileTransferSize` now takes an array of prefixes (paths or
  absolute URLs) and resolves each against `window.location.origin`.
- Dedup switched from URL-based to entry-identity-based, so range
  requests against the same COG file accumulate correctly.
- `MapPage` passes the dataset's `tile_url` prefix plus `cogUrl` and
  `parquetUrl` from the map item.

Example dataset that exposed the gap: https://cngsandbox.org/map/912564d7-aa10-4482-a85f-65878bfcb6a3 (paletted COG, client-side rendered, metric stuck at "0 B fetched").

## Test plan

- [x] `frontend` vitest suite passes (556 tests)
- [x] New unit tests cover: multiple prefixes, absolute URL prefixes, range-request accumulation, empty prefix list
- [ ] Manual smoke in a real browser — couldn't run on this VM (deck.gl needs WebGL, headless Chromium can't get a GL context). Verify on the linked example dataset that the metric increments as you pan/zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transfer metrics now aggregate data usage from multiple tile sources (server tiles, direct imagery, and data files) for fuller visibility.
  * Repeated/partial transfers (e.g., range requests) are included in totals rather than deduplicated.
  * Cross-origin resource transfers are matched correctly.
  * Metric resets when no valid sources are provided, avoiding misleading zero values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->