### PR TITLE
feat(frontend): add global footer with attribution and key links

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import { Flex, Text } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
 import { GithubLogo } from "@phosphor-icons/react";
+import { useWorkspace } from "../hooks/useWorkspace";
 
 const GITHUB_URL = "https://github.com/aboydnw/cng-sandbox";
 const SECURITY_MAILTO = "mailto:security@developmentseed.org";
@@ -13,6 +14,7 @@ const linkStyle = {
 };
 
 export function Footer() {
+  const { workspacePath } = useWorkspace();
   return (
     <Flex
       as="footer"
@@ -42,7 +44,7 @@ export function Footer() {
         </a>
       </Text>
       <Flex align="center" gap={5}>
-        <Link to="/about" style={linkStyle}>
+        <Link to={workspacePath("/about")} style={linkStyle}>
           About
         </Link>
         <a

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -8,7 +8,7 @@ const SECURITY_MAILTO = "mailto:security@developmentseed.org";
 const DS_URL = "https://developmentseed.org/";
 
 const linkStyle = {
-  color: "var(--chakra-colors-gray-600)",
+  color: "var(--chakra-colors-brand-textSecondary)",
   fontSize: "var(--chakra-fontSizes-sm)",
   textDecoration: "none",
 };
@@ -28,7 +28,7 @@ export function Footer() {
       gap={6}
       flexWrap="wrap"
     >
-      <Text fontSize="sm" color="gray.600">
+      <Text fontSize="sm" color="brand.textSecondary">
         Built by{" "}
         <a
           href={DS_URL}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,69 @@
+import { Flex, Text } from "@chakra-ui/react";
+import { Link } from "react-router-dom";
+import { GithubLogo } from "@phosphor-icons/react";
+
+const GITHUB_URL = "https://github.com/aboydnw/cng-sandbox";
+const SECURITY_MAILTO = "mailto:security@developmentseed.org";
+const DS_URL = "https://developmentseed.org/";
+
+const linkStyle = {
+  color: "var(--chakra-colors-gray-600)",
+  fontSize: "var(--chakra-fontSizes-sm)",
+  textDecoration: "none",
+};
+
+export function Footer() {
+  return (
+    <Flex
+      as="footer"
+      align="center"
+      justify="space-between"
+      px={6}
+      py={4}
+      bg="white"
+      borderTop="1px solid"
+      borderColor="brand.border"
+      gap={6}
+      flexWrap="wrap"
+    >
+      <Text fontSize="sm" color="gray.600">
+        Built by{" "}
+        <a
+          href={DS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            color: "var(--chakra-colors-brand-orange)",
+            fontWeight: 600,
+            textDecoration: "none",
+          }}
+        >
+          Development Seed
+        </a>
+      </Text>
+      <Flex align="center" gap={5}>
+        <Link to="/about" style={linkStyle}>
+          About
+        </Link>
+        <a
+          href={GITHUB_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            ...linkStyle,
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+          aria-label="GitHub repository"
+        >
+          <GithubLogo size={16} weight="duotone" />
+          GitHub
+        </a>
+        <a href={SECURITY_MAILTO} style={linkStyle}>
+          Security
+        </a>
+      </Flex>
+    </Flex>
+  );
+}

--- a/frontend/src/components/__tests__/Footer.test.tsx
+++ b/frontend/src/components/__tests__/Footer.test.tsx
@@ -1,15 +1,25 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { ChakraProvider } from "@chakra-ui/react";
 import { describe, it, expect } from "vitest";
 import { system } from "../../theme";
+import { WorkspaceProvider } from "../../hooks/useWorkspace";
 import { Footer } from "../Footer";
 
 function renderFooter() {
   return render(
     <ChakraProvider value={system}>
-      <MemoryRouter>
-        <Footer />
+      <MemoryRouter initialEntries={["/w/test-workspace"]}>
+        <Routes>
+          <Route
+            path="/w/:workspaceId/*"
+            element={
+              <WorkspaceProvider>
+                <Footer />
+              </WorkspaceProvider>
+            }
+          />
+        </Routes>
       </MemoryRouter>
     </ChakraProvider>
   );
@@ -26,10 +36,10 @@ describe("Footer", () => {
     expect(link.getAttribute("rel")).toContain("noopener");
   });
 
-  it("links to the About page", () => {
+  it("links to the workspace-scoped About page", () => {
     renderFooter();
     const link = screen.getByRole("link", { name: /about/i });
-    expect(link.getAttribute("href")).toBe("/about");
+    expect(link.getAttribute("href")).toBe("/w/test-workspace/about");
   });
 
   it("links to the security mailto", () => {

--- a/frontend/src/components/__tests__/Footer.test.tsx
+++ b/frontend/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ChakraProvider } from "@chakra-ui/react";
+import { describe, it, expect } from "vitest";
+import { system } from "../../theme";
+import { Footer } from "../Footer";
+
+function renderFooter() {
+  return render(
+    <ChakraProvider value={system}>
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>
+    </ChakraProvider>
+  );
+}
+
+describe("Footer", () => {
+  it("links to the GitHub repo", () => {
+    renderFooter();
+    const link = screen.getByRole("link", { name: /github/i });
+    expect(link.getAttribute("href")).toBe(
+      "https://github.com/aboydnw/cng-sandbox"
+    );
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("links to the About page", () => {
+    renderFooter();
+    const link = screen.getByRole("link", { name: /about/i });
+    expect(link.getAttribute("href")).toBe("/about");
+  });
+
+  it("links to the security mailto", () => {
+    renderFooter();
+    const link = screen.getByRole("link", { name: /security/i });
+    expect(link.getAttribute("href")).toBe(
+      "mailto:security@developmentseed.org"
+    );
+  });
+
+  it("credits Development Seed", () => {
+    renderFooter();
+    const link = screen.getByRole("link", { name: /development seed/i });
+    expect(link.getAttribute("href")).toBe("https://developmentseed.org/");
+  });
+});

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -7,6 +7,7 @@ import {
   ArrowRight,
 } from "@phosphor-icons/react";
 import { Header } from "../components/Header";
+import { Footer } from "../components/Footer";
 
 const PIPELINE_STEPS = [
   {
@@ -262,6 +263,7 @@ export default function AboutPage() {
           </Text>
         </Box>
       </Box>
+      <Footer />
     </Box>
   );
 }

--- a/frontend/src/pages/DataPage.tsx
+++ b/frontend/src/pages/DataPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Box, Button, Flex, Heading, Table, Text } from "@chakra-ui/react";
 import { SpinnerGap } from "@phosphor-icons/react";
 import { Header } from "../components/Header";
+import { Footer } from "../components/Footer";
 import { useWorkspace } from "../hooks/useWorkspace";
 import { config } from "../config";
 import { workspaceFetch, connectionsApi } from "../lib/api";
@@ -390,6 +391,7 @@ export default function DataPage() {
           })()
         )}
       </Box>
+      <Footer />
     </Box>
   );
 }

--- a/frontend/src/pages/DiscoverDatasetPage.tsx
+++ b/frontend/src/pages/DiscoverDatasetPage.tsx
@@ -8,6 +8,7 @@ import { config } from "../config";
 import type { Dataset } from "../types";
 import { getCatalogEntry, listingUrlForSlug } from "../lib/discoverCatalog";
 import { DiscoverHeader } from "../components/discover/DiscoverHeader";
+import { Footer } from "../components/Footer";
 
 const PAGE_BG = "#fafaf8";
 const BORDER = "#e8e6e1";
@@ -60,6 +61,7 @@ export default function DiscoverDatasetPage() {
             Back to discover
           </Link>
         </Box>
+        <Footer />
       </Box>
     );
   }
@@ -351,6 +353,7 @@ export default function DiscoverDatasetPage() {
           </Box>
         </Flex>
       </Box>
+      <Footer />
     </Box>
   );
 }

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -157,6 +157,7 @@ export default function DiscoverPage() {
           </Text>
         </Box>
       </Box>
+      <Footer />
     </Box>
   );
 }
@@ -319,7 +320,6 @@ function CatalogCard({
           )}
         </Flex>
       </Box>
-      <Footer />
     </Box>
   );
 }

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -11,6 +11,7 @@ import {
   type CatalogEntry,
 } from "../lib/discoverCatalog";
 import { DiscoverHeader } from "../components/discover/DiscoverHeader";
