### PR TITLE
feat(frontend): refocus landing on storytelling, add workspace switcher menu

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,8 +1,12 @@
-import { Flex, Text } from "@chakra-ui/react";
-import { Link } from "react-router-dom";
+import { Flex, Menu, Portal, Text } from "@chakra-ui/react";
+import { Link, useNavigate } from "react-router-dom";
 import type { ReactNode } from "react";
-import { useState, useCallback } from "react";
-import { useOptionalWorkspace } from "../hooks/useWorkspace";
+import { useState, useCallback, useEffect } from "react";
+import { CaretDown, Check } from "@phosphor-icons/react";
+import {
+  useOptionalWorkspace,
+  WORKSPACE_STORAGE_KEY,
+} from "../hooks/useWorkspace";
 
 interface HeaderProps {
   children?: ReactNode;
@@ -11,7 +15,16 @@ interface HeaderProps {
 
 export function Header({ children, showWorkspace = true }: HeaderProps) {
   const workspace = useOptionalWorkspace();
+  const navigate = useNavigate();
   const [copied, setCopied] = useState(false);
+  const [isPrimary, setIsPrimary] = useState(false);
+
+  useEffect(() => {
+    if (!workspace) return;
+    setIsPrimary(
+      localStorage.getItem(WORKSPACE_STORAGE_KEY) === workspace.workspaceId
+    );
+  }, [workspace]);
 
   const homeHref = workspace ? workspace.workspacePath("/") : "/";
   const dataHref = workspace ? workspace.workspacePath("/data") : null;
@@ -25,6 +38,16 @@ export function Header({ children, showWorkspace = true }: HeaderProps) {
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }, [workspace]);
+
+  const makePrimary = useCallback(() => {
+    if (!workspace) return;
+    localStorage.setItem(WORKSPACE_STORAGE_KEY, workspace.workspaceId);
+    setIsPrimary(true);
+  }, [workspace]);
+
+  const changeWorkspaces = useCallback(() => {
+    navigate("/?switch=1");
+  }, [navigate]);
 
   return (
     <Flex
@@ -93,23 +116,90 @@ export function Header({ children, showWorkspace = true }: HeaderProps) {
         </Link>
       </Flex>
       {showWorkspace && workspace && (
-        <Flex
-          align="center"
-          gap={1}
-          px={2}
-          py={1}
-          borderRadius="md"
-          bg="gray.100"
-          cursor="pointer"
-          onClick={copyWorkspaceUrl}
-          title="Click to copy workspace link"
-          fontSize="xs"
-          color="gray.500"
-        >
-          <Text>
-            {copied ? "Copied!" : `Workspace ${workspace.workspaceId}`}
-          </Text>
-        </Flex>
+        <Menu.Root>
+          <Menu.Trigger asChild>
+            <Flex
+              align="center"
+              gap={1}
+              px={2}
+              py={1}
+              borderRadius="md"
+              bg="gray.100"
+              cursor="pointer"
+              fontSize="xs"
+              color="gray.500"
+              _hover={{ bg: "gray.200" }}
+              aria-label="Workspace menu"
+            >
+              <Text>
+                {copied ? "Copied!" : `Workspace ${workspace.workspaceId}`}
+              </Text>
+              <CaretDown size={10} />
+            </Flex>
+          </Menu.Trigger>
+          <Portal>
+            <Menu.Positioner>
+              <Menu.Content
+                bg="white"
+                border="1px solid"
+                borderColor="brand.border"
+                borderRadius="8px"
+                boxShadow="md"
+                py={1}
+                minW="220px"
+                fontSize="sm"
+              >
+                <Menu.Item
+                  value="copy-link"
+                  onClick={copyWorkspaceUrl}
+                  px={3}
+                  py={2}
+                  cursor="pointer"
+                  _hover={{ bg: "brand.bgSubtle" }}
+                >
+                  Copy workspace link
+                </Menu.Item>
+                {!isPrimary && (
+                  <Menu.Item
+                    value="make-primary"
+                    onClick={makePrimary}
+                    px={3}
+                    py={2}
+                    cursor="pointer"
+                    _hover={{ bg: "brand.bgSubtle" }}
+                  >
+                    Make this my primary workspace
+                  </Menu.Item>
+                )}
+                {isPrimary && (
+                  <Menu.Item
+                    value="is-primary"
+                    disabled
+                    px={3}
+                    py={2}
+                    color="gray.500"
+                  >
+                    <Flex align="center" gap={2}>
+                      <Check size={14} weight="bold" />
+                      <Text>Primary workspace</Text>
+                    </Flex>
+                  </Menu.Item>
+                )}
+                <Menu.Separator borderColor="brand.border" my={1} />
+                <Menu.Item
+                  value="change-workspace"
+                  onClick={changeWorkspaces}
+                  px={3}
+                  py={2}
+                  cursor="pointer"
+                  _hover={{ bg: "brand.bgSubtle" }}
+                >
+                  Change workspaces
+                </Menu.Item>
+              </Menu.Content>
+            </Menu.Positioner>
+          </Portal>
+        </Menu.Root>
       )}
       {children && (
         <Flex

--- a/frontend/src/components/__tests__/Header.test.tsx
+++ b/frontend/src/components/__tests__/Header.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Header } from "../Header";
 import { ChakraProvider } from "@chakra-ui/react";
 import { system } from "../../theme";
@@ -74,5 +75,53 @@ describe("Header (public, no workspace)", () => {
     const links = screen.getAllByRole("link");
     const home = links.find((el) => el.getAttribute("href") === "/");
     expect(home).toBeTruthy();
+  });
+});
+
+describe("Header workspace menu", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("opens a menu with copy / make-primary / change items when not yet primary", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Header />);
+    await user.click(screen.getByLabelText(/workspace menu/i));
+    expect(
+      await screen.findByRole("menuitem", { name: /copy workspace link/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", {
+        name: /make this my primary workspace/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /change workspaces/i })
+    ).toBeInTheDocument();
+  });
+
+  it("hides 'make primary' when this workspace is already the primary", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem("myWorkspaceId", "test-workspace");
+    renderWithProviders(<Header />);
+    await user.click(screen.getByLabelText(/workspace menu/i));
+    await screen.findByRole("menuitem", { name: /copy workspace link/i });
+    expect(
+      screen.queryByRole("menuitem", {
+        name: /make this my primary workspace/i,
+      })
+    ).toBeNull();
+    expect(screen.getByText(/^primary workspace$/i)).toBeInTheDocument();
+  });
+
+  it("writes the workspace id to localStorage when 'make primary' is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Header />);
+    await user.click(screen.getByLabelText(/workspace menu/i));
+    const item = await screen.findByRole("menuitem", {
+      name: /make this my primary workspace/i,
+    });
+    await user.click(item);
+    expect(localStorage.getItem("myWorkspaceId")).toBe("test-workspace");
   });
 });

