### PR TITLE
feat(frontend): refresh About page copy and pin Footer to bottom

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import { GithubLogo } from "@phosphor-icons/react";
 import { useOptionalWorkspace } from "../hooks/useWorkspace";
 
 const GITHUB_URL = "https://github.com/aboydnw/cng-sandbox";
-const SECURITY_MAILTO = "mailto:security@developmentseed.org";
+const CONTACT_URL = "https://developmentseed.org/contact/";
 const DS_URL = "https://developmentseed.org/";
 
 const linkStyle = {
@@ -19,6 +19,7 @@ export function Footer() {
   return (
     <Flex
       as="footer"
+      mt="auto"
       align="center"
       justify="space-between"
       px={6}
@@ -63,8 +64,13 @@ export function Footer() {
           <GithubLogo size={16} weight="duotone" />
           GitHub
         </a>
-        <a href={SECURITY_MAILTO} style={linkStyle}>
-          Security
+        <a
+          href={CONTACT_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={linkStyle}
+        >
+          Contact Us
         </a>
       </Flex>
     </Flex>

--- a/frontend/src/components/__tests__/Footer.test.tsx
+++ b/frontend/src/components/__tests__/Footer.test.tsx
@@ -42,12 +42,14 @@ describe("Footer", () => {
     expect(link.getAttribute("href")).toBe("/w/test-workspace/about");
   });
 
-  it("links to the security mailto", () => {
+  it("links to the Development Seed contact page", () => {
     renderFooter();
-    const link = screen.getByRole("link", { name: /security/i });
+    const link = screen.getByRole("link", { name: /contact us/i });
     expect(link.getAttribute("href")).toBe(
-      "mailto:security@developmentseed.org"
+      "https://developmentseed.org/contact/"
     );
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
   });
 
   it("credits Development Seed", () => {

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -97,7 +97,7 @@ const OPEN_SOURCE_STACK = [
 
 export default function AboutPage() {
   return (
-    <Box minH="100vh" bg="gray.50">
+    <Flex direction="column" minH="100vh" bg="gray.50">
       <Header />
       <Box maxW="960px" mx="auto" py={8} px={4}>
         <Box mb={10}>
@@ -271,28 +271,30 @@ export default function AboutPage() {
           </Text>
           <Text color="gray.700" fontSize="sm" lineHeight="tall" mb={3}>
             Files you upload are stored under a workspace ID generated for you.
-            Anyone with your workspace link can see the data in that workspace.
-            Don't upload anything you wouldn't want a stranger with the link to
-            see.
+            To protect from data storage costs, datasets have an expiration
+            policy of 30 days from the time of upload. If you would like to
+            explore a more permanent data storage solution, please reach out to{" "}
+            <a
+              href="mailto:info@developmentseed.org"
+              style={{
+                color: "var(--chakra-colors-brand-orange)",
+                fontWeight: 600,
+              }}
+            >
+              info@developmentseed.org
+            </a>
+            .
           </Text>
 
           <Text fontWeight={600} color="gray.800" fontSize="sm" mt={4} mb={1}>
             Workspaces
           </Text>
           <Text color="gray.700" fontSize="sm" lineHeight="tall" mb={3}>
-            Workspaces and their data don't expire automatically today. We may
-            clean up unused workspaces in the future, with notice. To delete
-            your workspace on demand, email{" "}
-            <a
-              href="mailto:security@developmentseed.org"
-              style={{
-                color: "var(--chakra-colors-brand-orange)",
-                fontWeight: 600,
-              }}
-            >
-              security@developmentseed.org
-            </a>
-            .
+            You are automatically assigned a unique workspace code. This allows
+            you to share your work with collaborators, but only if you directly
+            share the URL or workspace ID with them. Workspaces do not
+            automatically expire, although uploaded datasets inside workspaces
+            will expire to the policy listed above.
           </Text>
 
           <Text fontWeight={600} color="gray.800" fontSize="sm" mt={4} mb={1}>
@@ -325,7 +327,7 @@ export default function AboutPage() {
           </Text>
 
           <Text fontWeight={600} color="gray.800" fontSize="sm" mt={4} mb={1}>
-            Source code &amp; security reports
+            Source code
           </Text>
           <Text color="gray.700" fontSize="sm" lineHeight="tall">
             The full source for this site is open on{" "}
@@ -340,27 +342,27 @@ export default function AboutPage() {
             >
               GitHub
             </a>
-            . Security reports:{" "}
-            <a
-              href="mailto:security@developmentseed.org"
-              style={{
-                color: "var(--chakra-colors-brand-orange)",
-                fontWeight: 600,
-              }}
-            >
-              security@developmentseed.org
-            </a>
             .
           </Text>
         </Box>
 
         <Box mb={8}>
           <Text color="gray.500" fontSize="sm">
-            v1.15.1
+            <a
+              href="https://github.com/aboydnw/cng-sandbox/releases"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: "var(--chakra-colors-brand-orange)",
+                fontWeight: 600,
+              }}
+            >
+              v{__APP_VERSION__}
+            </a>
           </Text>
         </Box>
       </Box>
       <Footer />
-    </Box>
+    </Flex>
   );
 }

--- a/frontend/src/pages/DataPage.tsx
+++ b/frontend/src/pages/DataPage.tsx
@@ -96,7 +96,7 @@ export default function DataPage() {
   }, []);
 
   return (
-    <Box minH="100vh" bg="gray.50">
+    <Flex direction="column" minH="100vh" bg="gray.50">
       <Header />
       <Box maxW="960px" mx="auto" py={8} px={4}>
         <Flex justify="space-between" align="center" mb={6}>
@@ -392,6 +392,6 @@ export default function DataPage() {
         )}
       </Box>
       <Footer />
-    </Box>
+    </Flex>
   );
 }

--- a/frontend/src/pages/DiscoverDatasetPage.tsx
+++ b/frontend/src/pages/DiscoverDatasetPage.tsx
@@ -42,7 +42,7 @@ export default function DiscoverDatasetPage() {
 
   if (!entry) {
     return (
-      <Box minH="100vh" bg={PAGE_BG} color={TEXT}>
+      <Flex direction="column" minH="100vh" bg={PAGE_BG} color={TEXT}>
         <DiscoverHeader />
         <Box maxW="1100px" mx="auto" px={6} py={16} textAlign="center">
           <Heading fontSize="28px" fontWeight={600} mb={2}>
@@ -62,7 +62,7 @@ export default function DiscoverDatasetPage() {
           </Link>
         </Box>
         <Footer />
-      </Box>
+      </Flex>
     );
   }
 
@@ -81,7 +81,7 @@ export default function DiscoverDatasetPage() {
   };
 
   return (
-    <Box minH="100vh" bg={PAGE_BG} color={TEXT}>
+    <Flex direction="column" minH="100vh" bg={PAGE_BG} color={TEXT}>
       <DiscoverHeader />
 
       <Box maxW="1100px" mx="auto" px={6} pt={8} pb={20}>
@@ -354,7 +354,7 @@ export default function DiscoverDatasetPage() {
         </Flex>
       </Box>
       <Footer />
-    </Box>
+    </Flex>
   );
 }
 

--- a/frontend/src/pages/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage.tsx
@@ -58,7 +58,7 @@ export default function DiscoverPage() {
   };
 
   return (
-    <Box minH="100vh" bg={PAGE_BG} color={TEXT}>
+    <Flex direction="column" minH="100vh" bg={PAGE_BG} color={TEXT}>
       <DiscoverHeader />
 
       <Box maxW="1100px" mx="auto" px={6} pt={10} pb={6}>
@@ -158,7 +158,7 @@ export default function DiscoverPage() {
         </Box>
       </Box>
       <Footer />
-    </Box>
+    </Flex>
   );
 }
 

--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -49,7 +49,7 @@ export default function StoriesPage() {
   const userStories = stories.filter((s) => !s.is_example);
 
   return (
-    <Box minH="100vh" bg="gray.50">
+    <Flex direction="column" minH="100vh" bg="gray.50">
       <Header />
       <Box maxW="960px" mx="auto" py={8} px={4}>
         <Flex justify="space-between" align="center" mb={6}>
@@ -203,6 +203,6 @@ export default function StoriesPage() {
         )}
       </Box>
       <Footer />
-    </Box>
+    </Flex>
   );
 }

--- a/frontend/src/pages/__tests__/AboutPage.test.tsx
+++ b/frontend/src/pages/__tests__/AboutPage.test.tsx
@@ -76,12 +76,20 @@ describe("AboutPage", () => {
     ).toBeTruthy();
   });
 
-  it("links security reports to the security mailto", () => {
+  it("links the uploads policy to the info mailto", () => {
     renderAbout();
     const links = screen.getAllByRole("link");
-    const mailto = links.find((el) =>
-      el.getAttribute("href")?.startsWith("mailto:security@")
+    const mailto = links.find(
+      (el) => el.getAttribute("href") === "mailto:info@developmentseed.org"
     );
     expect(mailto).toBeTruthy();
+  });
+
+  it("links the version to the GitHub releases page", () => {
+    renderAbout();
+    const link = screen.getByText(new RegExp(`^v${__APP_VERSION__}$`));
+    expect(link.closest("a")?.getAttribute("href")).toBe(
+      "https://github.com/aboydnw/cng-sandbox/releases"
+    );
   });
 });

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __APP_VERSION__: string;
+
 declare module "*.csv?raw" {
   const content: string;
   export default content;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,20 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { defineConfig, mergeConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { sharedConfig } from "./vite.shared.config";
 
+const appVersion = readFileSync(
+  resolve(__dirname, "..", "version.txt"),
+  "utf8"
+).trim();
+
 export default defineConfig(
   mergeConfig(sharedConfig, {
     plugins: [react()],
+    define: {
+      __APP_VERSION__: JSON.stringify(appVersion),
+    },
     build: {
       target: "esnext",
     },


### PR DESCRIPTION
## Summary

- **Workspaces section** now reads: "You are automatically assigned a unique workspace code…" and explains that workspaces don't expire but uploaded datasets do.
- **Your uploads section** now reads: "Files you upload are stored under a workspace ID generated for you. To protect from data storage costs, datasets have an expiration policy of 30 days…" with a `mailto:info@developmentseed.org` link.
- **Source code section**: dropped "& security reports" from the heading and removed the trailing `security@developmentseed.org` line.
- **Version**: the v1.15.1 hardcode is replaced with the value from `version.txt` (release-please bumps this on every release), wired through Vite's `define` config and exposed as `__APP_VERSION__`. The version label now links to the GitHub releases page.
- **Footer**: "Security" link replaced with "Contact Us" → https://developmentseed.org/contact/.
- **Footer pinning**: the footer was floating mid-page on short pages because the page wrappers were not flex columns. Added `mt="auto"` to the Footer and converted the outer wrappers of About, Data, Stories, Discover, and DiscoverDataset pages to `Flex direction="column" minH="100vh"`. UploadPage / ExpiredPage / LandingPage already used the right pattern; they now benefit from `mt="auto"` too.

## Test plan
- [ ] About page shows the new Workspaces / Your uploads / Source code copy and a clickable v2.0.0 that opens the GitHub releases page in a new tab.
- [ ] Footer shows "Contact Us" linking to https://developmentseed.org/contact/ in a new tab.
- [ ] Footer is pinned to the viewport bottom on the landing page and other short pages, and sits at the end of content on long pages (About, Data, etc).
- [ ] `cd frontend && npx vitest run` is green for AboutPage and Footer tests.
- [ ] `npx prettier --check 'src/**/*.{ts,tsx,css}'` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic version display now shows live app version on the About page

* **Content Updates**
  * Footer: Replaced Security link with Contact Us link
  * About page: Added 30-day expiration policy for uploaded datasets; clarified workspace sharing and deletion details; updated section headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->