### PR TITLE
feat(frontend): add Privacy & data section to About

### DIFF
--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -257,6 +257,103 @@ export default function AboutPage() {
           </Box>
         </Box>
 
+        <Box mb={10}>
+          <Heading size="md" color="gray.700" mb={2}>
+            Privacy & data
+          </Heading>
+          <Text color="gray.700" fontSize="sm" lineHeight="tall" mb={3}>
+            CNG Sandbox is a public demo. Here is how we treat the data you
+            upload and the activity you generate while using the site.
+          </Text>
+
+          <Text fontWeight={600} color="gray.800" fontSize="sm" mt={4} mb={1}>
+            Your uploads
+          </Text>
+          <Text color="gray.700" fontSize="sm" lineHeight="tall" mb={3}>
+            Files you upload are stored under a workspace ID generated for you.
+            Anyone with your workspace link can see the data in that workspace.
+            Don't upload anything you wouldn't want a stranger with the link to
+            see.
+          </Text>
+
+          <Text fontWeight={600} color="gray.800" fontSize="sm" mt={4} mb={1}>
+            Workspaces
+          </Text>
+          <Text color="gray.700" fontSize="sm" lineHeight="tall" mb={3}>
+            Workspaces and their data don't expire automatically today. We may
+            clean up unused workspaces in the future, with notice. To delete
+            your workspace on demand, email{" "}
+            <a
+              href="mailto:security@developmentseed.org"
+              style={{
+                color: "var(--chakra-colors-brand-orange)",
+                fontWeight: 600,
+              }}
+            >
+              security@developmentseed.org
+            </a>
+            .
+          </Text>
+
+          <Text fontWeight={600} color="gray.800" fontSize="sm" mt={4} mb={1}>
+            Analytics
+          </Text>
+          <Text color="gray.700" fontSize="sm" lineHeight="tall" mb={3}>
+            We use{" "}
+            <a
+              href="https://plausible.io/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: "var(--chakra-colors-brand-orange)",
+                fontWeight: 600,
+              }}
+            >
+              Plausible Analytics
+            </a>
+            , which is privacy-friendly and does not use cookies,
+            fingerprinting, or persistent identifiers. We track aggregate page
+            views and events; we do not see who you are.
+          </Text>
+
+          <Text fontWeight={600} color="gray.800" fontSize="sm" mt={4} mb={1}>
+            Account &amp; login
+          </Text>
+          <Text color="gray.700" fontSize="sm" lineHeight="tall" mb={3}>
+            There is no account system. We don't ask for your email, name, or
+            any other personal information.
+          </Text>
+
+          <Text fontWeight={600} color="gray.800" fontSize="sm" mt={4} mb={1}>
+            Source code &amp; security reports
+          </Text>
+          <Text color="gray.700" fontSize="sm" lineHeight="tall">
+            The full source for this site is open on{" "}
+            <a
+              href="https://github.com/aboydnw/cng-sandbox"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: "var(--chakra-colors-brand-orange)",
+                fontWeight: 600,
+              }}
+            >
+              GitHub
+            </a>
+            . Security reports:{" "}
+            <a
+              href="mailto:security@developmentseed.org"
+              style={{
+                color: "var(--chakra-colors-brand-orange)",
+                fontWeight: 600,
+              }}
+            >
+              security@developmentseed.org
+            </a>
+            .
+          </Text>
+        </Box>
+
         <Box mb={8}>
           <Text color="gray.500" fontSize="sm">
             v1.15.1

--- a/frontend/src/pages/__tests__/AboutPage.test.tsx
+++ b/frontend/src/pages/__tests__/AboutPage.test.tsx
@@ -66,4 +66,22 @@ describe("AboutPage", () => {
     );
     expect(footerLink).toBeTruthy();
   });
+
+  it("renders the privacy & data section", () => {
+    renderAbout();
+    expect(screen.getByText("Privacy & data")).toBeTruthy();
+    expect(screen.getByText(/Plausible/)).toBeTruthy();
+    expect(
+      screen.getByText(/no account system|don't ask for your email/i)
+    ).toBeTruthy();
+  });
+
+  it("links security reports to the security mailto", () => {
+    renderAbout();
+    const links = screen.getAllByRole("link");
+    const mailto = links.find((el) =>
+      el.getAttribute("href")?.startsWith("mailto:security@")
+    );
+    expect(mailto).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a "Privacy & data" section to the About page covering uploads, workspaces, analytics (Plausible), accounts, and security reports.
- Motivation: domain reputation engines look for a visible privacy statement when classifying a young domain that hosts an upload form. Its absence was a contributing signal in the cngsandbox.org phishing flag.
- Copy is the engineer's default from [the plan](../Obsidian/Project%20Docs/CNG%20Sandbox/plans/2026-05-05-about-page-privacy.md). **Anthony — please review and edit copy before merge.**

## Test plan
- [x] `npx vitest run src/pages/__tests__/AboutPage.test.tsx` — 7 passed
- [x] `npx prettier --check` — clean
- [x] Visual check on local Vite dev (`/w/test-ws/about`) — heading + 5 subsections render, links styled in `brand.orange`
- [ ] User to review copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Privacy & data" section to the About page with details on data handling, uploads, workspaces, analytics, account/login processes, and security contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->