### PR TITLE
feat(workspace): make Stories the workspace home (storytelling pivot 1/5)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,16 +34,22 @@ function LibraryRedirect() {
   return <Navigate to={workspacePath("/data")} replace />;
 }
 
+function StoriesRedirect() {
+  const { workspacePath } = useWorkspace();
+  return <Navigate to={workspacePath("/")} replace />;
+}
+
 function WorkspaceRoutes() {
   return (
     <WorkspaceProvider>
       <Routes>
-        <Route path="/" element={<UploadPage />} />
+        <Route path="/" element={<StoriesPage />} />
+        <Route path="/quick-map" element={<UploadPage />} />
         <Route path="/map/:id" element={<MapPage />} />
         <Route path="/map/connection/:id" element={<MapPage />} />
         <Route path="/expired/:id" element={<ExpiredPage />} />
         <Route path="/data" element={<DataPage />} />
-        <Route path="/stories" element={<StoriesPage />} />
+        <Route path="/stories" element={<StoriesRedirect />} />
         <Route path="/library" element={<LibraryRedirect />} />
         <Route path="/datasets" element={<DatasetsRedirect />} />
         <Route path="/story/new" element={<StoryEditorPage />} />

--- a/frontend/src/__tests__/App.routing.test.tsx
+++ b/frontend/src/__tests__/App.routing.test.tsx
@@ -27,6 +27,10 @@ vi.mock("../pages/UploadPage", () => ({
   default: () => <div data-testid="upload-page" />,
 }));
 
+vi.mock("../pages/StoriesPage", () => ({
+  default: () => <div data-testid="stories-page" />,
+}));
+
 vi.mock("../pages/LibraryPage", () => ({
   default: () => <div data-testid="library-page" />,
 }));
@@ -88,9 +92,19 @@ test("/about renders the public AboutPage without a workspace", () => {
   expect(screen.getByTestId("about-page")).toBeInTheDocument();
 });
 
-test("/w/:workspaceId/ still renders the workspace UploadPage", () => {
+test("/w/:workspaceId/ renders the workspace StoriesPage", () => {
   renderApp("/w/abc12345/");
+  expect(screen.getByTestId("stories-page")).toBeInTheDocument();
+});
+
+test("/w/:workspaceId/quick-map renders the workspace UploadPage", () => {
+  renderApp("/w/abc12345/quick-map");
   expect(screen.getByTestId("upload-page")).toBeInTheDocument();
+});
+
+test("/w/:workspaceId/stories redirects to workspace root", () => {
+  renderApp("/w/abc12345/stories");
+  expect(screen.getByTestId("stories-page")).toBeInTheDocument();
 });
 
 test("unknown public path falls through to WorkspaceRedirect", () => {

--- a/frontend/src/components/ExampleStoryCard.tsx
+++ b/frontend/src/components/ExampleStoryCard.tsx
@@ -1,0 +1,73 @@
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { Link } from "react-router-dom";
+
+export interface ExampleStoryCardProps {
+  title: string;
+  chapterCount: number;
+  dataType: string;
+  href: string;
+  compact?: boolean;
+}
+
+function gradientForTitle(title: string): string {
+  let hash = 0;
+  for (let i = 0; i < title.length; i++) {
+    hash = (hash * 31 + title.charCodeAt(i)) >>> 0;
+  }
+  const palettes: Array<[string, string]> = [
+    ["#3a6b8c", "#79a8c2"],
+    ["#7a4a18", "#d0a878"],
+    ["#2c5e3a", "#7fbf90"],
+    ["#5b3a8c", "#a079c2"],
+    ["#8c3a5e", "#c279a0"],
+  ];
+  const [from, to] = palettes[hash % palettes.length];
+  return `linear-gradient(135deg, ${from}, ${to})`;
+}
+
+export function ExampleStoryCard({
+  title,
+  chapterCount,
+  dataType,
+  href,
+  compact = false,
+}: ExampleStoryCardProps) {
+  const subtitle = `${dataType} · ${chapterCount} ${
+    chapterCount === 1 ? "chapter" : "chapters"
+  }`;
+  return (
+    <Link to={href} style={{ textDecoration: "none" }}>
+      <Flex
+        direction="column"
+        border="1px solid"
+        borderColor="brand.border"
+        borderRadius="6px"
+        overflow="hidden"
+        bg="white"
+        _hover={{ borderColor: "brand.orange" }}
+        transition="border-color 0.15s"
+      >
+        <Box
+          h={compact ? "46px" : "90px"}
+          style={{ background: gradientForTitle(title) }}
+        />
+        <Box px={3} py={2}>
+          <Text
+            fontWeight={600}
+            fontSize={compact ? "12px" : "14px"}
+            color="brand.brown"
+            truncate
+            title={title}
+          >
+            {title}
+          </Text>
+          {!compact && (
+            <Text fontSize="11px" color="gray.500" mt={1}>
+              {subtitle}
+            </Text>
+          )}
+        </Box>
+      </Flex>
+    </Link>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -80,18 +80,6 @@ export function Header({ children, showWorkspace = true }: HeaderProps) {
             </Text>
           </Flex>
         </Link>
-        {dataHref && (
-          <Link to={dataHref} style={{ textDecoration: "none" }}>
-            <Text
-              fontSize="sm"
-              fontWeight={500}
-              color="brand.brown"
-              _hover={{ color: "brand.orange" }}
-            >
-              Data
-            </Text>
-          </Link>
-        )}
         {storiesHref && (
           <Link to={storiesHref} style={{ textDecoration: "none" }}>
             <Text
@@ -101,6 +89,18 @@ export function Header({ children, showWorkspace = true }: HeaderProps) {
               _hover={{ color: "brand.orange" }}
             >
               Stories
+            </Text>
+          </Link>
+        )}
+        {dataHref && (
+          <Link to={dataHref} style={{ textDecoration: "none" }}>
+            <Text
+              fontSize="sm"
+              fontWeight={500}
+              color="brand.brown"
+              _hover={{ color: "brand.orange" }}
+            >
+              Data
             </Text>
           </Link>
         )}
@@ -114,6 +114,36 @@ export function Header({ children, showWorkspace = true }: HeaderProps) {
             About
           </Text>
         </Link>
+      </Flex>
+      <Flex align="center" gap={4} ml="auto" mr={3}>
+        <a
+          href="https://github.com/aboydnw/cng-sandbox"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ textDecoration: "none" }}
+        >
+          <Text
+            fontSize="sm"
+            fontWeight={500}
+            color="gray.600"
+            _hover={{ color: "gray.800" }}
+          >
+            GitHub
+          </Text>
+        </a>
+        <a
+          href="mailto:info@developmentseed.org"
+          style={{ textDecoration: "none" }}
+        >
+          <Text
+            fontSize="sm"
+            fontWeight={500}
+            color="gray.600"
+            _hover={{ color: "gray.800" }}
+          >
+            Contact
+          </Text>
+        </a>
       </Flex>
       {showWorkspace && workspace && (
         <Menu.Root>

--- a/frontend/src/components/__tests__/ExampleStoryCard.test.tsx
+++ b/frontend/src/components/__tests__/ExampleStoryCard.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../../theme";
+import { ExampleStoryCard } from "../ExampleStoryCard";
+
+function renderCard(props: React.ComponentProps<typeof ExampleStoryCard>) {
+  return render(
+    <ChakraProvider value={system}>
+      <MemoryRouter>
+        <ExampleStoryCard {...props} />
+      </MemoryRouter>
+    </ChakraProvider>
+  );
+}
+
+describe("ExampleStoryCard", () => {
+  it("renders the story title", () => {
+    renderCard({
+      title: "Arctic ice loss",
+      chapterCount: 4,
+      dataType: "Raster",
+      href: "/w/x/story/abc/edit",
+    });
+    expect(screen.getByText("Arctic ice loss")).toBeInTheDocument();
+  });
+
+  it("renders the data-type and chapter-count subtitle", () => {
+    renderCard({
+      title: "Arctic ice loss",
+      chapterCount: 4,
+      dataType: "Raster",
+      href: "/w/x/story/abc/edit",
+    });
+    expect(screen.getByText(/raster · 4 chapters/i)).toBeInTheDocument();
+  });
+
+  it("links to the given href", () => {
+    renderCard({
+      title: "T",
+      chapterCount: 1,
+      dataType: "Vector",
+      href: "/w/x/story/abc/edit",
+    });
+    const link = screen.getByRole("link", { name: /t/i });
+    expect(link.getAttribute("href")).toBe("/w/x/story/abc/edit");
+  });
+
+  it("uses singular 'chapter' when chapterCount is 1", () => {
+    renderCard({
+      title: "T",
+      chapterCount: 1,
+      dataType: "Vector",
+      href: "/x",
+    });
+    expect(screen.getByText(/vector · 1 chapter$/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/Header.test.tsx
+++ b/frontend/src/components/__tests__/Header.test.tsx
@@ -78,6 +78,47 @@ describe("Header (public, no workspace)", () => {
   });
 });
 
+describe("Header nav order", () => {
+  it("renders Stories before Data in the nav", () => {
+    renderWithProviders(<Header />);
+    const stories = screen.getByRole("link", { name: /^stories$/i });
+    const data = screen.getByRole("link", { name: /^data$/i });
+    const cmp = stories.compareDocumentPosition(data);
+    expect(cmp & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});
+
+describe("Header utility links", () => {
+  it("renders a GitHub link pointing at the cng-sandbox repo", () => {
+    renderWithProviders(<Header />);
+    const link = screen.getByRole("link", { name: /github/i });
+    expect(link.getAttribute("href")).toBe(
+      "https://github.com/aboydnw/cng-sandbox"
+    );
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("renders a Contact link pointing at the DevSeed info mailto", () => {
+    renderWithProviders(<Header />);
+    const link = screen.getByRole("link", { name: /contact/i });
+    expect(link.getAttribute("href")).toBe("mailto:info@developmentseed.org");
+  });
+
+  it("renders the GitHub and Contact links on the public (no-workspace) header too", () => {
+    render(
+      <ChakraProvider value={system}>
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route path="/" element={<Header />} />
+          </Routes>
+        </MemoryRouter>
+      </ChakraProvider>
+    );
+    expect(screen.getByRole("link", { name: /github/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /contact/i })).toBeInTheDocument();
+  });
+});
+
 describe("Header workspace menu", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -51,70 +51,29 @@ export default function StoriesPage() {
   return (
     <Flex direction="column" minH="100vh" bg="gray.50">
       <Header />
-      <Box maxW="960px" mx="auto" py={8} px={4}>
+      <Box maxW="960px" mx="auto" py={8} px={4} w="100%">
         <Flex justify="space-between" align="center" mb={6}>
           <Heading size="lg" color="gray.800">
-            Stories
+            Your stories
           </Heading>
-          <Link to={workspacePath("/story/new")}>
-            <Button size="sm" colorScheme="orange">
-              New story
-            </Button>
-          </Link>
+          <Flex gap={2}>
+            <Link to={workspacePath("/quick-map")}>
+              <Button
+                size="sm"
+                variant="outline"
+                borderColor="brand.border"
+                color="brand.brown"
+              >
+                Quick map
+              </Button>
+            </Link>
+            <Link to={workspacePath("/story/new")}>
+              <Button size="sm" colorScheme="orange">
+                New story
+              </Button>
+            </Link>
+          </Flex>
         </Flex>
-
-        {exampleStories.length > 0 && (
-          <Box mb={8}>
-            <Heading size="md" color="gray.700" mb={3}>
-              Example stories
-            </Heading>
-            <Text fontSize="13px" color="gray.500" mb={3}>
-              Curated stories shared with every workspace.
-            </Text>
-            <Table.Root size="sm" tableLayout="fixed">
-              <Table.Header>
-                <Table.Row>
-                  <Table.ColumnHeader>Name</Table.ColumnHeader>
-                  <Table.ColumnHeader w="100px">Chapters</Table.ColumnHeader>
-                  <Table.ColumnHeader w="100px">Updated</Table.ColumnHeader>
-                </Table.Row>
-              </Table.Header>
-              <Table.Body>
-                {exampleStories.map((story) => (
-                  <Table.Row key={story.id}>
-                    <Table.Cell>
-                      <Link to={workspacePath(`/story/${story.id}/edit`)}>
-                        <Text
-                          color="brand.orange"
-                          _hover={{ textDecoration: "underline" }}
-                          fontWeight={500}
-                          truncate
-                          title={story.title}
-                        >
-                          {story.title}
-                        </Text>
-                      </Link>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Text fontSize="sm" color="gray.600">
-                        {story.chapters.length}
-                      </Text>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Text fontSize="sm" color="gray.600">
-                        {story.updated_at ? timeAgo(story.updated_at) : "—"}
-                      </Text>
-                    </Table.Cell>
-                  </Table.Row>
-                ))}
-              </Table.Body>
-            </Table.Root>
-          </Box>
-        )}
-
-        <Heading size="md" color="gray.700" mb={3}>
-          Your stories
-        </Heading>
 
         {loading ? (
           <Flex justify="center" py={12}>
@@ -124,20 +83,9 @@ export default function StoriesPage() {
             />
           </Flex>
         ) : userStories.length === 0 ? (
-          <Flex
-            direction="column"
-            align="center"
-            py={12}
-            gap={3}
-            color="gray.500"
-          >
-            <Text>No stories yet.</Text>
-            <Link to={workspacePath("/story/new")}>
-              <Text color="brand.orange" fontWeight={600}>
-                Create your first story
-              </Text>
-            </Link>
-          </Flex>
+          <Text color="gray.500" fontSize="sm" mb={2}>
+            No stories yet — start one or browse the example stories below.
+          </Text>
         ) : (
           <Table.Root size="sm" tableLayout="fixed">
             <Table.Header>
@@ -195,6 +143,59 @@ export default function StoriesPage() {
                     >
                       Delete
                     </Button>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table.Root>
+        )}
+
+        <Box my={8} h="1px" bg="brand.border" />
+
+        <Heading size="md" color="gray.700" mb={3}>
+          Example stories
+        </Heading>
+        <Text fontSize="13px" color="gray.500" mb={3}>
+          Curated stories shared with every workspace.
+        </Text>
+        {exampleStories.length === 0 ? (
+          <Text fontSize="sm" color="gray.500">
+            No example stories available.
+          </Text>
+        ) : (
+          <Table.Root size="sm" tableLayout="fixed">
+            <Table.Header>
+              <Table.Row>
+                <Table.ColumnHeader>Name</Table.ColumnHeader>
+                <Table.ColumnHeader w="100px">Chapters</Table.ColumnHeader>
+                <Table.ColumnHeader w="100px">Updated</Table.ColumnHeader>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {exampleStories.map((story) => (
+                <Table.Row key={story.id}>
+                  <Table.Cell>
+                    <Link to={workspacePath(`/story/${story.id}/edit`)}>
+                      <Text
+                        color="brand.orange"
+                        _hover={{ textDecoration: "underline" }}
+                        fontWeight={500}
+                        truncate
+                        title={story.title}
+                      >
+                        {story.title}
+                      </Text>
+                    </Link>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text fontSize="sm" color="gray.600">
+                      {story.chapters.length}
+                    </Text>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Text fontSize="sm" color="gray.600">
+                      {story.updated_at ? timeAgo(story.updated_at) : "—"}
+                    </Text>
                   </Table.Cell>
                 </Table.Row>
               ))}

--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -7,6 +7,22 @@ import { Footer } from "../components/Footer";
 import { useWorkspace } from "../hooks/useWorkspace";
 import { listStoriesFromServer, deleteStoryFromServer } from "../lib/story/api";
 import type { Story } from "../lib/story/types";
+import { ExampleStoryCard } from "../components/ExampleStoryCard";
+
+function inferDataType(story: Story): string {
+  const types = new Set<string>();
+  for (const ch of story.chapters) {
+    const t = (ch as { type?: string }).type;
+    if (t === "map") types.add("Map");
+    if (t === "chart") types.add("Chart");
+    if (t === "image") types.add("Image");
+    if (t === "video") types.add("Video");
+    if (t === "prose") types.add("Prose");
+  }
+  if (types.size === 0) return "Story";
+  if (types.size === 1) return Array.from(types)[0];
+  return "Mixed";
+}
 
 function timeAgo(dateStr: string): string {
   const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
@@ -163,44 +179,25 @@ export default function StoriesPage() {
             No example stories available.
           </Text>
         ) : (
-          <Table.Root size="sm" tableLayout="fixed">
-            <Table.Header>
-              <Table.Row>
-                <Table.ColumnHeader>Name</Table.ColumnHeader>
-                <Table.ColumnHeader w="100px">Chapters</Table.ColumnHeader>
-                <Table.ColumnHeader w="100px">Updated</Table.ColumnHeader>
-              </Table.Row>
-            </Table.Header>
-            <Table.Body>
-              {exampleStories.map((story) => (
-                <Table.Row key={story.id}>
-                  <Table.Cell>
-                    <Link to={workspacePath(`/story/${story.id}/edit`)}>
-                      <Text
-                        color="brand.orange"
-                        _hover={{ textDecoration: "underline" }}
-                        fontWeight={500}
-                        truncate
-                        title={story.title}
-                      >
-                        {story.title}
-                      </Text>
-                    </Link>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <Text fontSize="sm" color="gray.600">
-                      {story.chapters.length}
-                    </Text>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <Text fontSize="sm" color="gray.600">
-                      {story.updated_at ? timeAgo(story.updated_at) : "—"}
-                    </Text>
-                  </Table.Cell>
-                </Table.Row>
-              ))}
-            </Table.Body>
-          </Table.Root>
+          <Box
+            display="grid"
+            gridTemplateColumns={{
+              base: "1fr",
+              md: "repeat(3, 1fr)",
+            }}
+            gap={3}
+          >
+            {exampleStories.map((story) => (
+              <ExampleStoryCard
+                key={story.id}
+                title={story.title}
+                chapterCount={story.chapters.length}
+                dataType={inferDataType(story)}
+                href={workspacePath(`/story/${story.id}/edit`)}
+                compact={userStories.length > 0}
+              />
+            ))}
+          </Box>
         )}
       </Box>
       <Footer />

--- a/frontend/src/pages/__tests__/StoriesPage.test.tsx
+++ b/frontend/src/pages/__tests__/StoriesPage.test.tsx
@@ -63,6 +63,35 @@ describe("Workspace routing", () => {
   });
 });
 
+import { listStoriesFromServer } from "../../lib/story/api";
+
+describe("StoriesPage example-story cards", () => {
+  it("renders example stories as ExampleStoryCard links, not as table rows", async () => {
+    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: "ex-1",
+        title: "Arctic ice loss",
+        chapters: [{}, {}, {}, {}],
+        is_example: true,
+        published: true,
+        updated_at: new Date().toISOString(),
+      } as any,
+    ]);
+    renderStoriesPage();
+    const link = await screen.findByRole("link", { name: /arctic ice loss/i });
+    expect(link.getAttribute("href")).toBe("/w/test-workspace/story/ex-1/edit");
+    expect(screen.queryByText("Chapters")).toBeNull();
+  });
+
+  it("renders 'No example stories available.' when no examples come back", async () => {
+    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    renderStoriesPage();
+    expect(
+      await screen.findByText(/no example stories available\./i)
+    ).toBeInTheDocument();
+  });
+});
+
 describe("StoriesPage layout", () => {
   it("renders a 'Quick map' link in the header pointing to /quick-map", async () => {
     renderStoriesPage();

--- a/frontend/src/pages/__tests__/StoriesPage.test.tsx
+++ b/frontend/src/pages/__tests__/StoriesPage.test.tsx
@@ -63,4 +63,36 @@ describe("Workspace routing", () => {
   });
 });
 
+describe("StoriesPage layout", () => {
+  it("renders a 'Quick map' link in the header pointing to /quick-map", async () => {
+    renderStoriesPage();
+    const link = await screen.findByRole("link", { name: /quick map/i });
+    expect(link.getAttribute("href")).toBe("/w/test-workspace/quick-map");
+  });
+
+  it("renders a 'New story' link in the header pointing to /story/new", async () => {
+    renderStoriesPage();
+    const link = await screen.findByRole("link", { name: /new story/i });
+    expect(link.getAttribute("href")).toBe("/w/test-workspace/story/new");
+  });
+
+  it("renders 'Your stories' heading before 'Example stories' heading in DOM order", async () => {
+    renderStoriesPage();
+    const headings = await screen.findAllByRole("heading");
+    const texts = headings.map((h) => h.textContent || "");
+    const yourIdx = texts.findIndex((t) => /your stories/i.test(t));
+    const exampleIdx = texts.findIndex((t) => /example stories/i.test(t));
+    expect(yourIdx).toBeGreaterThan(-1);
+    expect(exampleIdx).toBeGreaterThan(-1);
+    expect(yourIdx).toBeLessThan(exampleIdx);
+  });
+
+  it("always renders the Example stories section, even when there are no example stories", async () => {
+    renderStoriesPage();
+    expect(
+      await screen.findByRole("heading", { name: /example stories/i })
+    ).toBeInTheDocument();
+  });
+});
+
 export { renderStoriesPage };

--- a/frontend/src/pages/__tests__/StoriesPage.test.tsx
+++ b/frontend/src/pages/__tests__/StoriesPage.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../../theme";
+import { WorkspaceProvider } from "../../hooks/useWorkspace";
+
+vi.mock("../../lib/story/api", () => ({
+  listStoriesFromServer: vi.fn().mockResolvedValue([]),
+  deleteStoryFromServer: vi.fn().mockResolvedValue(undefined),
+}));
+
+import App from "../../App";
+import StoriesPage from "../StoriesPage";
+
+function renderApp(initialPath: string) {
+  return render(
+    <ChakraProvider value={system}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <App />
+      </MemoryRouter>
+    </ChakraProvider>
+  );
+}
+
+function renderStoriesPage() {
+  return render(
+    <ChakraProvider value={system}>
+      <MemoryRouter initialEntries={["/w/test-workspace"]}>
+        <Routes>
+          <Route
+            path="/w/:workspaceId/*"
+            element={
+              <WorkspaceProvider>
+                <StoriesPage />
+              </WorkspaceProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </ChakraProvider>
+  );
+}
+
+describe("Workspace routing", () => {
+  it("renders StoriesPage at workspace root (/)", async () => {
+    renderApp("/w/test-workspace");
+    expect(
+      await screen.findByRole("heading", { name: /your stories/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders UploadPage at /quick-map", async () => {
+    renderApp("/w/test-workspace/quick-map");
+    expect(await screen.findByText(/upload/i)).toBeInTheDocument();
+  });
+
+  it("redirects /stories to /", async () => {
+    renderApp("/w/test-workspace/stories");
+    expect(
+      await screen.findByRole("heading", { name: /your stories/i })
+    ).toBeInTheDocument();
+  });
+});
+
+export { renderStoriesPage };

--- a/frontend/src/pages/__tests__/StoriesPage.test.tsx
+++ b/frontend/src/pages/__tests__/StoriesPage.test.tsx
@@ -64,6 +64,7 @@ describe("Workspace routing", () => {
 });
 
 import { listStoriesFromServer } from "../../lib/story/api";
+import type { Story } from "../../lib/story/types";
 
 describe("StoriesPage example-story cards", () => {
   it("renders example stories as ExampleStoryCard links, not as table rows", async () => {
@@ -75,7 +76,7 @@ describe("StoriesPage example-story cards", () => {
         is_example: true,
         published: true,
         updated_at: new Date().toISOString(),
-      } as any,
+      } as unknown as Story,
     ]);
     renderStoriesPage();
     const link = await screen.findByRole("link", { name: /arctic ice loss/i });

--- a/frontend/src/pages/__tests__/StoriesPage.test.tsx
+++ b/frontend/src/pages/__tests__/StoriesPage.test.tsx
@@ -84,7 +84,9 @@ describe("StoriesPage example-story cards", () => {
   });
 
   it("renders 'No example stories available.' when no examples come back", async () => {
-    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      []
+    );
     renderStoriesPage();
     expect(
       await screen.findByText(/no example stories available\./i)


### PR DESCRIPTION
## Summary
- Workspace `/` now renders the Stories tab (was UploadPage)
- UploadPage moved to `/quick-map`; reachable from a new secondary button on Stories
- StoriesPage layout restructured: Your stories first, divider, then Example stories
- Example stories now render as a visual card grid (with title-stable gradient hero) instead of a table
- Header: nav reordered to Stories before Data; new utility cluster with GitHub repo link and Contact mailto

Plan 1 of 5 in the storytelling pivot. See spec at `~/Obsidian/Project Docs/CNG Sandbox/specs/2026-05-12-storytelling-pivot-design.md`.

## Test plan
- [x] `cd frontend && npx vitest run` — 777 tests pass
- [x] Visit workspace root, Stories tab renders with new layout
- [x] Click "Quick map", UploadPage renders at `/quick-map`
- [x] Visit `/stories`, redirect to `/`
- [x] Header GitHub link opens cng-sandbox repo in new tab
- [x] Header Contact link is a mailto to info@developmentseed.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned Stories page with card-based example stories and a prominent "Your stories" section
  * New Example story cards with compact and detailed display modes
  * Header now shows "Stories" before "Data" and adds external GitHub and Contact links

* **UX / Routing**
  * Visiting the legacy /stories route redirects to the workspace "Your stories" view

* **Tests**
  * Added coverage for header, stories page, and example card behaviors

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/441)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->