### PR TITLE
fix(deploy): reload Caddy after docker compose up

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -98,7 +98,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no \
             -i ~/.ssh/deploy_key \
             "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}" \
-            "cd ${{ secrets.DEPLOY_PATH }} && git checkout main && git pull origin main && IMAGE_TAG='${IMAGE_TAG}' docker compose --profile prod pull && IMAGE_TAG='${IMAGE_TAG}' docker compose --profile prod up -d"
+            "cd ${{ secrets.DEPLOY_PATH }} && git checkout main && git pull origin main && IMAGE_TAG='${IMAGE_TAG}' docker compose --profile prod pull && IMAGE_TAG='${IMAGE_TAG}' docker compose --profile prod up -d && IMAGE_TAG='${IMAGE_TAG}' docker compose --profile prod exec -T caddy caddy reload --config /etc/caddy/Caddyfile"
 
       - name: Verify deploy health
         run: |


### PR DESCRIPTION
## Summary

- Deploy workflow now runs `caddy reload` after `docker compose up -d`, so Caddyfile edits actually take effect in prod.
- Root cause of the lingering password prompt on storytelling.developmentseed.org: v2.0.0 removed `basic_auth` from the Caddyfile, but Caddy's image tag didn't change, so `compose up -d` left the running container alone. The bind-mounted Caddyfile updated on disk; the in-memory config did not.
- `caddy reload` is a zero-downtime config swap and is a no-op when Caddy was just (re)started, so it's safe to run unconditionally on every deploy.

## Follow-up (separate, manual)

This PR fixes future deploys. To clear the current 401, the next release (or a manual `workflow_dispatch` of release-please.yml) will reload Caddy. Alternatively SSH and run the same `caddy reload` command by hand — no need to wait for a release.

## Test plan

- [ ] Merge release-please PR (or `workflow_dispatch` release-please.yml) and confirm `https://storytelling.developmentseed.org/` returns 200 instead of 401
- [ ] Confirm no downtime during the deploy (Caddy reload is graceful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the production deployment process to reload configuration settings after service updates, ensuring all changes take effect properly in the production environment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/444)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->