--- a/frontend/src/hooks/useWorkspace.tsx
+++ b/frontend/src/hooks/useWorkspace.tsx
@@ -8,7 +8,8 @@ import {
 import { useParams, Navigate, useLocation } from "react-router-dom";
 import { setWorkspaceId } from "../lib/api";
 
-const STORAGE_KEY = "myWorkspaceId";
+export const WORKSPACE_STORAGE_KEY = "myWorkspaceId";
+const STORAGE_KEY = WORKSPACE_STORAGE_KEY;
 
 export function generateWorkspaceId(): string {
   const chars = "abcdefghijklmnopqrstuvwxyz0123456789";

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,16 +1,29 @@
-import { useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { Box, Button, Flex, Heading, Input, Text } from "@chakra-ui/react";
 import { ArrowRight, Rocket } from "@phosphor-icons/react";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
-import { generateWorkspaceId } from "../hooks/useWorkspace";
+import {
+  generateWorkspaceId,
+  WORKSPACE_STORAGE_KEY,
+} from "../hooks/useWorkspace";
 
-const STORAGE_KEY = "myWorkspaceId";
+const STORAGE_KEY = WORKSPACE_STORAGE_KEY;
 
 export default function LandingPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const switching = searchParams.get("switch") === "1";
   const [enteredId, setEnteredId] = useState("");
+
+  useEffect(() => {
+    if (switching) return;
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      navigate(`/w/${stored}/`, { replace: true });
+    }
+  }, [switching, navigate]);
 
   const createWorkspace = () => {
     const id = generateWorkspaceId();
@@ -60,10 +73,10 @@ export default function LandingPage() {
             CNG Sandbox
           </Heading>
           <Text color="gray.700" fontSize="md" lineHeight="tall" mb={8}>
-            A playground for the cloud-native geospatial stack. Upload a
-            GeoTIFF, GeoJSON, Shapefile, NetCDF, or HDF5 file and watch it get
-            converted, tiled, and rendered as an interactive map &mdash; in
-            seconds, in your browser.
+            Build interactive maps and stories from open geospatial data. Pull
+            from curated source.coop datasets, connect to other open data
+            sources, or upload your own files to see them tiled and visualized
+            in cloud-native formats.
           </Text>
 
           <Button
@@ -75,7 +88,7 @@ export default function LandingPage() {
             w="full"
             mb={4}
           >
-            Create a new workspace
+            Start Building
           </Button>
 
           <Box

--- a/frontend/src/pages/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/__tests__/LandingPage.test.tsx
@@ -10,10 +10,10 @@ function WorkspaceTarget() {
   return <div data-testid="workspace-target" data-workspace-id={workspaceId} />;
 }
 
-function renderLanding() {
+function renderLanding(initialEntry: string = "/") {
   return render(
     <ChakraProvider value={system}>
-      <MemoryRouter initialEntries={["/"]}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/w/:workspaceId/*" element={<WorkspaceTarget />} />
@@ -34,15 +34,31 @@ describe("LandingPage", () => {
       screen.getByRole("heading", { name: /CNG Sandbox/ })
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/cloud-native geospatial|upload.*GeoTIFF/i)
+      screen.getByText(/interactive maps and stories|source\.coop/i)
     ).toBeTruthy();
   });
 
   it("creates a new workspace when the primary CTA is clicked", () => {
     renderLanding();
-    const cta = screen.getByRole("button", { name: /create.*workspace/i });
+    const cta = screen.getByRole("button", { name: /start building/i });
     fireEvent.click(cta);
     expect(screen.getByTestId("workspace-target")).toBeInTheDocument();
+  });
+
+  it("auto-redirects to a stored workspace when one exists in localStorage", () => {
+    localStorage.setItem("myWorkspaceId", "stored123");
+    renderLanding();
+    const target = screen.getByTestId("workspace-target");
+    expect(target).toHaveAttribute("data-workspace-id", "stored123");
+  });
+
+  it("does not auto-redirect when ?switch=1 is set, even if a workspace is stored", () => {
+    localStorage.setItem("myWorkspaceId", "stored123");
+    renderLanding("/?switch=1");
+    expect(screen.queryByTestId("workspace-target")).toBeNull();
+    expect(
+      screen.getByRole("heading", { name: /CNG Sandbox/ })
+    ).toBeInTheDocument();
   });
 
   it("navigates to an existing workspace when the user submits an ID", () => {

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,1 +1,9 @@
 import "@testing-library/jest-dom";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}


### PR DESCRIPTION
## Summary

- Rewrites the landing-page copy to lead with **story building** (source.coop datasets, connections, your own uploads) instead of file conversion, and renames the primary CTA `Create a new workspace` → `Start Building`.
- Auto-redirects `/` to the workspace stored in `localStorage.myWorkspaceId` so returning users skip the landing page. Visiting `/?switch=1` disables the redirect so the picker is still reachable.
- Replaces the header workspace pill (which previously only copied a link on click) with a dropdown menu containing **Copy workspace link**, **Make this my primary workspace** (writes to localStorage), and **Change workspaces** (sends the user to `/?switch=1`). When the current workspace is already primary, the menu shows a disabled `Primary workspace` indicator instead.

## Test plan

- [x] `yarn tsc --noEmit`
- [x] `yarn prettier --check` on all touched files
- [x] `yarn test` — 745/745 passing (3 new LandingPage cases, 3 new Header cases)
- [x] Manual smoke (vite dev + Playwright):
  - [x] Fresh visitor sees landing page at `/`
  - [x] Returning visitor with `myWorkspaceId` in localStorage gets auto-redirected to `/w/<id>/`
  - [x] Header pill opens menu; primary workspace shows ✓ indicator, non-primary shows the make-primary action
  - [x] Clicking **Make this my primary workspace** writes the id to localStorage and switches the menu to the primary state
  - [x] Clicking **Change workspaces** navigates to `/?switch=1` and the landing page renders (no auto-redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace selection menu in header with options to copy link, set as primary, and switch workspaces
  * Landing page now auto-navigates to your previously selected workspace
  
* **Updates**
  * Landing page hero text updated to highlight building interactive maps with geospatial data
  * Primary call-to-action button text changed to "Start Building"

* **Tests**
  * Added test coverage for workspace menu functionality and landing page routing behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->