### PR TITLE
fix(stories): send workspace header on story export requests

### DIFF
--- a/frontend/src/lib/story/__tests__/exportConfig.test.ts
+++ b/frontend/src/lib/story/__tests__/exportConfig.test.ts
@@ -43,9 +43,9 @@ describe("downloadStoryConfig", () => {
 
     await downloadStoryConfig("story-1", "My Story");
 
-    expect(global.fetch).toHaveBeenCalledWith(
-      "/api/stories/story-1/export/config"
-    );
+    expect(global.fetch).toHaveBeenCalled();
+    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe("/api/stories/story-1/export/config");
     expect(createObjectURL).toHaveBeenCalled();
     expect(clickSpy).toHaveBeenCalled();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock");

--- a/frontend/src/lib/story/archival/downloadArchival.ts
+++ b/frontend/src/lib/story/archival/downloadArchival.ts
@@ -1,3 +1,4 @@
+import { workspaceFetch } from "../../api";
 import type { CngRcConfig } from "../cngRcTypes";
 import { buildArchivalHtml } from "./buildArchivalHtml";
 
@@ -7,7 +8,7 @@ export async function downloadArchivalHtml(
   onProgress?: (current: number, total: number) => void,
   signal?: AbortSignal
 ): Promise<void> {
-  const response = await fetch(
+  const response = await workspaceFetch(
     `/api/stories/${encodeURIComponent(storyId)}/export/config`,
     {
       signal,

--- a/frontend/src/lib/story/buildStaticBundle.ts
+++ b/frontend/src/lib/story/buildStaticBundle.ts
@@ -1,4 +1,5 @@
 import JSZip from "jszip";
+import { workspaceFetch } from "../api";
 import { slugifyStoryTitle } from "./slug";
 
 interface ViewerManifest {
@@ -21,7 +22,7 @@ export async function buildAndDownloadBundle(
     const response = await fetch(`/viewer/${name}`).then(assertOk);
     return [name, await response.arrayBuffer()] as const;
   });
-  const configFetch = fetch(
+  const configFetch = workspaceFetch(
     `/api/stories/${encodeURIComponent(storyId)}/export/config`
   )
     .then(assertOk)

--- a/frontend/src/lib/story/exportConfig.ts
+++ b/frontend/src/lib/story/exportConfig.ts
@@ -1,10 +1,13 @@
+import { workspaceFetch } from "../api";
 import { slugifyStoryTitle } from "./slug";
 
 export async function downloadStoryConfig(
   storyId: string,
   storyTitle: string
 ): Promise<void> {
-  const response = await fetch(`/api/stories/${storyId}/export/config`);
+  const response = await workspaceFetch(
+    `/api/stories/${storyId}/export/config`
+  );
   if (!response.ok) {
     throw new Error(`Failed to export story config: ${response.status}`);
   }


### PR DESCRIPTION
## Summary
- Three story export endpoints (cng-rc JSON, archival HTML, static bundle zip) used raw `fetch()` instead of `workspaceFetch()`, so requests went out without the `X-Workspace-Id` header.
- The backend route at `ingestion/src/routes/stories.py:145` 404s unpublished, non-example stories when the workspace header is missing, so owners could not export their own draft stories.
- Swapped all three call sites to `workspaceFetch()`. Updated the one test assertion that pinned `fetch` to a single-arg call.

## Test plan
- [x] `npx vitest run` — full frontend suite (806 pass / 0 fail)
- [ ] Manual: open a draft story in the editor, run all three Export options, confirm downloads succeed

## Notes
- Bug 2 from the same investigation (`/viewer/manifest.json` 404 → JSON parse error on static-bundle zip in local dev) is intentionally **not** fixed here. Static bundle export still requires a prod-built viewer bundle; will document in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal improvements and refactoring with no user-facing changes.

* **Refactor**
  * Improved internal data fetching mechanism for story export functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/449)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->