### PR TITLE
feat(stories): clone-on-click for example stories (storytelling pivot 2/5)

### DIFF
--- a/frontend/src/components/ExampleStoryCard.tsx
+++ b/frontend/src/components/ExampleStoryCard.tsx
@@ -42,14 +42,7 @@ export function ExampleStoryCard({
   };
   return (
     <Box
-      as="button"
-      type="button"
-      onClick={handleClick}
-      disabled={loading}
-      aria-busy={loading || undefined}
-      textAlign="left"
-      p={0}
-      m={0}
+      asChild
       bg="white"
       border="1px solid"
       borderColor="brand.border"
@@ -60,28 +53,41 @@ export function ExampleStoryCard({
       _hover={loading ? undefined : { borderColor: "brand.orange" }}
       transition="border-color 0.15s, opacity 0.15s"
     >
-      <Flex direction="column">
-        <Box
-          h={compact ? "46px" : "90px"}
-          style={{ background: gradientForTitle(title) }}
-        />
-        <Box px={3} py={2}>
-          <Text
-            fontWeight={600}
-            fontSize={compact ? "12px" : "14px"}
-            color="brand.brown"
-            truncate
-            title={title}
-          >
-            {title}
-          </Text>
-          {!compact && (
-            <Text fontSize="11px" color="gray.500" mt={1}>
-              {loading ? "Cloning into your workspace…" : subtitle}
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={loading}
+        aria-busy={loading || undefined}
+        style={{
+          padding: 0,
+          margin: 0,
+          textAlign: "left",
+          font: "inherit",
+        }}
+      >
+        <Flex direction="column">
+          <Box
+            h={compact ? "46px" : "90px"}
+            style={{ background: gradientForTitle(title) }}
+          />
+          <Box px={3} py={2}>
+            <Text
+              fontWeight={600}
+              fontSize={compact ? "12px" : "14px"}
+              color="brand.brown"
+              truncate
+              title={title}
+            >
+              {title}
             </Text>
-          )}
-        </Box>
-      </Flex>
+            {!compact && (
+              <Text fontSize="11px" color="gray.500" mt={1}>
+                {loading ? "Cloning into your workspace…" : subtitle}
+              </Text>
+            )}
+          </Box>
+        </Flex>
+      </button>
     </Box>
   );
 }

--- a/frontend/src/components/ExampleStoryCard.tsx
+++ b/frontend/src/components/ExampleStoryCard.tsx
@@ -1,11 +1,11 @@
 import { Box, Flex, Text } from "@chakra-ui/react";
-import { Link } from "react-router-dom";
 
 export interface ExampleStoryCardProps {
   title: string;
   chapterCount: number;
   dataType: string;
-  href: string;
+  onClick: () => void;
+  loading?: boolean;
   compact?: boolean;
 }
 
@@ -29,24 +29,38 @@ export function ExampleStoryCard({
   title,
   chapterCount,
   dataType,
-  href,
+  onClick,
+  loading = false,
   compact = false,
 }: ExampleStoryCardProps) {
   const subtitle = `${dataType} · ${chapterCount} ${
     chapterCount === 1 ? "chapter" : "chapters"
   }`;
+  const handleClick = () => {
+    if (loading) return;
+    onClick();
+  };
   return (
-    <Link to={href} style={{ textDecoration: "none" }}>
-      <Flex
-        direction="column"
-        border="1px solid"
-        borderColor="brand.border"
-        borderRadius="6px"
-        overflow="hidden"
-        bg="white"
-        _hover={{ borderColor: "brand.orange" }}
-        transition="border-color 0.15s"
-      >
+    <Box
+      as="button"
+      type="button"
+      onClick={handleClick}
+      disabled={loading}
+      aria-busy={loading || undefined}
+      textAlign="left"
+      p={0}
+      m={0}
+      bg="white"
+      border="1px solid"
+      borderColor="brand.border"
+      borderRadius="6px"
+      overflow="hidden"
+      cursor={loading ? "wait" : "pointer"}
+      opacity={loading ? 0.7 : 1}
+      _hover={loading ? undefined : { borderColor: "brand.orange" }}
+      transition="border-color 0.15s, opacity 0.15s"
+    >
+      <Flex direction="column">
         <Box
           h={compact ? "46px" : "90px"}
           style={{ background: gradientForTitle(title) }}
@@ -63,11 +77,11 @@ export function ExampleStoryCard({
           </Text>
           {!compact && (
             <Text fontSize="11px" color="gray.500" mt={1}>
-              {subtitle}
+              {loading ? "Cloning into your workspace…" : subtitle}
             </Text>
           )}
         </Box>
       </Flex>
-    </Link>
+    </Box>
   );
 }

--- a/frontend/src/components/__tests__/ExampleStoryCard.test.tsx
+++ b/frontend/src/components/__tests__/ExampleStoryCard.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
 import { ChakraProvider } from "@chakra-ui/react";
 import { system } from "../../theme";
 import { ExampleStoryCard } from "../ExampleStoryCard";
@@ -8,9 +8,7 @@ import { ExampleStoryCard } from "../ExampleStoryCard";
 function renderCard(props: React.ComponentProps<typeof ExampleStoryCard>) {
   return render(
     <ChakraProvider value={system}>
-      <MemoryRouter>
-        <ExampleStoryCard {...props} />
-      </MemoryRouter>
+      <ExampleStoryCard {...props} />
     </ChakraProvider>
   );
 }
@@ -21,7 +19,7 @@ describe("ExampleStoryCard", () => {
       title: "Arctic ice loss",
       chapterCount: 4,
       dataType: "Raster",
-      href: "/w/x/story/abc/edit",
+      onClick: () => {},
     });
     expect(screen.getByText("Arctic ice loss")).toBeInTheDocument();
   });
@@ -31,20 +29,36 @@ describe("ExampleStoryCard", () => {
       title: "Arctic ice loss",
       chapterCount: 4,
       dataType: "Raster",
-      href: "/w/x/story/abc/edit",
+      onClick: () => {},
     });
     expect(screen.getByText(/raster · 4 chapters/i)).toBeInTheDocument();
   });
 
