### PR TITLE
fix(frontend): link example stories to edit page

### DIFF
--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -82,7 +82,7 @@ export default function StoriesPage() {
                 {exampleStories.map((story) => (
                   <Table.Row key={story.id}>
                     <Table.Cell>
-                      <Link to={workspacePath(`/story/${story.id}`)}>
+                      <Link to={workspacePath(`/story/${story.id}/edit`)}>
                         <Text
                           color="brand.orange"
                           _hover={{ textDecoration: "underline" }}


### PR DESCRIPTION
## Summary
- Example stories on the Stories page now link to the editor (`/story/:id/edit`) like user stories, instead of the read-only viewer.

## Test plan
- [ ] Open Stories page, click an example story title — confirm editor opens.
- [ ] Click a user story title — confirm editor still opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Example stories in the table now open in edit mode instead of view mode when selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->