+import { Footer } from "../components/Footer";
 
 const PAGE_BG = "#fafaf8";
 const CARD_BG = "#ffffff";
@@ -318,6 +319,7 @@ function CatalogCard({
           )}
         </Flex>
       </Box>
+      <Footer />
     </Box>
   );
 }

--- a/frontend/src/pages/ExpiredPage.tsx
+++ b/frontend/src/pages/ExpiredPage.tsx
@@ -10,13 +10,7 @@ export default function ExpiredPage() {
   return (
     <Flex direction="column" minH="100vh" bg="white">
       <Header />
-      <Flex
-        direction="column"
-        align="center"
-        justify="center"
-        flex="1"
-        px={8}
-      >
+      <Flex direction="column" align="center" justify="center" flex="1" px={8}>
         <Flex
           align="center"
           justify="center"

--- a/frontend/src/pages/ExpiredPage.tsx
+++ b/frontend/src/pages/ExpiredPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Box, Button, Flex, Text } from "@chakra-ui/react";
 import { Header } from "../components/Header";
+import { Footer } from "../components/Footer";
 import { useWorkspace } from "../hooks/useWorkspace";
 
 export default function ExpiredPage() {
@@ -70,6 +71,7 @@ export default function ExpiredPage() {
           </Button>
         </Flex>
       </Flex>
+      <Footer />
     </Box>
   );
 }

--- a/frontend/src/pages/ExpiredPage.tsx
+++ b/frontend/src/pages/ExpiredPage.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { Box, Button, Flex, Text } from "@chakra-ui/react";
+import { Button, Flex, Text } from "@chakra-ui/react";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
 import { useWorkspace } from "../hooks/useWorkspace";
@@ -8,13 +8,13 @@ export default function ExpiredPage() {
   const { workspacePath } = useWorkspace();
 
   return (
-    <Box minH="100vh" bg="white">
+    <Flex direction="column" minH="100vh" bg="white">
       <Header />
       <Flex
         direction="column"
         align="center"
         justify="center"
-        h="calc(100vh - 56px)"
+        flex="1"
         px={8}
       >
         <Flex
@@ -72,6 +72,6 @@ export default function ExpiredPage() {
         </Flex>
       </Flex>
       <Footer />
-    </Box>
+    </Flex>
   );
 }

--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Box, Button, Flex, Heading, Table, Text } from "@chakra-ui/react";
 import { SpinnerGap } from "@phosphor-icons/react";
 import { Header } from "../components/Header";
+import { Footer } from "../components/Footer";
 import { useWorkspace } from "../hooks/useWorkspace";
 import { listStoriesFromServer, deleteStoryFromServer } from "../lib/story/api";
 import type { Story } from "../lib/story/types";
@@ -201,6 +202,7 @@ export default function StoriesPage() {
           </Table.Root>
         )}
       </Box>
