### PR TITLE
chore(deploy): export only built static assets from frontend-build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -65,7 +65,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: frontend
-          target: builder
+          target: prod-export
           build-args: VITE_VIEWER_ORIGIN=${{ vars.VITE_VIEWER_ORIGIN }}
           push: true
           tags: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,14 +208,14 @@ services:
     image: ghcr.io/aboydnw/cng-sandbox/frontend-build:${IMAGE_TAG:-latest}
     build:
       context: frontend
-      target: builder
+      target: prod-export
       args:
         VITE_VIEWER_ORIGIN: ${VITE_VIEWER_ORIGIN:-}
     profiles:
       - prod
     volumes:
       - frontend_dist:/dist
-    command: ["sh", "-c", "rm -rf /dist/* && cp -a /app/dist/. /dist/"]
+    command: ["sh", "-c", "rm -rf /dist/* && cp -a /build/. /dist/"]
 
   caddy:
     image: caddy:2.11.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,7 +215,7 @@ services:
       - prod
     volumes:
       - frontend_dist:/dist
-    command: ["sh", "-c", "rm -rf /dist/* && cp -a /build/. /dist/"]
+    command: ["sh", "-c", "find /dist -mindepth 1 -delete && cp -a /build/. /dist/"]
 
   caddy:
     image: caddy:2.11.2

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,6 +24,8 @@ COPY public/ ./public/
 EXPOSE 5185
 CMD ["npx", "vite", "--host"]
 
-# --- Prod: static files only, served by Caddy ---
-FROM scratch AS prod
-COPY --from=builder /app/dist /dist
+# --- Prod-export: tiny image holding only built static assets, used by the
+# frontend-build compose service to copy files into the shared volume. Alpine
+# is used (rather than scratch) so the compose `command` has a shell. ---
+FROM alpine:3 AS prod-export
+COPY --from=builder /app/dist /build


### PR DESCRIPTION
## Summary
- The `frontend-build` compose service was targeting the `builder` stage, producing a **4.7GB** image (node_modules + source + dist). Even with every layer cached, exporting + unpacking it dominated prod build time (~90s exporting layers + ~24s unpacking).
- Add a tiny `prod-export` stage based on Alpine that carries only the built `/dist/` output (**28MB**). Point the compose service at it and adjust the `cp` command.
- Caddy still reads static files from the same shared `frontend_dist` volume; runtime behavior is unchanged.

## Expected impact
- Prod build wall time on cache hit: **~118s → ~15-20s** (the 90s+24s export/unpack collapses to <1s).
- The GHCR-pushed `frontend-build:latest` image shrinks by two orders of magnitude, reducing pull time on the Hetzner VM during deploy.

## Verified locally
- `docker build --target prod-export ./frontend` → 28.2MB image.
- Mounted a fresh volume and ran the new compose `command` — `index.html` and `assets/` land in the volume as expected, and a planted `.well-known/stale.txt` from a previous "deploy" is wiped.
- `docker compose -p wt-build-time-fixes --profile prod config` parses cleanly.
- Did **not** rebuild against the prod stack project per `CLAUDE.md`.

## Follow-up commits
- **Workflow alignment**: `release-please.yml` was still hardcoded to `target: builder`. Without this fix, the next deploy would have pulled a builder-stage image with dist at `/app/dist`, while the compose `command` now expects `/build/` — prod would have failed to repopulate `/srv/frontend`. Changed to `target: prod-export`.
- **CodeRabbit**: replaced `rm -rf /dist/*` with `find /dist -mindepth 1 -delete` so dotfiles/dot-directories are also wiped between deploys. Defensive — current Vite output ships no dotfiles.

## Out of scope (separate PR)
The `frontend` (Vite dev) service has no `profiles` field, so it currently runs in prod too — wasting ~3.6GB of unpack on every prod build and a Vite dev server in prod doing nothing (Caddy serves statics directly from the volume). Removing it cleanly requires moving dev workflows behind `--profile dev`, touching `README.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `mcp/README.md`, `.github/workflows/ci.yml`, and `scripts/worktree-stack.sh`. Worth doing as its own PR.

## Test plan
- [ ] CI `docker-build` and `conventional-commits` jobs pass.
- [ ] After merge + auto-deploy, confirm Hetzner deploy step takes noticeably less time and the site still serves the new SPA bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker build and CI workflow: the final packaging stage and asset export were changed, asset copy and cleanup steps were reordered to remove old artifacts before exporting, and the CI build target was updated to match the new packaging stage. These changes improve packaging consistency and deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->