### PR TITLE
fix(share): treat example datasets as always-shared in share UI

### DIFF
--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -8,6 +8,7 @@ interface ShareButtonProps {
   resourceId: string;
   isShared: boolean;
   onSharedChange(newValue: boolean): void;
+  isExample?: boolean;
 }
 
 export function ShareButton({
@@ -15,30 +16,33 @@ export function ShareButton({
   resourceId,
   isShared,
   onSharedChange,
+  isExample = false,
 }: ShareButtonProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const showSharedView = isShared || isExample;
 
   return (
     <>
       <Button
-        bg={isShared ? "brand.bgSubtle" : "brand.orange"}
-        color={isShared ? "brand.orange" : "white"}
-        borderWidth={isShared ? "1px" : undefined}
-        borderColor={isShared ? "brand.border" : undefined}
+        bg={showSharedView ? "brand.bgSubtle" : "brand.orange"}
+        color={showSharedView ? "brand.orange" : "white"}
+        borderWidth={showSharedView ? "1px" : undefined}
+        borderColor={showSharedView ? "brand.border" : undefined}
         size="sm"
         fontWeight={600}
         borderRadius="4px"
-        _hover={{ bg: isShared ? "brand.border" : "brand.orangeHover" }}
+        _hover={{ bg: showSharedView ? "brand.border" : "brand.orangeHover" }}
         onClick={() => setDialogOpen(true)}
         px={4}
       >
         <ShareNetwork size={14} weight="bold" />
-        {isShared ? "Shared" : "Share"}
+        {showSharedView ? "Shared" : "Share"}
       </Button>
       <ShareDialog
         kind={kind}
         resourceId={resourceId}
         isShared={isShared}
+        isExample={isExample}
         isOpen={dialogOpen}
         onClose={() => setDialogOpen(false)}
         onSharedChange={onSharedChange}

--- a/frontend/src/components/ShareDialog.tsx
+++ b/frontend/src/components/ShareDialog.tsx
@@ -31,6 +31,7 @@ interface ShareDialogProps {
   isOpen: boolean;
   onClose(): void;
   onSharedChange(newValue: boolean): void;
+  isExample?: boolean;
 }
 
 export function ShareDialog({
@@ -40,7 +41,9 @@ export function ShareDialog({
   isOpen,
   onClose,
   onSharedChange,
+  isExample = false,
 }: ShareDialogProps) {
+  const showSharedView = isShared || isExample;
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -119,13 +122,13 @@ export function ShareDialog({
           <DialogContent shadow="lg">
             <DialogHeader>
               <DialogTitle>
-                {isShared ? "Public link" : "Share publicly"}
+                {showSharedView ? "Public link" : "Share publicly"}
               </DialogTitle>
               <CloseButton size="sm" onClick={handleClose} />
             </DialogHeader>
 
             <DialogBody>
-              {isShared ? (
+              {showSharedView ? (
                 <Flex direction="column" gap={3}>
                   <Text fontSize="sm" color="gray.600">
                     Anyone with this link can view this {kind} without signing
@@ -172,7 +175,17 @@ export function ShareDialog({
             </DialogBody>
 
             <DialogFooter>
-              {isShared ? (
+              {isExample ? (
+                <Button
+                  size="sm"
+                  bg="brand.orange"
+                  color="white"
+                  _hover={{ bg: "brand.orangeHover" }}
+                  onClick={handleClose}
+                >
+                  Done
+                </Button>
+              ) : isShared ? (
                 <>
                   <Button
                     variant="ghost"

--- a/frontend/src/components/__tests__/ShareDialog.test.tsx
+++ b/frontend/src/components/__tests__/ShareDialog.test.tsx
@@ -191,4 +191,53 @@ describe("ShareDialog", () => {
       expect(screen.getByText(/something went wrong/i)).toBeTruthy();
     });
   });
+
+  describe("when isExample is true", () => {
+    it("renders the Public link view even when isShared is false", () => {
+      renderWithChakra(
+        <ShareDialog
+          {...defaultProps}
+          kind="dataset"
+          resourceId="ex-1"
+          isShared={false}
+          isExample={true}
+        />
+      );
+      expect(screen.getByRole("heading", { name: "Public link" })).toBeTruthy();
+      expect(
+        screen.getByDisplayValue(`${window.location.origin}/map/ex-1`)
+      ).toBeTruthy();
+    });
+
+    it("does not render Share or Stop sharing buttons", () => {
+      renderWithChakra(
+        <ShareDialog
+          {...defaultProps}
+          kind="dataset"
+          resourceId="ex-1"
+          isShared={false}
+          isExample={true}
+        />
+      );
+      expect(screen.queryByRole("button", { name: /^Share$/i })).toBeNull();
+      expect(
+        screen.queryByRole("button", { name: /Stop sharing/i })
+      ).toBeNull();
+    });
+
+    it("never calls datasetsApi.share", async () => {
+      renderWithChakra(
+        <ShareDialog
+          {...defaultProps}
+          kind="dataset"
+          resourceId="ex-1"
+          isShared={false}
+          isExample={true}
+        />
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^Done$/i }));
+      await Promise.resolve();
+      expect(datasetsApi.share).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -526,6 +526,7 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
                   : item?.dataset?.id) ?? ""
               }
               isShared={isShared}
+              isExample={itemIsExample}
               onSharedChange={setLocalIsShared}
             />
           )}


### PR DESCRIPTION
## Summary
- Backend [datasets.py:112-115](ingestion/src/routes/datasets.py#L112-L115) rejects `PATCH /datasets/{id}/share` with 403 for `is_example=True` datasets, but the frontend still rendered the toggleable Share dialog on example datasets — clicking "Share" hit that 403 (issue #334).
- Example datasets are already publicly readable for every workspace ([sharing.py:70-71](ingestion/src/services/sharing.py#L70-L71)), so a toggle is meaningless. Drop it on examples: `ShareButton` always shows "Shared", `ShareDialog` renders the public-link / copy view with a single Done button, no PATCH issued.
- `MapPage` now threads `itemIsExample` (already computed) into `ShareButton`.

Closes #334

## Test plan
- [x] `npx vitest run` — all 814 tests pass, including 3 new `ShareDialog` cases covering example-dataset behavior
- [x] `npx prettier --check` clean on all touched files
- [x] `npx tsc --noEmit` clean
- [ ] Smoke: open an example dataset (e.g. source.coop), click Share, confirm dialog shows "Public link" + Copy button, no 403 in network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ShareButton and ShareDialog components now support example items with shared view presentation
  * Example items display as shared in the UI without requiring actual sharing configuration
  * ShareDialog provides context-appropriate actions and messaging for example and shared content
  * ShareButton intelligently combines example and shared states in its presentation

* **Tests**
  * Added comprehensive test coverage for example item functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/461)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->