-  it("links to the given href", () => {
+  it("calls onClick when the card is activated", async () => {
+    const handler = vi.fn();
     renderCard({
-      title: "T",
-      chapterCount: 1,
-      dataType: "Vector",
-      href: "/w/x/story/abc/edit",
+      title: "Arctic ice loss",
+      chapterCount: 4,
+      dataType: "Raster",
+      onClick: handler,
     });
-    const link = screen.getByRole("link", { name: /t/i });
-    expect(link.getAttribute("href")).toBe("/w/x/story/abc/edit");
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /arctic ice loss/i }));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClick when loading=true", async () => {
+    const handler = vi.fn();
+    renderCard({
+      title: "Arctic ice loss",
+      chapterCount: 4,
+      dataType: "Raster",
+      onClick: handler,
+      loading: true,
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /arctic ice loss/i }));
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it("uses singular 'chapter' when chapterCount is 1", () => {
@@ -52,7 +66,7 @@ describe("ExampleStoryCard", () => {
       title: "T",
       chapterCount: 1,
       dataType: "Vector",
-      href: "/x",
+      onClick: () => {},
     });
     expect(screen.getByText(/vector · 1 chapter$/i)).toBeInTheDocument();
   });

--- a/frontend/src/lib/story/__tests__/api.fork.test.ts
+++ b/frontend/src/lib/story/__tests__/api.fork.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../api", () => ({
+  workspaceFetch: vi.fn(),
+}));
+
+import { workspaceFetch } from "../../api";
+import { forkStoryOnServer } from "../api";
+import type { Story } from "../types";
+
+describe("forkStoryOnServer", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("POSTs to /api/stories/<id>/fork and returns the parsed story", async () => {
+    const forked: Story = {
+      id: "new-id",
+      title: "Forked",
+      description: null,
+      dataset_id: null,
+      dataset_ids: [],
+      chapters: [],
+      published: false,
+      is_example: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } as unknown as Story;
+    (workspaceFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => forked,
+    });
+    const result = await forkStoryOnServer("source-id");
+    expect(workspaceFetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/stories\/source-id\/fork$/),
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(result).toEqual(forked);
+  });
+
+  it("throws when the response is not ok", async () => {
+    (workspaceFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+    await expect(forkStoryOnServer("missing-id")).rejects.toThrow(/404/);
+  });
+});

--- a/frontend/src/lib/story/api.ts
+++ b/frontend/src/lib/story/api.ts
@@ -54,3 +54,9 @@ export async function deleteStoryFromServer(id: string): Promise<void> {
   const resp = await workspaceFetch(`${BASE}/${id}`, { method: "DELETE" });
   if (!resp.ok) throw new Error(`Failed to delete story: ${resp.status}`);
 }
