### PR TITLE
fix(frontend): create paletted COG LUT as 2d-array texture

### DIFF
--- a/frontend/src/lib/layers/__tests__/cogLayerPaletted.test.ts
+++ b/frontend/src/lib/layers/__tests__/cogLayerPaletted.test.ts
@@ -192,4 +192,50 @@ describe("buildCogLayerPaletted with categories", () => {
       })
     );
   });
+
+  it("creates the LUT as a 2d-array texture for the Colormap GPU module", async () => {
+    const layers = buildCogLayerPaletted({
+      cogUrl: "/cog/example.tif",
+      opacity: 1,
+      categories: [{ value: 1, color: "#ff0000", label: "A" }],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getTileData = (layers[0] as any).props.getTileData;
+
+    const fakeTile = {
+      array: {
+        layout: "interleaved",
+        bands: [],
+        data: new Uint8Array([1, 0]),
+        width: 2,
+        height: 1,
+      },
+    };
+    const image = { fetchTile: vi.fn().mockResolvedValue(fakeTile) };
+    const device = {
+      createTexture: vi.fn().mockReturnValue({ mock: "tex" }),
+    };
+
+    await getTileData(image, {
+      device,
+      x: 0,
+      y: 0,
+      signal: new AbortController().signal,
+    });
+
+    // The LUT call is the second createTexture invocation; deck.gl-raster
+    // ≥0.6 needs `dimension: "2d-array"` here or the Colormap module samples
+    // black, blanking out every paletted COG tile.
+    const lutCall = device.createTexture.mock.calls.find(
+      ([opts]) => opts && (opts as { format?: string }).format === "rgba8unorm"
+    );
+    expect(lutCall).toBeDefined();
+    expect(lutCall![0]).toMatchObject({
+      dimension: "2d-array",
+      format: "rgba8unorm",
+      width: 256,
+      height: 1,
+      depth: 1,
+    });
+  });
 });

--- a/frontend/src/lib/layers/cogLayer.ts
+++ b/frontend/src/lib/layers/cogLayer.ts
@@ -159,12 +159,24 @@ export function buildCogLayerPaletted({
       sampler: { minFilter: "nearest", magFilter: "nearest" },
     });
 
+    // deck.gl-raster ≥0.6 expects the Colormap module's LUT as a 2d-array
+    // texture; a plain 2d texture sampler returns black, which made every
+    // categorical COG render fully dark after the 0.5→0.6 bump.
     const lutTex = device.createTexture({
+      dimension: "2d-array",
       data: lut,
       format: "rgba8unorm",
       width: 256,
       height: 1,
-      sampler: { minFilter: "nearest", magFilter: "nearest" },
+      depth: 1,
+      mipLevels: 1,
+      sampler: {
+        minFilter: "nearest",
+        magFilter: "nearest",
+        addressModeU: "clamp-to-edge",
+        addressModeV: "clamp-to-edge",
+        addressModeW: "clamp-to-edge",
+      },
     });
 
     // `raw` travels on the tile's data so the pixel inspector can sample it


### PR DESCRIPTION
## Summary

- `v1.31.0` bumped `@developmentseed/deck.gl-raster` from 0.5.x → 0.6.x (PR #391, alongside the new zarr renderer). The `Colormap` GPU module in 0.6 requires its LUT texture be created with `dimension: "2d-array"`. `zarrLayer.ts` was updated for this in the same PR; `cogLayer.ts`'s `buildCogLayerPaletted` was not.
- Result: every client-rendered categorical COG (e.g. the [NLCD 2024 example](https://cngsandbox.org/map/912564d7-aa10-4482-a85f-65878bfcb6a3)) sampled black against the new module — the tile bytes are correct, but the GPU LUT lookup returns 0.
- Fix copies the LUT texture spec from `zarrLayer.ts:57-72` onto `cogLayer.ts`'s paletted branch and adds a regression test asserting the call shape so this can't quietly recur.

## Test plan

- [ ] `cd frontend && npx vitest run` — full suite passes (685+1 new)
- [ ] `cd frontend && yarn build` — TS + Vite build clean
- [ ] After deploy, https://cngsandbox.org/map/912564d7-aa10-4482-a85f-65878bfcb6a3 renders the NLCD palette (greens / yellows / blues), not black
- [ ] Spot-check any other paletted/RAT example COG renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed texture configuration for categorical Cloud Optimized GeoTIFF tiles that was causing map layers to render incorrectly or fail to display properly.

* **Tests**
  * Added test to validate texture creation and configuration behavior when handling categorical geographic data with color mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->