### PR TITLE
fix(stories): guard against undefined onAfterRender crashing guided tour

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import DiscoverDatasetPage from "./pages/DiscoverDatasetPage";
 import LandingPage from "./pages/LandingPage";
 import { Toaster } from "./components/ui/toaster";
 import { toaster } from "./lib/toaster";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 
 function StoryReaderRedirect() {
   const { id } = useParams<{ id: string }>();
@@ -66,16 +67,18 @@ function WorkspaceRoutes() {
 export default function App() {
   return (
     <>
-      <Routes>
-        <Route path="/" element={<LandingPage />} />
-        <Route path="/about" element={<AboutPage />} />
-        <Route path="/story/:id/embed" element={<StoryEmbedPage />} />
-        <Route path="/map/connection/:id" element={<MapPage shared />} />
-        <Route path="/map/:id" element={<MapPage shared />} />
-        <Route path="/story/:id" element={<StoryReaderPage />} />
-        <Route path="/w/:workspaceId/*" element={<WorkspaceRoutes />} />
-        <Route path="*" element={<WorkspaceRedirect />} />
-      </Routes>
+      <ErrorBoundary>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/about" element={<AboutPage />} />
+          <Route path="/story/:id/embed" element={<StoryEmbedPage />} />
+          <Route path="/map/connection/:id" element={<MapPage shared />} />
+          <Route path="/map/:id" element={<MapPage shared />} />
+          <Route path="/story/:id" element={<StoryReaderPage />} />
+          <Route path="/w/:workspaceId/*" element={<WorkspaceRoutes />} />
+          <Route path="*" element={<WorkspaceRedirect />} />
+        </Routes>
+      </ErrorBoundary>
       <Toaster toaster={toaster} />
     </>
   );

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ReactNode } from "react";
-import { Box, Heading, Text, Button } from "@chakra-ui/react";
+import { Box, Button, Flex, Text } from "@chakra-ui/react";
+import { ArrowClockwise, BugBeetle, GithubLogo } from "@phosphor-icons/react";
 
 interface Props {
   children: ReactNode;
@@ -10,6 +11,8 @@ interface State {
   error: Error | null;
 }
 
+const ISSUE_URL = "https://github.com/aboydnw/cng-sandbox/issues/new";
+
 export class ErrorBoundary extends Component<Props, State> {
   state: State = { hasError: false, error: null };
 
@@ -17,20 +20,98 @@ export class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
+  componentDidCatch(error: Error, info: { componentStack?: string | null }) {
+    console.error("ErrorBoundary caught:", error, info.componentStack);
+  }
+
   render() {
-    if (this.state.hasError) {
-      return (
-        <Box p={8} textAlign="center">
-          <Heading size="lg" mb={4}>
-            Something went wrong
-          </Heading>
-          <Text mb={4} color="gray.600">
-            {this.state.error?.message || "An unexpected error occurred"}
+    if (!this.state.hasError) return this.props.children;
+
+    const message = this.state.error?.message || "An unexpected error occurred";
+
+    return (
+      <Flex
+        direction="column"
+        align="center"
+        justify="center"
+        minH="100vh"
+        bg="white"
+        px={8}
+        py={12}
+      >
+        <Flex
+          align="center"
+          justify="center"
+          w="56px"
+          h="56px"
+          bg="brand.bgSubtle"
+          borderRadius="full"
+          mb={5}
+          color="brand.brown"
+        >
+          <BugBeetle size={24} weight="duotone" />
+        </Flex>
+        <Text color="brand.brown" fontSize="20px" fontWeight={700} mb={2}>
+          Something went wrong
+        </Text>
+        <Text
+          color="brand.textSecondary"
+          fontSize="14px"
+          mb={5}
+          maxW="420px"
+          textAlign="center"
+          lineHeight={1.5}
+        >
+          Try refreshing the page. If the problem persists, please open an issue
+          on GitHub so we can fix it.
+        </Text>
+        <Box
+          maxW="420px"
+          w="100%"
+          mb={7}
+          px={3}
+          py={2}
+          bg="brand.bgSubtle"
+          borderWidth="1px"
+          borderColor="brand.border"
+          borderRadius="4px"
+        >
+          <Text
+            color="brand.brown"
+            fontSize="12px"
+            fontFamily="mono"
+            textAlign="center"
+            wordBreak="break-word"
+          >
+            {message}
           </Text>
-          <Button onClick={() => window.location.reload()}>Reload page</Button>
         </Box>
-      );
-    }
-    return this.props.children;
+        <Flex gap={3}>
+          <Button
+            bg="brand.orange"
+            color="white"
+            fontWeight={600}
+            borderRadius="4px"
+            _hover={{ bg: "brand.orangeHover" }}
+            onClick={() => window.location.reload()}
+          >
+            <ArrowClockwise size={16} weight="bold" />
+            Refresh page
+          </Button>
+          <Button
+            bg="brand.bgSubtle"
+            color="brand.brown"
+            fontWeight={500}
+            borderRadius="4px"
+            asChild
+          >
+            <a href={ISSUE_URL} target="_blank" rel="noopener noreferrer">
+              <GithubLogo size={16} weight="bold" />
+              Report on GitHub
+            </a>
+          </Button>
+        </Flex>
+      </Flex>
+    );
   }
 }

--- a/frontend/src/components/UnifiedMap.tsx
+++ b/frontend/src/components/UnifiedMap.tsx
@@ -117,7 +117,10 @@ export const UnifiedMap = forwardRef<any, UnifiedMapProps>(function UnifiedMap(
         onHover={onHover}
         onClick={onClick}
         getTooltip={getTooltip}
-        onAfterRender={onAfterRender}
+        // Only forward when defined: deck.gl's Deck class calls
+        // `this.props.onAfterRender()` unconditionally during _drawLayers, so
+        // an explicit `undefined` here overrides its `noop` default and throws.
+        {...(onAfterRender ? { onAfterRender } : {})}
       >
         <Map
           ref={mapRef}

--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { ErrorBoundary } from "../ErrorBoundary";
+
+function wrap(ui: React.ReactElement) {
+  return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+function Boom({
+  message = "kaboom",
+}: {
+  message?: string;
+}): React.ReactElement {
+  throw new Error(message);
+}
+
+describe("ErrorBoundary", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("renders children when no error is thrown", () => {
+    wrap(
+      <ErrorBoundary>
+        <div data-testid="child">OK</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("renders fallback with error message, refresh button, and GitHub issue link on crash", () => {
+    wrap(
+      <ErrorBoundary>
+        <Boom message="this.props.onAfterRender is not a function" />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/this\.props\.onAfterRender is not a function/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /refresh page/i })
+    ).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /report on github/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/aboydnw/cng-sandbox/issues/new"
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/frontend/src/components/__tests__/UnifiedMap.test.tsx
+++ b/frontend/src/components/__tests__/UnifiedMap.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+
+const deckPropsCalls: Record<string, unknown>[] = [];
+
+vi.mock("@deck.gl/react", () => ({
+  default: (props: Record<string, unknown>) => {
+    deckPropsCalls.push(props);
+    return (
+      <div data-testid="deckgl-mock">{props.children as React.ReactNode}</div>
+    );
+  },
+}));
+
+vi.mock("@deck.gl/core", () => ({
+  MapView: class {
+    constructor(_opts: unknown) {}
+  },
+  FlyToInterpolator: class {},
+}));
+
+vi.mock("react-map-gl/maplibre", () => ({
+  default: () => <div data-testid="maplibre-mock" />,
+}));
+
+import { UnifiedMap } from "../UnifiedMap";
+
+function wrap(ui: React.ReactElement) {
+  return render(<ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>);
+}
+
+const camera = { longitude: 0, latitude: 0, zoom: 1, bearing: 0, pitch: 0 };
+
+describe("UnifiedMap", () => {
+  // Regression: deck.gl's Deck class calls `this.props.onAfterRender()`
+  // unconditionally during _drawLayers. Passing `onAfterRender={undefined}`
+  // overrides its `noop` default and throws
+  // `TypeError: this.props.onAfterRender is not a function`,
+  // blanking the story reader on any guided-tour chapter.
+  it("does not pass onAfterRender to DeckGL when the prop is omitted", () => {
+    deckPropsCalls.length = 0;
+    wrap(
+      <UnifiedMap
+        camera={camera}
+        onCameraChange={() => {}}
+        layers={[]}
+        basemap="positron"
+        onBasemapChange={() => {}}
+      />
+    );
+    expect(deckPropsCalls).toHaveLength(1);
+    expect("onAfterRender" in deckPropsCalls[0]).toBe(false);
+  });
+
+  it("forwards onAfterRender when provided", () => {
+    deckPropsCalls.length = 0;
+    const cb = vi.fn();
+    wrap(
+      <UnifiedMap
+        camera={camera}
+        onCameraChange={() => {}}
+        layers={[]}
+        basemap="positron"
+        onBasemapChange={() => {}}
+        onAfterRender={cb}
+      />
+    );
+    expect(deckPropsCalls[0].onAfterRender).toBe(cb);
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause**: PR #451 added `onAfterRender={onAfterRender}` to `<DeckGL>` in `UnifiedMap`. Callers that did not pass `onAfterRender` ended up forwarding `undefined`, which overrode deck.gl_s internal `noop` default. `Deck#_drawLayers` then called `this.props.onAfterRender()` and threw `TypeError: this.props.onAfterRender is not a function`, blanking the page whenever a user opened a guided tour chapter.
- **Fix**: spread the prop conditionally so deck.gl falls back to its own default when no callback is supplied. Added a regression test that mocks `<DeckGL>` and asserts the prop is absent when not provided.
- **Error page**: upgraded the existing `ErrorBoundary` to a branded fallback (warm tokens, Phosphor icons, dedicated _Refresh page_ and _Report on GitHub_ actions) and wrapped it around the App routes so the next unexpected crash gives users a recovery path instead of a blank screen.

## Test plan
- [x] `npx vitest run` (full frontend suite, 811 tests) — passes
- [x] New regression test (`UnifiedMap.test.tsx`) verified to fail without the fix and pass with it
- [x] New `ErrorBoundary.test.tsx` covers fallback content, refresh button, and GitHub link `target`/`rel`
- [x] `prettier --check` and `tsc --noEmit` clean
- [ ] Manual smoke on Mac: open a published story with multiple guided tour chapters and click through; confirm map renders and no `onAfterRender` console error
- [ ] (Optional) Force a render-phase crash and confirm the new fallback page renders with both action buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced error handling with an improved, user-friendly error display screen
  * Added "Refresh page" button and "Report on GitHub" link to help users recover from errors and report issues

* **Bug Fixes**
  * Fixed map component rendering callback behavior to ensure proper functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/459)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->