+      <Footer />
     </Box>
   );
 }

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useWorkspace } from "../hooks/useWorkspace";
 import { Box, Flex, Text } from "@chakra-ui/react";
 import { Header } from "../components/Header";
+import { Footer } from "../components/Footer";
 import { HomepageHero } from "../components/HomepageHero";
 import { PathCard } from "../components/PathCard";
 import { ProgressTracker } from "../components/ProgressTracker";
@@ -458,6 +459,8 @@ export default function UploadPage() {
           setConnectionError(null);
         }}
       />
+
+      <Footer />
     </Flex>
   );
 }

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -332,7 +332,7 @@ export default function UploadPage() {
   );
 
   return (
-    <Flex direction="column" h="100vh" bg="white" overflow="hidden">
+    <Flex direction="column" minH="100vh" bg="white">
       <Header />
       <HomepageHero />
 


### PR DESCRIPTION
## Summary
- New `Footer.tsx` component (Chakra Flex, brand tokens, Phosphor icons) credits Development Seed and links to GitHub, About, and a security mailto.
- Rendered on non-immersive pages: Upload, Data, Stories, About, Discover, DiscoverDataset, Expired. Immersive views (Map, Story Reader, Story Editor, Story Embed) intentionally omit it.
- Implementation plan: `Obsidian/Project Docs/CNG Sandbox/plans/2026-05-05-global-footer.md`.

## Test plan
- [x] Footer unit test asserts the four required links (GitHub, About, Security, Development Seed) — `frontend/src/components/__tests__/Footer.test.tsx`
- [x] Full frontend test suite passes (723/723)
- [x] Prettier clean
- [x] Visually verified Footer renders on Upload, Data, Stories, About, Discover pages
- [x] Visually verified Map page does NOT render Footer
- [ ] Reviewer: confirm Footer placement looks right alongside the existing layout, and weigh in on whether the AboutPage `v1.15.1` block should be removed in favor of putting the version in the Footer in a follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a responsive Footer with Development Seed credit and links to About, GitHub, and a security contact.
  * Footer integrated into multiple pages site-wide for consistent layout.

* **Tests**
  * Added unit tests to verify footer rendering and correctness of links across app layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->