### PR TITLE
feat(stories): export prominence (storytelling pivot 5/5)

### DIFF
--- a/frontend/src/components/ExportDialog.tsx
+++ b/frontend/src/components/ExportDialog.tsx
@@ -1,5 +1,4 @@
 import {
-  CloseButton,
   DialogBackdrop,
   DialogBody,
   DialogContent,
@@ -7,9 +6,11 @@ import {
   DialogPositioner,
   DialogRoot,
   DialogTitle,
+  IconButton,
   Portal,
   Text,
 } from "@chakra-ui/react";
+import { X } from "@phosphor-icons/react";
 import { ExportSection } from "./ExportSection";
 import { ArchivalProgress } from "./ArchivalProgress";
 import { useArchivalDownload } from "../lib/story/useArchivalDownload";
@@ -46,7 +47,19 @@ export function ExportDialog({ open, onClose, story }: ExportDialogProps) {
                 <DialogTitle>
                   Export &ldquo;{story.title || "Untitled story"}&rdquo;
                 </DialogTitle>
-                <CloseButton size="sm" onClick={onClose} aria-label="Close" />
+                <IconButton
+                  size="sm"
+                  variant="ghost"
+                  onClick={onClose}
+                  aria-label="Close"
+                  _hover={{ bg: "brand.bgSubtle", color: "brand.orange" }}
+                  _focusVisible={{
+                    outline: "2px solid",
+                    outlineColor: "brand.border",
+                  }}
+                >
+                  <X size={16} />
+                </IconButton>
               </DialogHeader>
               <DialogBody>
                 <Text fontSize="sm" color="fg.muted" mb={2}>

--- a/frontend/src/components/ExportDialog.tsx
+++ b/frontend/src/components/ExportDialog.tsx
@@ -1,0 +1,69 @@
+import {
+  CloseButton,
+  DialogBackdrop,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  DialogPositioner,
+  DialogRoot,
+  DialogTitle,
+  Portal,
+  Text,
+} from "@chakra-ui/react";
+import { ExportSection } from "./ExportSection";
+import { ArchivalProgress } from "./ArchivalProgress";
+import { useArchivalDownload } from "../lib/story/useArchivalDownload";
+import type { Story } from "../lib/story";
+
+interface ExportDialogProps {
+  open: boolean;
+  onClose: () => void;
+  story: Story;
+}
+
+export function ExportDialog({ open, onClose, story }: ExportDialogProps) {
+  const { progress, handleArchival, handleCancelArchival } =
+    useArchivalDownload(story.id, story.title);
+
+  return (
+    <>
+      <ArchivalProgress
+        open={progress.open}
+        current={progress.current}
+        total={progress.total}
+        onClose={handleCancelArchival}
+      />
+      <DialogRoot
+        open={open}
+        onOpenChange={(e) => !e.open && onClose()}
+        size="md"
+      >
+        <Portal>
+          <DialogBackdrop />
+          <DialogPositioner>
+            <DialogContent shadow="lg">
+              <DialogHeader>
+                <DialogTitle>
+                  Export &ldquo;{story.title || "Untitled story"}&rdquo;
+                </DialogTitle>
+                <CloseButton size="sm" onClick={onClose} aria-label="Close" />
+              </DialogHeader>
+              <DialogBody>
+                <Text fontSize="sm" color="fg.muted" mb={2}>
+                  Download a portable representation of this story. Works on
+                  drafts and published stories.
+                </Text>
+                <ExportSection
+                  story={story}
+                  onArchival={() => {
+                    void handleArchival();
+                  }}
+                />
+              </DialogBody>
+            </DialogContent>
+          </DialogPositioner>
+        </Portal>
+      </DialogRoot>
+    </>
+  );
+}

--- a/frontend/src/components/ExportPickerDialog.tsx
+++ b/frontend/src/components/ExportPickerDialog.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import {
   Button,
-  CloseButton,
   DialogBackdrop,
   DialogBody,
   DialogContent,
@@ -10,9 +9,11 @@ import {
   DialogRoot,
   DialogTitle,
   Flex,
+  IconButton,
   Portal,
   Text,
 } from "@chakra-ui/react";
+import { X } from "@phosphor-icons/react";
 import { listStoriesFromServer } from "../lib/story/api";
 import { ExportDialog } from "./ExportDialog";
 import type { Story } from "../lib/story";
@@ -30,15 +31,25 @@ export function ExportPickerDialog({ open, onClose }: ExportPickerDialogProps) {
 
   useEffect(() => {
     if (!open) return;
+    let cancelled = false;
     setLoading(true);
     setLoadError(null);
     listStoriesFromServer()
-      .then((rows) => setStories(rows.filter((s) => !s.is_example)))
+      .then((rows) => {
+        if (cancelled) return;
+        setStories(rows.filter((s) => !s.is_example));
+      })
       .catch(() => {
+        if (cancelled) return;
         setLoadError("Could not load stories. Please try again.");
         setStories([]);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [open]);
 
   if (picked) {
@@ -66,7 +77,19 @@ export function ExportPickerDialog({ open, onClose }: ExportPickerDialogProps) {
           <DialogContent shadow="lg">
             <DialogHeader>
               <DialogTitle>Pick a story to export</DialogTitle>
-              <CloseButton size="sm" onClick={onClose} aria-label="Close" />
+              <IconButton
+                size="sm"
+                variant="ghost"
+                onClick={onClose}
+                aria-label="Close"
+                _hover={{ bg: "brand.bgSubtle", color: "brand.orange" }}
+                _focusVisible={{
+                  outline: "2px solid",
+                  outlineColor: "brand.border",
+                }}
+              >
+                <X size={16} />
+              </IconButton>
             </DialogHeader>
             <DialogBody>
               {loading ? (

--- a/frontend/src/components/ExportPickerDialog.tsx
+++ b/frontend/src/components/ExportPickerDialog.tsx
@@ -25,12 +25,20 @@ interface ExportPickerDialogProps {
 export function ExportPickerDialog({ open, onClose }: ExportPickerDialogProps) {
   const [stories, setStories] = useState<Story[]>([]);
   const [picked, setPicked] = useState<Story | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
+    setLoading(true);
+    setLoadError(null);
     listStoriesFromServer()
       .then((rows) => setStories(rows.filter((s) => !s.is_example)))
-      .catch(() => {});
+      .catch(() => {
+        setLoadError("Could not load stories. Please try again.");
+        setStories([]);
+      })
+      .finally(() => setLoading(false));
   }, [open]);
 
   if (picked) {
@@ -61,7 +69,15 @@ export function ExportPickerDialog({ open, onClose }: ExportPickerDialogProps) {
               <CloseButton size="sm" onClick={onClose} aria-label="Close" />
             </DialogHeader>
             <DialogBody>
-              {stories.length === 0 ? (
+              {loading ? (
+                <Text fontSize="sm" color="fg.muted">
+                  Loading stories…
+                </Text>
+              ) : loadError ? (
+                <Text fontSize="sm" color="red.600">
+                  {loadError}
+                </Text>
+              ) : stories.length === 0 ? (
                 <Text fontSize="sm" color="fg.muted">
                   You have no stories yet. Start one from the Stories tab.
                 </Text>

--- a/frontend/src/components/ExportPickerDialog.tsx
+++ b/frontend/src/components/ExportPickerDialog.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import {
+  Button,
+  CloseButton,
+  DialogBackdrop,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  DialogPositioner,
+  DialogRoot,
+  DialogTitle,
+  Flex,
+  Portal,
+  Text,
+} from "@chakra-ui/react";
+import { listStoriesFromServer } from "../lib/story/api";
+import { ExportDialog } from "./ExportDialog";
+import type { Story } from "../lib/story";
+
+interface ExportPickerDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ExportPickerDialog({ open, onClose }: ExportPickerDialogProps) {
+  const [stories, setStories] = useState<Story[]>([]);
+  const [picked, setPicked] = useState<Story | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    listStoriesFromServer()
+      .then((rows) => setStories(rows.filter((s) => !s.is_example)))
+      .catch(() => {});
+  }, [open]);
+
+  if (picked) {
+    return (
+      <ExportDialog
+        open
+        story={picked}
+        onClose={() => {
+          setPicked(null);
+          onClose();
+        }}
+      />
+    );
+  }
+
+  return (
+    <DialogRoot
+      open={open}
+      onOpenChange={(d) => !d.open && onClose()}
+      size="md"
+    >
+      <Portal>
+        <DialogBackdrop />
+        <DialogPositioner>
+          <DialogContent shadow="lg">
+            <DialogHeader>
+              <DialogTitle>Pick a story to export</DialogTitle>
+              <CloseButton size="sm" onClick={onClose} aria-label="Close" />
+            </DialogHeader>
+            <DialogBody>
+              {stories.length === 0 ? (
+                <Text fontSize="sm" color="fg.muted">
+                  You have no stories yet. Start one from the Stories tab.
+                </Text>
+              ) : (
+                <Flex direction="column" gap={2}>
+                  {stories.map((s) => (
+                    <Button
+                      key={s.id}
+                      variant="outline"
+                      justifyContent="flex-start"
+                      onClick={() => setPicked(s)}
+                    >
+                      {s.title || "Untitled story"}
+                    </Button>
+                  ))}
+                </Flex>
+              )}
+            </DialogBody>
+          </DialogContent>
+        </DialogPositioner>
+      </Portal>
+    </DialogRoot>
+  );
+}

--- a/frontend/src/components/ExportSection.tsx
+++ b/frontend/src/components/ExportSection.tsx
@@ -1,0 +1,73 @@
+import { Box, Button, Text } from "@chakra-ui/react";
+import { downloadStoryConfig } from "../lib/story/exportConfig";
+import { buildAndDownloadBundle } from "../lib/story/buildStaticBundle";
+import { EmbedSnippet } from "./EmbedSnippet";
+import type { Story } from "../lib/story";
+
+interface ExportSectionProps {
+  story: Story;
+  onArchival: () => void;
+}
+
+export function ExportSection({ story, onArchival }: ExportSectionProps) {
+  return (
+    <Box mt={6}>
+      <Text
+        fontSize="xs"
+        fontWeight={600}
+        color="gray.500"
+        mb={1.5}
+        textTransform="uppercase"
+        letterSpacing="wider"
+      >
+        Export
+      </Text>
+      <Text fontSize="sm" color="fg.muted" mb={3}>
+        Download a portable representation of this story.
+      </Text>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => {
+          void downloadStoryConfig(story.id, story.title).catch((err) => {
+            console.error("Failed to download story config", err);
+          });
+        }}
+      >
+        Download story config (cng-rc.json)
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        mt={3}
+        onClick={() => {
+          void buildAndDownloadBundle(story.id, story.title).catch((err) => {
+            console.error("Failed to download static bundle", err);
+          });
+        }}
+      >
+        Download static bundle (.zip)
+      </Button>
+      <Text fontSize="xs" color="fg.muted" mt={1}>
+        Self-contained viewer + config. Upload anywhere static files can be
+        served.
+      </Text>
+      <Button size="sm" variant="outline" mt={3} onClick={() => onArchival()}>
+        Download archival HTML
+      </Button>
+      <Text fontSize="xs" color="fg.muted" mt={1}>
+        Single self-contained file. Maps and charts inlined as images. Suitable
+        for Zenodo and long-term archives.
+      </Text>
+      <Box mt={4}>
+        <EmbedSnippet
+          viewerOrigin={
+            import.meta.env.VITE_VIEWER_ORIGIN ?? window.location.origin
+          }
+          storyId={story.id}
+          configUrl={`${window.location.origin}/api/stories/${story.id}/export/config`}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -139,13 +139,13 @@ export function Header({ children, showWorkspace = true }: HeaderProps) {
                 <DownloadSimple
                   size={14}
                   weight="bold"
-                  color="var(--chakra-colors-gray-600)"
+                  color="var(--chakra-colors-brand-brown)"
                 />
                 <Text
                   fontSize="sm"
                   fontWeight={500}
-                  color="gray.600"
-                  _hover={{ color: "gray.800" }}
+                  color="brand.brown"
+                  _hover={{ color: "brand.orange" }}
                 >
                   Export
                 </Text>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,11 +2,12 @@ import { Flex, Menu, Portal, Text } from "@chakra-ui/react";
 import { Link, useNavigate } from "react-router-dom";
 import type { ReactNode } from "react";
 import { useState, useCallback, useEffect } from "react";
-import { CaretDown, Check } from "@phosphor-icons/react";
+import { CaretDown, Check, DownloadSimple } from "@phosphor-icons/react";
 import {
   useOptionalWorkspace,
   WORKSPACE_STORAGE_KEY,
 } from "../hooks/useWorkspace";
+import { ExportPickerDialog } from "./ExportPickerDialog";
 
 interface HeaderProps {
   children?: ReactNode;
@@ -18,6 +19,7 @@ export function Header({ children, showWorkspace = true }: HeaderProps) {
   const navigate = useNavigate();
   const [copied, setCopied] = useState(false);
   const [isPrimary, setIsPrimary] = useState(false);
+  const [exportPickerOpen, setExportPickerOpen] = useState(false);
 
   useEffect(() => {
     if (!workspace) return;
@@ -50,199 +52,234 @@ export function Header({ children, showWorkspace = true }: HeaderProps) {
   }, [navigate]);
 
   return (
-    <Flex
-      as="header"
-      align="center"
-      justify="space-between"
-      px={6}
-      py={3}
-      bg="white"
-      borderBottom="1px solid"
-      borderColor="brand.border"
-    >
-      <Flex align="center" gap={6} flexShrink={0}>
-        <Link to={homeHref} style={{ textDecoration: "none", flexShrink: 0 }}>
-          <Flex align="center" gap={3} flexShrink={0}>
-            <img
-              src="/logo.svg"
-              alt="Development Seed"
-              width={32}
-              height={32}
-            />
-            <Text
-              as="span"
-              color="brand.brown"
-              fontWeight={700}
-              fontSize="15px"
-              whiteSpace="nowrap"
-            >
-              CNG Sandbox
-            </Text>
-          </Flex>
-        </Link>
-        {storiesHref && (
-          <Link to={storiesHref} style={{ textDecoration: "none" }}>
-            <Text
-              fontSize="sm"
-              fontWeight={500}
-              color="brand.brown"
-              _hover={{ color: "brand.orange" }}
-            >
-              Stories
-            </Text>
-          </Link>
-        )}
-        {dataHref && (
-          <Link to={dataHref} style={{ textDecoration: "none" }}>
-            <Text
-              fontSize="sm"
-              fontWeight={500}
-              color="brand.brown"
-              _hover={{ color: "brand.orange" }}
-            >
-              Data
-            </Text>
-          </Link>
-        )}
-        <Link to={aboutHref} style={{ textDecoration: "none" }}>
-          <Text
-            fontSize="sm"
-            fontWeight={500}
-            color="gray.600"
-            _hover={{ color: "gray.800" }}
-          >
-            About
-          </Text>
-        </Link>
-      </Flex>
-      <Flex align="center" gap={4} ml="auto" mr={3}>
-        <a
-          href="https://github.com/aboydnw/cng-sandbox"
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ textDecoration: "none" }}
-        >
-          <Text
-            fontSize="sm"
-            fontWeight={500}
-            color="gray.600"
-            _hover={{ color: "gray.800" }}
-          >
-            GitHub
-          </Text>
-        </a>
-        <a
-          href="mailto:info@developmentseed.org"
-          style={{ textDecoration: "none" }}
-        >
-          <Text
-            fontSize="sm"
-            fontWeight={500}
-            color="gray.600"
-            _hover={{ color: "gray.800" }}
-          >
-            Contact
-          </Text>
-        </a>
-      </Flex>
-      {showWorkspace && workspace && (
-        <Menu.Root>
-          <Menu.Trigger asChild>
-            <Flex
-              align="center"
-              gap={1}
-              px={2}
-              py={1}
-              borderRadius="md"
-              bg="gray.100"
-              cursor="pointer"
-              fontSize="xs"
-              color="gray.500"
-              _hover={{ bg: "gray.200" }}
-              aria-label="Workspace menu"
-            >
-              <Text>
-                {copied ? "Copied!" : `Workspace ${workspace.workspaceId}`}
-              </Text>
-              <CaretDown size={10} />
-            </Flex>
-          </Menu.Trigger>
-          <Portal>
-            <Menu.Positioner>
-              <Menu.Content
-                bg="white"
-                border="1px solid"
-                borderColor="brand.border"
-                borderRadius="8px"
-                boxShadow="md"
-                py={1}
-                minW="220px"
-                fontSize="sm"
+    <>
+      <ExportPickerDialog
+        open={exportPickerOpen}
+        onClose={() => setExportPickerOpen(false)}
+      />
+      <Flex
+        as="header"
+        align="center"
+        justify="space-between"
+        px={6}
+        py={3}
+        bg="white"
+        borderBottom="1px solid"
+        borderColor="brand.border"
+      >
+        <Flex align="center" gap={6} flexShrink={0}>
+          <Link to={homeHref} style={{ textDecoration: "none", flexShrink: 0 }}>
+            <Flex align="center" gap={3} flexShrink={0}>
+              <img
+                src="/logo.svg"
+                alt="Development Seed"
+                width={32}
+                height={32}
+              />
+              <Text
+                as="span"
+                color="brand.brown"
+                fontWeight={700}
+                fontSize="15px"
+                whiteSpace="nowrap"
               >
-                <Menu.Item
-                  value="copy-link"
-                  onClick={copyWorkspaceUrl}
-                  px={3}
-                  py={2}
-                  cursor="pointer"
-                  _hover={{ bg: "brand.bgSubtle" }}
+                CNG Sandbox
+              </Text>
+            </Flex>
+          </Link>
+          {storiesHref && (
+            <Link to={storiesHref} style={{ textDecoration: "none" }}>
+              <Text
+                fontSize="sm"
+                fontWeight={500}
+                color="brand.brown"
+                _hover={{ color: "brand.orange" }}
+              >
+                Stories
+              </Text>
+            </Link>
+          )}
+          {dataHref && (
+            <Link to={dataHref} style={{ textDecoration: "none" }}>
+              <Text
+                fontSize="sm"
+                fontWeight={500}
+                color="brand.brown"
+                _hover={{ color: "brand.orange" }}
+              >
+                Data
+              </Text>
+            </Link>
+          )}
+          <Link to={aboutHref} style={{ textDecoration: "none" }}>
+            <Text
+              fontSize="sm"
+              fontWeight={500}
+              color="gray.600"
+              _hover={{ color: "gray.800" }}
+            >
+              About
+            </Text>
+          </Link>
+        </Flex>
+        <Flex align="center" gap={4} ml="auto" mr={3}>
+          {workspace && (
+            <button
+              type="button"
+              onClick={() => setExportPickerOpen(true)}
+              style={{
+                background: "transparent",
+                border: 0,
+                cursor: "pointer",
+                padding: 0,
+              }}
+              aria-label="Export a story"
+            >
+              <Flex align="center" gap={1}>
+                <DownloadSimple
+                  size={14}
+                  weight="bold"
+                  color="var(--chakra-colors-gray-600)"
+                />
+                <Text
+                  fontSize="sm"
+                  fontWeight={500}
+                  color="gray.600"
+                  _hover={{ color: "gray.800" }}
                 >
-                  Copy workspace link
-                </Menu.Item>
-                {!isPrimary && (
+                  Export
+                </Text>
+              </Flex>
+            </button>
+          )}
+          <a
+            href="https://github.com/aboydnw/cng-sandbox"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ textDecoration: "none" }}
+          >
+            <Text
+              fontSize="sm"
+              fontWeight={500}
+              color="gray.600"
+              _hover={{ color: "gray.800" }}
+            >
+              GitHub
+            </Text>
+          </a>
+          <a
+            href="mailto:info@developmentseed.org"
+            style={{ textDecoration: "none" }}
+          >
+            <Text
+              fontSize="sm"
+              fontWeight={500}
+              color="gray.600"
+              _hover={{ color: "gray.800" }}
+            >
+              Contact
+            </Text>
+          </a>
+        </Flex>
+        {showWorkspace && workspace && (
+          <Menu.Root>
+            <Menu.Trigger asChild>
+              <Flex
+                align="center"
+                gap={1}
+                px={2}
+                py={1}
+                borderRadius="md"
+                bg="gray.100"
+                cursor="pointer"
+                fontSize="xs"
+                color="gray.500"
+                _hover={{ bg: "gray.200" }}
+                aria-label="Workspace menu"
+              >
+                <Text>
+                  {copied ? "Copied!" : `Workspace ${workspace.workspaceId}`}
+                </Text>
+                <CaretDown size={10} />
+              </Flex>
+            </Menu.Trigger>
+            <Portal>
+              <Menu.Positioner>
+                <Menu.Content
+                  bg="white"
+                  border="1px solid"
+                  borderColor="brand.border"
+                  borderRadius="8px"
+                  boxShadow="md"
+                  py={1}
+                  minW="220px"
+                  fontSize="sm"
+                >
                   <Menu.Item
-                    value="make-primary"
-                    onClick={makePrimary}
+                    value="copy-link"
+                    onClick={copyWorkspaceUrl}
                     px={3}
                     py={2}
                     cursor="pointer"
                     _hover={{ bg: "brand.bgSubtle" }}
                   >
-                    Make this my primary workspace
+                    Copy workspace link
                   </Menu.Item>
-                )}
-                {isPrimary && (
+                  {!isPrimary && (
+                    <Menu.Item
+                      value="make-primary"
+                      onClick={makePrimary}
+                      px={3}
+                      py={2}
+                      cursor="pointer"
+                      _hover={{ bg: "brand.bgSubtle" }}
+                    >
+                      Make this my primary workspace
+                    </Menu.Item>
+                  )}
+                  {isPrimary && (
+                    <Menu.Item
+                      value="is-primary"
+                      disabled
+                      px={3}
+                      py={2}
+                      color="gray.500"
+                    >
+                      <Flex align="center" gap={2}>
+                        <Check size={14} weight="bold" />
+                        <Text>Primary workspace</Text>
+                      </Flex>
+                    </Menu.Item>
+                  )}
+                  <Menu.Separator borderColor="brand.border" my={1} />
                   <Menu.Item
-                    value="is-primary"
-                    disabled
+                    value="change-workspace"
+                    onClick={changeWorkspaces}
                     px={3}
                     py={2}
-                    color="gray.500"
+                    cursor="pointer"
+                    _hover={{ bg: "brand.bgSubtle" }}
                   >
-                    <Flex align="center" gap={2}>
-                      <Check size={14} weight="bold" />
-                      <Text>Primary workspace</Text>
-                    </Flex>
+                    Change workspaces
                   </Menu.Item>
-                )}
-                <Menu.Separator borderColor="brand.border" my={1} />
-                <Menu.Item
-                  value="change-workspace"
-                  onClick={changeWorkspaces}
-                  px={3}
-                  py={2}
-                  cursor="pointer"
-                  _hover={{ bg: "brand.bgSubtle" }}
-                >
-                  Change workspaces
-                </Menu.Item>
-              </Menu.Content>
-            </Menu.Positioner>
-          </Portal>
-        </Menu.Root>
-      )}
-      {children && (
-        <Flex
-          gap={2}
-          align="center"
-          flex="1 1 auto"
-          minW={0}
-          justify="flex-end"
-          ml={6}
-        >
-          {children}
-        </Flex>
-      )}
-    </Flex>
+                </Menu.Content>
+              </Menu.Positioner>
+            </Portal>
+          </Menu.Root>
+        )}
+        {children && (
+          <Flex
+            gap={2}
+            align="center"
+            flex="1 1 auto"
+            minW={0}
+            justify="flex-end"
+            ml={6}
+          >
+            {children}
+          </Flex>
+        )}
+      </Flex>
+    </>
   );
 }

--- a/frontend/src/components/PublishDialog.tsx
+++ b/frontend/src/components/PublishDialog.tsx
@@ -20,11 +20,9 @@ import {
 import { CheckCircle, Copy, Warning } from "@phosphor-icons/react";
 import type { Story } from "../lib/story";
 import { isMapBoundChapter } from "../lib/story";
-import { downloadStoryConfig } from "../lib/story/exportConfig";
-import { buildAndDownloadBundle } from "../lib/story/buildStaticBundle";
-import { downloadArchivalHtml } from "../lib/story/archival/downloadArchival";
+import { useArchivalDownload } from "../lib/story/useArchivalDownload";
 import { ArchivalProgress } from "./ArchivalProgress";
-import { EmbedSnippet } from "./EmbedSnippet";
+import { ExportSection } from "./ExportSection";
 
 interface PublishDialogProps {
   open: boolean;
@@ -44,45 +42,8 @@ export function PublishDialog({
   const [published, setPublished] = useState(story.published);
   const [copied, setCopied] = useState(false);
   const urlInputRef = useRef<HTMLInputElement>(null);
-  const [archivalProgress, setArchivalProgress] = useState<{
-    open: boolean;
-    current: number;
-    total: number;
-  }>({ open: false, current: 0, total: 0 });
-  const archivalAbortRef = useRef<AbortController | null>(null);
-
-  async function handleArchival() {
-    archivalAbortRef.current?.abort();
-    const controller = new AbortController();
-    archivalAbortRef.current = controller;
-    setArchivalProgress({ open: true, current: 0, total: 1 });
-    try {
-      await downloadArchivalHtml(
-        story.id,
-        story.title,
-        (current, total) => {
-          if (controller.signal.aborted) return;
-          setArchivalProgress({ open: true, current, total });
-        },
-        controller.signal
-      );
-    } catch (err) {
-      if ((err as { name?: string })?.name !== "AbortError") {
-        console.error("Failed to download archival HTML", err);
-      }
-    } finally {
-      if (archivalAbortRef.current === controller) {
-        archivalAbortRef.current = null;
-        setArchivalProgress({ open: false, current: 0, total: 0 });
-      }
-    }
-  }
-
-  function handleCancelArchival() {
-    archivalAbortRef.current?.abort();
-    archivalAbortRef.current = null;
-    setArchivalProgress({ open: false, current: 0, total: 0 });
-  }
+  const { progress: archivalProgress, handleArchival, handleCancelArchival } =
+    useArchivalDownload(story.id, story.title);
 
   const incompleteChapters = story.chapters.filter(
     (ch) => !ch.narrative.trim()
@@ -266,83 +227,12 @@ export function PublishDialog({
                         </Button>
                       </Flex>
                     </Box>
-                    <Box mt={6}>
-                      <Text
-                        fontSize="xs"
-                        fontWeight={600}
-                        color="gray.500"
-                        mb={1.5}
-                        textTransform="uppercase"
-                        letterSpacing="wider"
-                      >
-                        Export
-                      </Text>
-                      <Text fontSize="sm" color="fg.muted" mb={3}>
-                        Download a portable representation of this story.
-                      </Text>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => {
-                          void downloadStoryConfig(story.id, story.title).catch(
-                            (err) => {
-                              console.error(
-                                "Failed to download story config",
-                                err
-                              );
-                            }
-                          );
-                        }}
-                      >
-                        Download story config (cng-rc.json)
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        mt={3}
-                        onClick={() => {
-                          void buildAndDownloadBundle(
-                            story.id,
-                            story.title
-                          ).catch((err) => {
-                            console.error(
-                              "Failed to download static bundle",
-                              err
-                            );
-                          });
-                        }}
-                      >
-                        Download static bundle (.zip)
-                      </Button>
-                      <Text fontSize="xs" color="fg.muted" mt={1}>
-                        Self-contained viewer + config. Upload anywhere static
-                        files can be served.
-                      </Text>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        mt={3}
-                        onClick={() => {
-                          void handleArchival();
-                        }}
-                      >
-                        Download archival HTML
-                      </Button>
-                      <Text fontSize="xs" color="fg.muted" mt={1}>
-                        Single self-contained file. Maps and charts inlined as
-                        images. Suitable for Zenodo and long-term archives.
-                      </Text>
-                      <Box mt={4}>
-                        <EmbedSnippet
-                          viewerOrigin={
-                            import.meta.env.VITE_VIEWER_ORIGIN ??
-                            window.location.origin
-                          }
-                          storyId={story.id}
-                          configUrl={`${window.location.origin}/api/stories/${story.id}/export/config`}
-                        />
-                      </Box>
-                    </Box>
+                    <ExportSection
+                      story={story}
+                      onArchival={() => {
+                        void handleArchival();
+                      }}
+                    />
                   </Flex>
                 )}
               </DialogBody>

--- a/frontend/src/components/PublishDialog.tsx
+++ b/frontend/src/components/PublishDialog.tsx
@@ -42,8 +42,11 @@ export function PublishDialog({
   const [published, setPublished] = useState(story.published);
   const [copied, setCopied] = useState(false);
   const urlInputRef = useRef<HTMLInputElement>(null);
-  const { progress: archivalProgress, handleArchival, handleCancelArchival } =
-    useArchivalDownload(story.id, story.title);
+  const {
+    progress: archivalProgress,
+    handleArchival,
+    handleCancelArchival,
+  } = useArchivalDownload(story.id, story.title);
 
   const incompleteChapters = story.chapters.filter(
     (ch) => !ch.narrative.trim()

--- a/frontend/src/components/__tests__/ExportDialog.test.tsx
+++ b/frontend/src/components/__tests__/ExportDialog.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../../theme";
+import { ExportDialog } from "../ExportDialog";
+import type { Story } from "../../lib/story";
+
+vi.mock("../../lib/story/buildStaticBundle", () => ({
+  buildAndDownloadBundle: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../lib/story/exportConfig", () => ({
+  downloadStoryConfig: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../lib/story/archival/downloadArchival", () => ({
+  downloadArchivalHtml: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../EmbedSnippet", () => ({
+  EmbedSnippet: () => <div data-testid="embed-snippet" />,
+}));
+vi.mock("../ArchivalProgress", () => ({
+  ArchivalProgress: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="archival-progress" /> : null,
+}));
+
+const story = {
+  id: "s-1",
+  title: "Demo",
+  description: null,
+  dataset_id: null,
+  dataset_ids: [],
+  chapters: [],
+  published: false,
+  is_example: false,
+} as unknown as Story;
+
+function renderDialog(open: boolean, onClose = vi.fn()) {
+  return render(
+    <ChakraProvider value={system}>
+      <ExportDialog open={open} onClose={onClose} story={story} />
+    </ChakraProvider>
+  );
+}
+
+describe("ExportDialog", () => {
+  it("renders export entry points when open", () => {
+    renderDialog(true);
+    expect(
+      screen.getByRole("button", { name: /download static bundle/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /download archival html/i })
+    ).toBeInTheDocument();
+  });
+
+  it("does not render content when closed", () => {
+    renderDialog(false);
+    expect(
+      screen.queryByRole("button", { name: /download static bundle/i })
+    ).toBeNull();
+  });
+
+  it("calls onClose when the close affordance fires", () => {
+    const onClose = vi.fn();
+    renderDialog(true, onClose);
+    const closeBtn = screen.getByRole("button", { name: /close/i });
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/ExportPickerDialog.test.tsx
+++ b/frontend/src/components/__tests__/ExportPickerDialog.test.tsx
@@ -76,6 +76,17 @@ describe("ExportPickerDialog", () => {
     });
   });
 
+  it("shows an error state when the list fetch fails", async () => {
+    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("boom")
+    );
+    renderPicker();
+    expect(
+      await screen.findByText(/could not load stories/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/no stories yet/i)).toBeNull();
+  });
+
   it("clicking a story opens the ExportDialog for it", async () => {
     (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       { id: "u-1", title: "Mine", chapters: [], is_example: false },

--- a/frontend/src/components/__tests__/ExportPickerDialog.test.tsx
+++ b/frontend/src/components/__tests__/ExportPickerDialog.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ChakraProvider } from "@chakra-ui/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { system } from "../../theme";
+import { WorkspaceProvider } from "../../hooks/useWorkspace";
+import { ExportPickerDialog } from "../ExportPickerDialog";
+
+vi.mock("../../lib/story/api", () => ({
+  listStoriesFromServer: vi.fn(),
+}));
+vi.mock("../../lib/story/buildStaticBundle", () => ({
+  buildAndDownloadBundle: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../lib/story/exportConfig", () => ({
+  downloadStoryConfig: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../lib/story/archival/downloadArchival", () => ({
+  downloadArchivalHtml: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../EmbedSnippet", () => ({
+  EmbedSnippet: () => <div data-testid="embed-snippet" />,
+}));
+vi.mock("../ArchivalProgress", () => ({
+  ArchivalProgress: () => null,
+}));
+
+import { listStoriesFromServer } from "../../lib/story/api";
+
+function renderPicker(open = true) {
+  return render(
+    <ChakraProvider value={system}>
+      <MemoryRouter initialEntries={["/w/test/"]}>
+        <Routes>
+          <Route
+            path="/w/:workspaceId/*"
+            element={
+              <WorkspaceProvider>
+                <ExportPickerDialog open={open} onClose={vi.fn()} />
+              </WorkspaceProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </ChakraProvider>
+  );
+}
+
+describe("ExportPickerDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists only the user's own (non-example) stories", async () => {
+    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { id: "u-1", title: "Mine", chapters: [], is_example: false },
+      { id: "ex-1", title: "Example", chapters: [], is_example: true },
+    ]);
+    renderPicker();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^mine$/i })
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: /^example$/i })).toBeNull();
+  });
+
+  it("shows empty state when there are no user stories", async () => {
+    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      []
+    );
+    renderPicker();
+    await waitFor(() => {
+      expect(screen.getByText(/no stories yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it("clicking a story opens the ExportDialog for it", async () => {
+    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { id: "u-1", title: "Mine", chapters: [], is_example: false },
+    ]);
+    renderPicker();
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("button", { name: /^mine$/i }));
+    expect(
+      await screen.findByRole("button", { name: /download static bundle/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/ExportSection.test.tsx
+++ b/frontend/src/components/__tests__/ExportSection.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../../theme";
+import { ExportSection } from "../ExportSection";
+import type { Story } from "../../lib/story";
+
+vi.mock("../../lib/story/buildStaticBundle", () => ({
+  buildAndDownloadBundle: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../lib/story/exportConfig", () => ({
+  downloadStoryConfig: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../EmbedSnippet", () => ({
+  EmbedSnippet: () => <div data-testid="embed-snippet" />,
+}));
+
+const baseStory = {
+  id: "s-1",
+  title: "Demo",
+  description: null,
+  dataset_id: null,
+  dataset_ids: [],
+  chapters: [],
+  published: false,
+  is_example: false,
+} as unknown as Story;
+
+function renderSection(
+  props: Partial<React.ComponentProps<typeof ExportSection>> = {}
+) {
+  return render(
+    <ChakraProvider value={system}>
+      <ExportSection story={baseStory} onArchival={vi.fn()} {...props} />
+    </ChakraProvider>
+  );
+}
+
+describe("ExportSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the four export entry points", () => {
+    renderSection();
+    expect(
+      screen.getByRole("button", { name: /download story config/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /download static bundle/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /download archival html/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("embed-snippet")).toBeInTheDocument();
+  });
+
+  it("clicking 'Download static bundle' invokes buildAndDownloadBundle", async () => {
+    renderSection();
+    fireEvent.click(
+      screen.getByRole("button", { name: /download static bundle/i })
+    );
+    const { buildAndDownloadBundle } = await import(
+      "../../lib/story/buildStaticBundle"
+    );
+    expect(buildAndDownloadBundle).toHaveBeenCalledWith("s-1", "Demo");
+  });
+
+  it("clicking 'Download story config' invokes downloadStoryConfig", async () => {
+    renderSection();
+    fireEvent.click(
+      screen.getByRole("button", { name: /download story config/i })
+    );
+    const { downloadStoryConfig } = await import(
+      "../../lib/story/exportConfig"
+    );
+    expect(downloadStoryConfig).toHaveBeenCalledWith("s-1", "Demo");
+  });
+
+  it("clicking 'Download archival HTML' calls onArchival", () => {
+    const onArchival = vi.fn();
+    renderSection({ onArchival });
+    fireEvent.click(
+      screen.getByRole("button", { name: /download archival html/i })
+    );
+    expect(onArchival).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/ExportSection.test.tsx
+++ b/frontend/src/components/__tests__/ExportSection.test.tsx
@@ -60,9 +60,8 @@ describe("ExportSection", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /download static bundle/i })
     );
-    const { buildAndDownloadBundle } = await import(
-      "../../lib/story/buildStaticBundle"
-    );
+    const { buildAndDownloadBundle } =
+      await import("../../lib/story/buildStaticBundle");
     expect(buildAndDownloadBundle).toHaveBeenCalledWith("s-1", "Demo");
   });
 
@@ -71,9 +70,8 @@ describe("ExportSection", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /download story config/i })
     );
-    const { downloadStoryConfig } = await import(
-      "../../lib/story/exportConfig"
-    );
+    const { downloadStoryConfig } =
+      await import("../../lib/story/exportConfig");
     expect(downloadStoryConfig).toHaveBeenCalledWith("s-1", "Demo");
   });
 

--- a/frontend/src/lib/story/useArchivalDownload.ts
+++ b/frontend/src/lib/story/useArchivalDownload.ts
@@ -1,0 +1,52 @@
+import { useRef, useState } from "react";
+import { downloadArchivalHtml } from "./archival/downloadArchival";
+
+interface ArchivalProgressState {
+  open: boolean;
+  current: number;
+  total: number;
+}
+
+export function useArchivalDownload(storyId: string, storyTitle: string) {
+  const [progress, setProgress] = useState<ArchivalProgressState>({
+    open: false,
+    current: 0,
+    total: 0,
+  });
+  const abortRef = useRef<AbortController | null>(null);
+
+  async function handleArchival() {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setProgress({ open: true, current: 0, total: 1 });
+    try {
+      await downloadArchivalHtml(
+        storyId,
+        storyTitle,
+        (current, total) => {
+          if (controller.signal.aborted) return;
+          setProgress({ open: true, current, total });
+        },
+        controller.signal
+      );
+    } catch (err) {
+      if ((err as { name?: string })?.name !== "AbortError") {
+        console.error("Failed to download archival HTML", err);
+      }
+    } finally {
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setProgress({ open: false, current: 0, total: 0 });
+      }
+    }
+  }
+
+  function handleCancelArchival() {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setProgress({ open: false, current: 0, total: 0 });
+  }
+
+  return { progress, handleArchival, handleCancelArchival };
+}

--- a/frontend/src/lib/story/useArchivalDownload.ts
+++ b/frontend/src/lib/story/useArchivalDownload.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { downloadArchivalHtml } from "./archival/downloadArchival";
 
 interface ArchivalProgressState {
@@ -14,6 +14,13 @@ export function useArchivalDownload(storyId: string, storyTitle: string) {
     total: 0,
   });
   const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      abortRef.current = null;
+    };
+  }, []);
 
   async function handleArchival() {
     abortRef.current?.abort();

--- a/frontend/src/pages/StoryEditorPage.tsx
+++ b/frontend/src/pages/StoryEditorPage.tsx
@@ -7,6 +7,7 @@ import {
   Check,
   SpinnerGap,
   CaretDown,
+  DownloadSimple,
 } from "@phosphor-icons/react";
 import { useTooltipDismiss } from "../hooks/useTooltipDismiss";
 import { useStoryEditor } from "../hooks/useStoryEditor";
@@ -17,6 +18,7 @@ import { VideoChapterEditor } from "../components/editor/VideoChapterEditor";
 import { UploadModal } from "../components/UploadModal";
 import { ConnectionModal } from "../components/ConnectionModal";
 import { PublishDialog } from "../components/PublishDialog";
+import { ExportDialog } from "../components/ExportDialog";
 import { Header } from "../components/Header";
 import { SaveStatus } from "../components/SaveStatus";
 import { RenderModeIndicator } from "../components/RenderModeIndicator";
@@ -110,6 +112,7 @@ export default function StoryEditorPage() {
   } = useStoryEditor();
 
   const [connectionModalOpen, setConnectionModalOpen] = useState(false);
+  const [exportDialogOpen, setExportDialogOpen] = useState(false);
 
   const activeDatasetTimesteps = useMemo(() => {
     if (!activeChapter || !isMapBoundChapter(activeChapter)) return undefined;
@@ -204,6 +207,16 @@ export default function StoryEditorPage() {
               </Text>
             </Flex>
           )}
+          <Button
+            size="sm"
+            variant="outline"
+            borderColor="brand.orange"
+            color="brand.orange"
+            _hover={{ bg: "brand.bgSubtle" }}
+            onClick={() => setExportDialogOpen(true)}
+          >
+            <DownloadSimple size={14} weight="bold" /> Export
+          </Button>
           <Flex align="center">
             <Button
               size="sm"
@@ -504,6 +517,11 @@ export default function StoryEditorPage() {
         shareUrl={`${window.location.origin}/story/${story.id}`}
         onPublish={handlePublish}
         onClose={() => setPublishDialogOpen(false)}
+      />
+      <ExportDialog
+        open={exportDialogOpen}
+        story={story}
+        onClose={() => setExportDialogOpen(false)}
       />
     </Box>
   );


### PR DESCRIPTION
## Summary

Plan 05 of the storytelling pivot — the final one. Makes story export a first-class action everywhere it belongs.

- **Workspace top-nav Export link** — new "Export" entry (with `DownloadSimple` icon) in the right-side utility cluster, only visible in workspace context. Opens a story picker; selecting a story opens the export dialog.
- **Story editor Export button** — new brand-orange-tinted Export button next to Preview/Publish. Works on drafts (no need to publish first).
- **`ExportSection` extracted** — the static-bundle / archival-HTML / config-JSON / embed-snippet block formerly inlined in `PublishDialog` is now a reusable `<ExportSection>` component. `PublishDialog` still uses it (unchanged behavior when published). New `ExportDialog` wraps it for the standalone draft case. New `ExportPickerDialog` adds the story-list picker for the top-nav case.
- **`useArchivalDownload` hook** — abort-controller-aware progress state for the archival HTML download was hoisted out of `PublishDialog` into a hook used by both `PublishDialog` and `ExportDialog` so the archival progress UI behaves identically in both flows.

## Why

Current state: export is only reachable from inside `PublishDialog`, which itself only surfaces export after a story has been *published*. For a "build it, export it, share it" demo story, that is exactly backwards — exporting should be available from anywhere, including drafts. Spec section *Export prominence* in \`specs/2026-05-12-storytelling-pivot-design.md\`.

## Test plan

- [x] \`cd frontend && npx vitest run\` — 805 tests pass
- [x] \`cd frontend && yarn tsc --noEmit && yarn eslint src/ --max-warnings 0 && yarn prettier --check\` — all clean
- [x] Top-nav Export link renders in workspace, not on public landing
- [x] Top-nav Export opens picker showing user stories only (not examples); empty-state copy shown when no stories
- [x] Editor Export button renders next to Preview; brand-orange outline; opens ExportDialog with the three Download buttons and embed snippet (works on a draft)
- [x] Picker → story click → ExportDialog opens (covered by unit test)
- [x] PublishDialog still shows the export block when published (unit tests in PublishDialog.export.test.tsx + PublishDialog.staticBundle.test.tsx still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added story export workflow with three download options: story config, static bundle, and archival HTML.
  * Export entry points added to header and story editor; a story picker (excludes example stories) lets you choose which story to export.
  * Archival export shows progress overlay with cancel support; picker shows loading, error, and empty states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/446)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->