+
+export async function forkStoryOnServer(id: string): Promise<Story> {
+  const resp = await workspaceFetch(`${BASE}/${id}/fork`, { method: "POST" });
+  if (!resp.ok) throw new Error(`Failed to fork story: ${resp.status}`);
+  return resp.json();
+}

--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Box, Button, Flex, Heading, Table, Text } from "@chakra-ui/react";
 import { SpinnerGap } from "@phosphor-icons/react";
@@ -46,19 +46,22 @@ export default function StoriesPage() {
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [cloningId, setCloningId] = useState<string | null>(null);
+  const cloneInFlightRef = useRef(false);
 
   const handleCloneExample = useCallback(
     async (story: Story) => {
-      if (cloningId) return;
+      if (cloneInFlightRef.current) return;
+      cloneInFlightRef.current = true;
       setCloningId(story.id);
       try {
         const forked = await forkStoryOnServer(story.id);
         navigate(workspacePath(`/story/${forked.id}/edit`));
       } catch {
+        cloneInFlightRef.current = false;
         setCloningId(null);
       }
     },
-    [cloningId, navigate, workspacePath]
+    [navigate, workspacePath]
   );
 
   useEffect(() => {

--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -1,11 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Box, Button, Flex, Heading, Table, Text } from "@chakra-ui/react";
 import { SpinnerGap } from "@phosphor-icons/react";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
 import { useWorkspace } from "../hooks/useWorkspace";
-import { listStoriesFromServer, deleteStoryFromServer } from "../lib/story/api";
+import {
+  listStoriesFromServer,
+  deleteStoryFromServer,
+  forkStoryOnServer,
+} from "../lib/story/api";
 import type { Story } from "../lib/story/types";
 import { ExampleStoryCard } from "../components/ExampleStoryCard";
 
@@ -37,9 +41,25 @@ function timeAgo(dateStr: string): string {
 
 export default function StoriesPage() {
   const { workspacePath } = useWorkspace();
+  const navigate = useNavigate();
   const [stories, setStories] = useState<Story[]>([]);
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [cloningId, setCloningId] = useState<string | null>(null);
+
+  const handleCloneExample = useCallback(
+    async (story: Story) => {
+      if (cloningId) return;
+      setCloningId(story.id);
+      try {
+        const forked = await forkStoryOnServer(story.id);
+        navigate(workspacePath(`/story/${forked.id}/edit`));
+      } catch {
+        setCloningId(null);
+      }
+    },
+    [cloningId, navigate, workspacePath]
+  );
 
   useEffect(() => {
     listStoriesFromServer()
@@ -193,7 +213,8 @@ export default function StoriesPage() {
                 title={story.title}
                 chapterCount={story.chapters.length}
                 dataType={inferDataType(story)}
-                href={workspacePath(`/story/${story.id}/edit`)}
+                onClick={() => handleCloneExample(story)}
+                loading={cloningId === story.id}
                 compact={userStories.length > 0}
               />
             ))}

--- a/frontend/src/pages/__tests__/StoriesPage.test.tsx
+++ b/frontend/src/pages/__tests__/StoriesPage.test.tsx
@@ -1,11 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {
-  MemoryRouter,
-  Route,
-  Routes,
-  useLocation,
-} from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import { ChakraProvider } from "@chakra-ui/react";
 import { system } from "../../theme";
@@ -20,11 +15,7 @@ vi.mock("../../lib/story/api", () => ({
 import App from "../../App";
 import StoriesPage from "../StoriesPage";
 
-function LocationProbe({
-  onLocation,
-}: {
-  onLocation: (path: string) => void;
-}) {
+function LocationProbe({ onLocation }: { onLocation: (path: string) => void }) {
   const loc = useLocation();
   onLocation(loc.pathname);
   return null;

--- a/frontend/src/pages/__tests__/StoriesPage.test.tsx
+++ b/frontend/src/pages/__tests__/StoriesPage.test.tsx
@@ -1,5 +1,11 @@
-import { render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+} from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import { ChakraProvider } from "@chakra-ui/react";
 import { system } from "../../theme";
@@ -8,10 +14,21 @@ import { WorkspaceProvider } from "../../hooks/useWorkspace";
 vi.mock("../../lib/story/api", () => ({
   listStoriesFromServer: vi.fn().mockResolvedValue([]),
   deleteStoryFromServer: vi.fn().mockResolvedValue(undefined),
+  forkStoryOnServer: vi.fn(),
 }));
 
 import App from "../../App";
 import StoriesPage from "../StoriesPage";
+
+function LocationProbe({
+  onLocation,
+}: {
+  onLocation: (path: string) => void;
+}) {
+  const loc = useLocation();
+  onLocation(loc.pathname);
+  return null;
+}
 
 function renderApp(initialPath: string) {
   return render(
@@ -63,11 +80,11 @@ describe("Workspace routing", () => {
   });
 });
 
-import { listStoriesFromServer } from "../../lib/story/api";
+import { listStoriesFromServer, forkStoryOnServer } from "../../lib/story/api";
 import type { Story } from "../../lib/story/types";
 
 describe("StoriesPage example-story cards", () => {
-  it("renders example stories as ExampleStoryCard links, not as table rows", async () => {
+  it("renders example stories as clickable cards, not as table rows", async () => {
     (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       {
         id: "ex-1",
@@ -79,8 +96,10 @@ describe("StoriesPage example-story cards", () => {
       } as unknown as Story,
     ]);
     renderStoriesPage();
-    const link = await screen.findByRole("link", { name: /arctic ice loss/i });
-    expect(link.getAttribute("href")).toBe("/w/test-workspace/story/ex-1/edit");
+    const card = await screen.findByRole("button", {
+      name: /arctic ice loss/i,
+    });
+    expect(card).toBeInTheDocument();
     expect(screen.queryByText("Chapters")).toBeNull();
   });
 
@@ -92,6 +111,59 @@ describe("StoriesPage example-story cards", () => {
     expect(
       await screen.findByText(/no example stories available\./i)
     ).toBeInTheDocument();
+  });
+});
+
+describe("StoriesPage example-story clone-on-click", () => {
+  it("forks the example and navigates to the new draft editor", async () => {
+    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: "ex-1",
+        title: "Arctic ice loss",
+        chapters: [{}, {}, {}, {}],
+        is_example: true,
+        published: true,
+        updated_at: new Date().toISOString(),
+      } as unknown as Story,
+    ]);
+    (forkStoryOnServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: "new-draft-id",
+      title: "Arctic ice loss",
+      chapters: [],
+      is_example: false,
+      published: false,
+    } as unknown as Story);
+
+    let path = "";
+    render(
+      <ChakraProvider value={system}>
+        <MemoryRouter initialEntries={["/w/test-workspace"]}>
+          <Routes>
+            <Route
+              path="/w/:workspaceId/*"
+              element={
+                <WorkspaceProvider>
+                  <>
+                    <StoriesPage />
+                    <LocationProbe onLocation={(p) => (path = p)} />
+                  </>
+                </WorkspaceProvider>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </ChakraProvider>
+    );
+
+    const card = await screen.findByRole("button", {
+      name: /arctic ice loss/i,
+    });
+    const user = userEvent.setup();
+    await user.click(card);
+    expect(forkStoryOnServer).toHaveBeenCalledWith("ex-1");
+    await waitFor(() => {
+      expect(path).toBe("/w/test-workspace/story/new-draft-id/edit");
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Clicking an Example Story card now POSTs to `/api/stories/{id}/fork` (existing backend endpoint) and opens the new draft in the editor
- Previously the card linked directly to the example's edit URL, where PATCH returns 403 because example stories are immutable
- `ExampleStoryCard` switched from `<Link>` to a `<button>` with `onClick` + `loading` props; subtitle becomes "Cloning into your workspace…" during the fork
- Added `forkStoryOnServer` to the frontend story API client
- Real chapter-derived thumbnails deferred (would need a snapshot pipeline; example stories rarely have image chapters to derive a thumbnail from)

Plan 2 of 5 in the storytelling pivot. See spec `2026-05-12-storytelling-pivot-design.md`.

## Test plan
- [x] `cd frontend && npx vitest run` — 781 tests pass
- [x] `cd frontend && npx eslint src/ --max-warnings 0` — clean
- [x] `cd frontend && npx prettier --check 'src/**/*.{ts,tsx,css}'` — clean
- [x] Click "Cities from space" example card → routes to `/story/<new_id>/edit` with a forked copy
- [x] Returning to workspace home shows the new draft in Your stories with status Draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click example story cards to clone them into your workspace; automatically navigate to the new draft.
  * Cards show a loading state ("Cloning into your workspace…") and ignore further clicks while cloning.
* **Tests**
  * Added/updated tests covering click-to-clone behavior, loading guard, and navigation after clone.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/442)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->