### PR TITLE
fix(stories): repair empty line charts

### DIFF
--- a/frontend/src/components/ChartChapterRenderer.tsx
+++ b/frontend/src/components/ChartChapterRenderer.tsx
@@ -10,6 +10,11 @@ import {
   fetchHistogram,
   fetchTimeseries,
 } from "../lib/story/charts";
+import { getStoryAsset } from "../lib/story/assets";
+
+function isAbsoluteUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
 
 const ReactECharts = lazy(() => import("echarts-for-react"));
 
@@ -35,8 +40,15 @@ export function ChartChapterRenderer({
       try {
         const { source, viz } = chapter.chart;
         if (source.kind === "csv") {
-          if (!source.url) return;
-          const rows = await fetchCsvRows(source.url);
+          if (!source.url && !source.asset_id) return;
+          let csvUrl = source.url;
+          if (!csvUrl || !isAbsoluteUrl(csvUrl)) {
+            if (!source.asset_id) return;
+            const meta = await getStoryAsset(source.asset_id);
+            if (cancelled) return;
+            csvUrl = meta.url;
+          }
+          const rows = await fetchCsvRows(csvUrl);
           if (cancelled) return;
           setOption(buildOptionFromCsvRows(rows, viz));
         } else if (source.kind === "dataset_timeseries") {

--- a/frontend/src/components/ChartChapterRenderer.tsx
+++ b/frontend/src/components/ChartChapterRenderer.tsx
@@ -40,10 +40,16 @@ export function ChartChapterRenderer({
       try {
         const { source, viz } = chapter.chart;
         if (source.kind === "csv") {
-          if (!source.url && !source.asset_id) return;
+          if (!source.url && !source.asset_id) {
+            throw new Error(
+              "chart csv source is missing both url and asset_id"
+            );
+          }
           let csvUrl = source.url;
           if (!csvUrl || !isAbsoluteUrl(csvUrl)) {
-            if (!source.asset_id) return;
+            if (!source.asset_id) {
+              throw new Error("relative csv source requires asset_id");
+            }
             const meta = await getStoryAsset(source.asset_id);
             if (cancelled) return;
             csvUrl = meta.url;

--- a/frontend/src/lib/story/assets.ts
+++ b/frontend/src/lib/story/assets.ts
@@ -58,6 +58,31 @@ export async function uploadCsvAsset(
   return resp.json();
 }
 
+export interface StoryAssetMetadata {
+  asset_id: string;
+  kind: "image" | "csv";
+  url: string;
+  thumbnail_url: string | null;
+  width: number | null;
+  height: number | null;
+  mime: string;
+  size_bytes: number;
+  row_count: number | null;
+  columns: string[] | null;
+}
+
+export async function getStoryAsset(
+  assetId: string
+): Promise<StoryAssetMetadata> {
+  const resp = await workspaceFetch(
+    `/api/story-assets/${encodeURIComponent(assetId)}`
+  );
+  if (!resp.ok) {
+    throw new Error(`asset fetch failed: ${resp.status}`);
+  }
+  return resp.json();
+}
+
 export async function deleteStoryAsset(assetId: string): Promise<void> {
   const resp = await workspaceFetch(
     `/api/story-assets/${encodeURIComponent(assetId)}`,

--- a/ingestion/src/routes/dataset_charts.py
+++ b/ingestion/src/routes/dataset_charts.py
@@ -41,7 +41,7 @@ def _titiler_point(
     If `client` is provided, reuse it. Otherwise, create a one-shot client.
     """
     url = f"{RASTER_TILER_URL}/collections/{collection_id}/point/{lon},{lat}"
-    params = {"datetime": datetime_iso}
+    params = {"datetime": datetime_iso, "assets": "data"}
     try:
         if client is None:
             with httpx.Client(timeout=20.0) as http_client:
@@ -165,7 +165,7 @@ def dataset_timeseries(
 def _titiler_statistics(collection_id: str, *, categorical: bool, bins: int) -> dict:
     """Query titiler-pgstac /statistics."""
     url = f"{RASTER_TILER_URL}/collections/{collection_id}/statistics"
-    params: dict[str, str | int] = {}
+    params: dict[str, str | int] = {"assets": "data"}
     if categorical:
         params["categorical"] = "true"
     else:

--- a/ingestion/src/routes/story_assets.py
+++ b/ingestion/src/routes/story_assets.py
@@ -36,6 +36,7 @@ def _public_url(key: str) -> str:
 
 
 def _put_object(key: str, body: bytes, content_type: str) -> str:
+    url = _public_url(key)
     storage = StorageService()
     obstore.put(
         storage.store,
@@ -43,7 +44,7 @@ def _put_object(key: str, body: bytes, content_type: str) -> str:
         io.BytesIO(body),
         attributes={"Content-Type": content_type},
     )
-    return _public_url(key)
+    return url
 
 
 def _delete_object(key: str) -> None:

--- a/ingestion/src/routes/story_assets.py
+++ b/ingestion/src/routes/story_assets.py
@@ -28,6 +28,13 @@ MAX_CSV_BYTES = 5 * 1024 * 1024
 ALLOWED_CSV_MIMES = {"text/csv", "application/vnd.ms-excel", "application/csv"}
 
 
+def _public_url(key: str) -> str:
+    base = os.environ.get("R2_PUBLIC_URL", "").rstrip("/")
+    if not base:
+        raise RuntimeError("R2_PUBLIC_URL is not configured")
+    return f"{base}/{key}"
+
+
 def _put_object(key: str, body: bytes, content_type: str) -> str:
     storage = StorageService()
     obstore.put(
@@ -36,18 +43,12 @@ def _put_object(key: str, body: bytes, content_type: str) -> str:
         io.BytesIO(body),
         attributes={"Content-Type": content_type},
     )
-    base = os.environ.get("R2_PUBLIC_URL", "").rstrip("/")
-    return f"{base}/{key}"
+    return _public_url(key)
 
 
 def _delete_object(key: str) -> None:
     storage = StorageService()
     storage.delete_object(key)
-
-
-def _public_url(key: str) -> str:
-    base = os.environ.get("R2_PUBLIC_URL", "").rstrip("/")
-    return f"{base}/{key}"
 
 
 @router.post("/story-assets", status_code=201)

--- a/ingestion/tests/conftest.py
+++ b/ingestion/tests/conftest.py
@@ -29,6 +29,11 @@ def _reset_rate_limiter():
     limiter.reset()
 
 
+@pytest.fixture(autouse=True)
+def _r2_public_url(monkeypatch):
+    monkeypatch.setenv("R2_PUBLIC_URL", "https://r2.example")
+
+
 @pytest.fixture
 def db_engine():
     engine = create_engine(

--- a/ingestion/tests/test_dataset_charts.py
+++ b/ingestion/tests/test_dataset_charts.py
@@ -183,6 +183,68 @@ def test_titiler_point_returns_none_on_string_value(monkeypatch):
     assert _titiler_point("col", "2020-01-01", 0.0, 0.0) is None
 
 
+def test_titiler_point_passes_assets_param(monkeypatch):
+    from src.routes.dataset_charts import _titiler_point
+
+    captured: dict = {}
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"values": [1.0]}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def get(self, url, params=None):
+            captured["params"] = params
+            return FakeResponse()
+
+    monkeypatch.setattr("src.routes.dataset_charts.httpx.Client", FakeClient)
+    _titiler_point("col", "2020-01-01", 0.0, 0.0)
+    assert captured["params"]["assets"] == "data"
+    assert captured["params"]["datetime"] == "2020-01-01"
+
+
+def test_titiler_statistics_passes_assets_param(monkeypatch):
+    from src.routes.dataset_charts import _titiler_statistics
+
+    captured: dict = {}
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"histogram": [[], []]}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def get(self, url, params=None):
+            captured["params"] = params
+            return FakeResponse()
+
+    monkeypatch.setattr("src.routes.dataset_charts.httpx.Client", FakeClient)
+    _titiler_statistics("col", categorical=False, bins=10)
+    assert captured["params"]["assets"] == "data"
+    assert captured["params"]["histogram_bins"] == 10
+
+
 def test_titiler_point_returns_none_on_non_200(monkeypatch, caplog):
     import logging
 

--- a/ingestion/tests/test_story_assets.py
+++ b/ingestion/tests/test_story_assets.py
@@ -166,3 +166,24 @@ def test_public_url_returns_absolute_when_env_set(monkeypatch):
 
     monkeypatch.setenv("R2_PUBLIC_URL", "https://r2.example/")
     assert _public_url("a/b.csv") == "https://r2.example/a/b.csv"
+
+
+def test_put_object_validates_env_before_upload(monkeypatch):
+    import src.routes.story_assets as story_assets_mod
+
+    upload_called = False
+
+    def fake_put(*args, **kwargs):
+        nonlocal upload_called
+        upload_called = True
+
+    monkeypatch.setattr(story_assets_mod.obstore, "put", fake_put)
+    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
+
+    try:
+        story_assets_mod._put_object("some/key", b"x", "text/csv")
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected RuntimeError")
+    assert not upload_called, "upload must not happen when R2_PUBLIC_URL is unset"

--- a/ingestion/tests/test_story_assets.py
+++ b/ingestion/tests/test_story_assets.py
@@ -147,3 +147,22 @@ def test_upload_csv_rejects_non_csv_mime(client: TestClient):
     data = {"kind": "csv"}
     resp = client.post("/api/story-assets", files=files, data=data)
     assert resp.status_code == 415
+
+
+def test_public_url_raises_when_env_unset(monkeypatch):
+    from src.routes.story_assets import _public_url
+
+    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
+    try:
+        _public_url("some/key")
+    except RuntimeError as exc:
+        assert "R2_PUBLIC_URL" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_public_url_returns_absolute_when_env_set(monkeypatch):
+    from src.routes.story_assets import _public_url
+
+    monkeypatch.setenv("R2_PUBLIC_URL", "https://r2.example/")
+    assert _public_url("a/b.csv") == "https://r2.example/a/b.csv"


### PR DESCRIPTION
## Summary

Two distinct bugs caused dataset_timeseries and CSV line charts to render empty (discovered while investigating story `4df6f8c1-3885-486c-a18d-695f62603ab0`).

**Bug A — Dataset timeseries/histogram:** `_titiler_point` and `_titiler_statistics` in `ingestion/src/routes/dataset_charts.py` call titiler-pgstac without an `assets` query param. titiler-pgstac 1.7 requires it (`assets must be defined either via expression or assets options`). The 400 was silently logged and coerced to `None`, so every timestep returned null and echarts drew nothing. Now passes `assets=data` to match the convention used by tile URLs in `stac_ingest.py`.

**Bug B — CSV chart:** A CSV uploaded while `R2_PUBLIC_URL` was unset got a relative URL (`/story-assets/...`) baked into the chart source. The browser fetches that from Vite, gets the SPA fallback HTML, Papa parses HTML → 0 rows → empty chart. Now `ChartChapterRenderer` detects non-absolute URLs and resolves the asset via `GET /api/story-assets/{asset_id}` to get the live R2 URL. Belt-and-braces: `_public_url` now raises if `R2_PUBLIC_URL` is missing, so a future env regression can't silently produce broken stored URLs.

## Test plan

- [x] `cd ingestion && uv run pytest tests/test_dataset_charts.py tests/test_story_assets.py` — 26 passed (includes new regression tests for `assets=data` param and `_public_url` env guard)
- [x] `cd frontend && npx vitest run` — all tests pass
- [x] `cd frontend && yarn tsc --noEmit` — clean
- [x] `cd frontend && yarn prettier --check` on changed files — clean
- [ ] Visual: load the user's test story after deploy and confirm both line charts render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV charts can now load data from asset sources in addition to direct URLs.

* **Improvements**
  * Enhanced asset retrieval for story assets and centralized public URL handling.
  * Dataset chart requests now include asset specifications.

* **Bug Fixes**
  * CSV chart loading now validates presence of a URL or asset and surfaces an error when neither is provided.

* **Tests**
  * Added coverage for asset parameter handling in chart requests and for asset URL construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->