### PR TITLE
feat: differentiate workspace home from Stories tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import MapPage from "./pages/MapPage";
 import ExpiredPage from "./pages/ExpiredPage";
 import DataPage from "./pages/DataPage";
 import StoriesPage from "./pages/StoriesPage";
+import WorkspaceHomePage from "./pages/WorkspaceHomePage";
 import StoryReaderPage from "./pages/StoryReaderPage";
 import StoryEditorPage from "./pages/StoryEditorPage";
 import StoryEmbedPage from "./pages/StoryEmbedPage";
@@ -35,22 +36,17 @@ function LibraryRedirect() {
   return <Navigate to={workspacePath("/data")} replace />;
 }
 
-function StoriesRedirect() {
-  const { workspacePath } = useWorkspace();
-  return <Navigate to={workspacePath("/")} replace />;
-}
-
 function WorkspaceRoutes() {
   return (
     <WorkspaceProvider>
       <Routes>
-        <Route path="/" element={<StoriesPage />} />
+        <Route path="/" element={<WorkspaceHomePage />} />
+        <Route path="/stories" element={<StoriesPage />} />
         <Route path="/quick-map" element={<UploadPage />} />
         <Route path="/map/:id" element={<MapPage />} />
         <Route path="/map/connection/:id" element={<MapPage />} />
         <Route path="/expired/:id" element={<ExpiredPage />} />
         <Route path="/data" element={<DataPage />} />
-        <Route path="/stories" element={<StoriesRedirect />} />
         <Route path="/library" element={<LibraryRedirect />} />
         <Route path="/datasets" element={<DatasetsRedirect />} />
         <Route path="/story/new" element={<StoryEditorPage />} />

--- a/frontend/src/__tests__/App.routing.test.tsx
+++ b/frontend/src/__tests__/App.routing.test.tsx
@@ -31,6 +31,10 @@ vi.mock("../pages/StoriesPage", () => ({
   default: () => <div data-testid="stories-page" />,
 }));
 
+vi.mock("../pages/WorkspaceHomePage", () => ({
+  default: () => <div data-testid="workspace-home-page" />,
+}));
+
 vi.mock("../pages/LibraryPage", () => ({
   default: () => <div data-testid="library-page" />,
 }));
@@ -92,9 +96,9 @@ test("/about renders the public AboutPage without a workspace", () => {
   expect(screen.getByTestId("about-page")).toBeInTheDocument();
 });
 
-test("/w/:workspaceId/ renders the workspace StoriesPage", () => {
+test("/w/:workspaceId/ renders the WorkspaceHomePage", () => {
   renderApp("/w/abc12345/");
-  expect(screen.getByTestId("stories-page")).toBeInTheDocument();
+  expect(screen.getByTestId("workspace-home-page")).toBeInTheDocument();
 });
 
 test("/w/:workspaceId/quick-map renders the workspace UploadPage", () => {
@@ -102,7 +106,7 @@ test("/w/:workspaceId/quick-map renders the workspace UploadPage", () => {
   expect(screen.getByTestId("upload-page")).toBeInTheDocument();
 });
 
-test("/w/:workspaceId/stories redirects to workspace root", () => {
+test("/w/:workspaceId/stories renders the StoriesPage", () => {
   renderApp("/w/abc12345/stories");
   expect(screen.getByTestId("stories-page")).toBeInTheDocument();
 });

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -41,7 +41,7 @@ export default function LandingPage() {
   const startStory = () => {
     const id = generateWorkspaceId();
     localStorage.setItem(STORAGE_KEY, id);
-    navigate(`/w/${id}/`);
+    navigate(`/w/${id}/story/new`);
   };
 
   const openExistingWorkspace = () => {

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Box, Button, Flex, Heading, Input, Text } from "@chakra-ui/react";
 import { ArrowRight, ArrowSquareOut, GithubLogo } from "@phosphor-icons/react";
@@ -28,6 +28,7 @@ export default function LandingPage() {
   const [enteredId, setEnteredId] = useState("");
   const [examples, setExamples] = useState<Story[]>([]);
   const [cloningId, setCloningId] = useState<string | null>(null);
+  const cloneInFlightRef = useRef(false);
 
   useEffect(() => {
     if (switching) return;
@@ -50,7 +51,8 @@ export default function LandingPage() {
   };
 
   const cloneExampleAndOpenEditor = async (story: Story) => {
-    if (cloningId) return;
+    if (cloneInFlightRef.current) return;
+    cloneInFlightRef.current = true;
     setCloningId(story.id);
     const id = generateWorkspaceId();
     localStorage.setItem(STORAGE_KEY, id);
@@ -59,6 +61,7 @@ export default function LandingPage() {
       const forked = await forkStoryOnServer(story.id);
       navigate(`/w/${id}/story/${forked.id}/edit`);
     } catch {
+      cloneInFlightRef.current = false;
       setCloningId(null);
       navigate(`/w/${id}/`);
     }

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -9,7 +9,11 @@ import {
   generateWorkspaceId,
   WORKSPACE_STORAGE_KEY,
 } from "../hooks/useWorkspace";
-import { listExampleStoriesFromServer } from "../lib/story/api";
+import {
+  forkStoryOnServer,
+  listExampleStoriesFromServer,
+} from "../lib/story/api";
+import { setWorkspaceId } from "../lib/api";
 import { inferDataType } from "../lib/story/dataType";
 import type { Story } from "../lib/story/types";
 
@@ -23,6 +27,7 @@ export default function LandingPage() {
   const switching = searchParams.get("switch") === "1";
   const [enteredId, setEnteredId] = useState("");
   const [examples, setExamples] = useState<Story[]>([]);
+  const [cloningId, setCloningId] = useState<string | null>(null);
 
   useEffect(() => {
     if (switching) return;
@@ -42,6 +47,21 @@ export default function LandingPage() {
     const id = generateWorkspaceId();
     localStorage.setItem(STORAGE_KEY, id);
     navigate(`/w/${id}/story/new`);
+  };
+
+  const cloneExampleAndOpenEditor = async (story: Story) => {
+    if (cloningId) return;
+    setCloningId(story.id);
+    const id = generateWorkspaceId();
+    localStorage.setItem(STORAGE_KEY, id);
+    setWorkspaceId(id);
+    try {
+      const forked = await forkStoryOnServer(story.id);
+      navigate(`/w/${id}/story/${forked.id}/edit`);
+    } catch {
+      setCloningId(null);
+      navigate(`/w/${id}/`);
+    }
   };
 
   const openExistingWorkspace = () => {
@@ -145,7 +165,8 @@ export default function LandingPage() {
                   title={story.title}
                   chapterCount={story.chapters.length}
                   dataType={inferDataType(story)}
-                  onClick={startStory}
+                  onClick={() => cloneExampleAndOpenEditor(story)}
+                  loading={cloningId === story.id}
                   compact={false}
                 />
               ))}

--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -1,18 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { Box, Button, Flex, Heading, Table, Text } from "@chakra-ui/react";
 import { SpinnerGap } from "@phosphor-icons/react";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
 import { useWorkspace } from "../hooks/useWorkspace";
-import {
-  listStoriesFromServer,
-  deleteStoryFromServer,
-  forkStoryOnServer,
-} from "../lib/story/api";
+import { listStoriesFromServer, deleteStoryFromServer } from "../lib/story/api";
 import type { Story } from "../lib/story/types";
-import { ExampleStoryCard } from "../components/ExampleStoryCard";
-import { inferDataType } from "../lib/story/dataType";
 
 function timeAgo(dateStr: string): string {
   const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
@@ -27,28 +21,9 @@ function timeAgo(dateStr: string): string {
 
 export default function StoriesPage() {
   const { workspacePath } = useWorkspace();
-  const navigate = useNavigate();
   const [stories, setStories] = useState<Story[]>([]);
   const [loading, setLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
-  const [cloningId, setCloningId] = useState<string | null>(null);
-  const cloneInFlightRef = useRef(false);
-
-  const handleCloneExample = useCallback(
-    async (story: Story) => {
-      if (cloneInFlightRef.current) return;
-      cloneInFlightRef.current = true;
-      setCloningId(story.id);
-      try {
-        const forked = await forkStoryOnServer(story.id);
-        navigate(workspacePath(`/story/${forked.id}/edit`));
-      } catch {
-        cloneInFlightRef.current = false;
-        setCloningId(null);
-      }
-    },
-    [navigate, workspacePath]
-  );
 
   useEffect(() => {
     listStoriesFromServer()
@@ -70,7 +45,6 @@ export default function StoriesPage() {
     }
   }, []);
 
-  const exampleStories = stories.filter((s) => s.is_example);
   const userStories = stories.filter((s) => !s.is_example);
 
   return (
@@ -109,7 +83,7 @@ export default function StoriesPage() {
           </Flex>
         ) : userStories.length === 0 ? (
           <Text color="gray.500" fontSize="sm" mb={2}>
-            No stories yet — start one or browse the example stories below.
+            No stories yet — click &ldquo;New story&rdquo; to get started.
           </Text>
         ) : (
           <Table.Root size="sm" tableLayout="fixed">
@@ -173,41 +147,6 @@ export default function StoriesPage() {
               ))}
             </Table.Body>
           </Table.Root>
-        )}
-
-        <Box my={8} h="1px" bg="brand.border" />
-
-        <Heading size="md" color="gray.700" mb={3}>
-          Example stories
-        </Heading>
-        <Text fontSize="13px" color="gray.500" mb={3}>
-          Curated stories shared with every workspace.
-        </Text>
-        {exampleStories.length === 0 ? (
-          <Text fontSize="sm" color="gray.500">
-            No example stories available.
-          </Text>
-        ) : (
-          <Box
-            display="grid"
-            gridTemplateColumns={{
-              base: "1fr",
-              md: "repeat(3, 1fr)",
-            }}
-            gap={3}
-          >
-            {exampleStories.map((story) => (
-              <ExampleStoryCard
-                key={story.id}
-                title={story.title}
-                chapterCount={story.chapters.length}
-                dataType={inferDataType(story)}
-                onClick={() => handleCloneExample(story)}
-                loading={cloningId === story.id}
-                compact={userStories.length > 0}
-              />
-            ))}
-          </Box>
         )}
       </Box>
       <Footer />

--- a/frontend/src/pages/WorkspaceHomePage.tsx
+++ b/frontend/src/pages/WorkspaceHomePage.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { Box, Button, Flex, Heading, Text } from "@chakra-ui/react";
 import { ArrowRight, SpinnerGap } from "@phosphor-icons/react";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
+import { ExampleStoryCard } from "../components/ExampleStoryCard";
 import { useWorkspace } from "../hooks/useWorkspace";
-import { listStoriesFromServer } from "../lib/story/api";
+import { forkStoryOnServer, listStoriesFromServer } from "../lib/story/api";
 import { workspaceFetch } from "../lib/api";
+import { inferDataType } from "../lib/story/dataType";
 import { config } from "../config";
 import type { Story } from "../lib/story/types";
 import type { Dataset } from "../types";
@@ -67,11 +69,34 @@ export default function WorkspaceHomePage() {
     };
   }, []);
 
+  const navigate = useNavigate();
+  const [cloningId, setCloningId] = useState<string | null>(null);
+  const cloneInFlightRef = useRef(false);
+
   const userStories = (stories ?? []).filter((s) => !s.is_example);
+  const exampleStories = (stories ?? []).filter((s) => s.is_example);
   const userDatasets = (datasets ?? []).filter((d) => !d.is_example);
   const recentStories = sortByUpdated(userStories).slice(0, 3);
   const recentDatasets = sortByUpdated(userDatasets).slice(0, 3);
   const loading = stories === null || datasets === null;
+  const isEmpty =
+    !loading && userStories.length === 0 && userDatasets.length === 0;
+
+  const handleCloneExample = useCallback(
+    async (story: Story) => {
+      if (cloneInFlightRef.current) return;
+      cloneInFlightRef.current = true;
+      setCloningId(story.id);
+      try {
+        const forked = await forkStoryOnServer(story.id);
+        navigate(workspacePath(`/story/${forked.id}/edit`));
+      } catch {
+        cloneInFlightRef.current = false;
+        setCloningId(null);
+      }
+    },
+    [navigate, workspacePath]
+  );
 
   return (
     <Flex direction="column" minH="100vh" bg="gray.50">
@@ -96,6 +121,38 @@ export default function WorkspaceHomePage() {
               style={{ animation: "spin 1s linear infinite" }}
             />
           </Flex>
+        ) : isEmpty ? (
+          <Box>
+            <Heading size="md" color="gray.700" mb={2}>
+              This workspace is empty
+            </Heading>
+            <Text fontSize="sm" color="gray.500" mb={6}>
+              Clone an example story to get started — you can edit it freely.
+            </Text>
+            {exampleStories.length === 0 ? (
+              <Text fontSize="sm" color="gray.500">
+                No examples available right now.
+              </Text>
+            ) : (
+              <Box
+                display="grid"
+                gridTemplateColumns={{ base: "1fr", md: "repeat(3, 1fr)" }}
+                gap={3}
+              >
+                {exampleStories.slice(0, 3).map((story) => (
+                  <ExampleStoryCard
+                    key={story.id}
+                    title={story.title}
+                    chapterCount={story.chapters.length}
+                    dataType={inferDataType(story)}
+                    onClick={() => handleCloneExample(story)}
+                    loading={cloningId === story.id}
+                    compact={false}
+                  />
+                ))}
+              </Box>
+            )}
+          </Box>
         ) : (
           <>
             <Section

--- a/frontend/src/pages/WorkspaceHomePage.tsx
+++ b/frontend/src/pages/WorkspaceHomePage.tsx
@@ -8,6 +8,7 @@ import { ExampleStoryCard } from "../components/ExampleStoryCard";
 import { useWorkspace } from "../hooks/useWorkspace";
 import { forkStoryOnServer, listStoriesFromServer } from "../lib/story/api";
 import { workspaceFetch } from "../lib/api";
+import { toaster } from "../lib/toaster";
 import { inferDataType } from "../lib/story/dataType";
 import { config } from "../config";
 import type { Story } from "../lib/story/types";
@@ -90,9 +91,14 @@ export default function WorkspaceHomePage() {
       try {
         const forked = await forkStoryOnServer(story.id);
         navigate(workspacePath(`/story/${forked.id}/edit`));
-      } catch {
+      } catch (err) {
         cloneInFlightRef.current = false;
         setCloningId(null);
+        toaster.create({
+          title: "Failed to open example story",
+          description: (err as Error).message,
+          type: "error",
+        });
       }
     },
     [navigate, workspacePath]

--- a/frontend/src/pages/WorkspaceHomePage.tsx
+++ b/frontend/src/pages/WorkspaceHomePage.tsx
@@ -1,0 +1,18 @@
+import { Box, Flex, Heading, Text } from "@chakra-ui/react";
+import { Header } from "../components/Header";
+import { Footer } from "../components/Footer";
+
+export default function WorkspaceHomePage() {
+  return (
+    <Flex direction="column" minH="100vh" bg="gray.50">
+      <Header />
+      <Box maxW="960px" mx="auto" py={8} px={4} w="100%" flex="1">
+        <Heading size="lg" color="gray.800" mb={4}>
+          Workspace home
+        </Heading>
+        <Text color="gray.600">Dashboard coming in Task 4.</Text>
+      </Box>
+      <Footer />
+    </Flex>
+  );
+}

--- a/frontend/src/pages/WorkspaceHomePage.tsx
+++ b/frontend/src/pages/WorkspaceHomePage.tsx
@@ -1,18 +1,234 @@
-import { Box, Flex, Heading, Text } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Box, Button, Flex, Heading, Text } from "@chakra-ui/react";
+import { ArrowRight, SpinnerGap } from "@phosphor-icons/react";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
+import { useWorkspace } from "../hooks/useWorkspace";
+import { listStoriesFromServer } from "../lib/story/api";
+import { workspaceFetch } from "../lib/api";
+import { config } from "../config";
+import type { Story } from "../lib/story/types";
+import type { Dataset } from "../types";
+import { displayName } from "../utils/dataset";
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function sortByUpdated<T extends { updated_at?: string; created_at?: string }>(
+  items: T[]
+): T[] {
+  return [...items].sort((a, b) => {
+    const aTime = new Date(a.updated_at ?? a.created_at ?? 0).getTime();
+    const bTime = new Date(b.updated_at ?? b.created_at ?? 0).getTime();
+    return bTime - aTime;
+  });
+}
 
 export default function WorkspaceHomePage() {
+  const { workspaceId, workspacePath } = useWorkspace();
+  const [stories, setStories] = useState<Story[] | null>(null);
+  const [datasets, setDatasets] = useState<Dataset[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listStoriesFromServer()
+      .then((data) => {
+        if (!cancelled) setStories(data);
+      })
+      .catch(() => {
+        if (!cancelled) setStories([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    workspaceFetch(`${config.apiBase}/api/datasets`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: Dataset[]) => {
+        if (!cancelled) setDatasets(data);
+      })
+      .catch(() => {
+        if (!cancelled) setDatasets([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const userStories = (stories ?? []).filter((s) => !s.is_example);
+  const userDatasets = (datasets ?? []).filter((d) => !d.is_example);
+  const recentStories = sortByUpdated(userStories).slice(0, 3);
+  const recentDatasets = sortByUpdated(userDatasets).slice(0, 3);
+  const loading = stories === null || datasets === null;
+
   return (
     <Flex direction="column" minH="100vh" bg="gray.50">
       <Header />
       <Box maxW="960px" mx="auto" py={8} px={4} w="100%" flex="1">
-        <Heading size="lg" color="gray.800" mb={4}>
-          Workspace home
-        </Heading>
-        <Text color="gray.600">Dashboard coming in Task 4.</Text>
+        <Flex justify="space-between" align="center" mb={2}>
+          <Heading size="lg" color="gray.800">
+            Workspace home
+          </Heading>
+        </Flex>
+        <Text fontSize="sm" color="gray.500" mb={6}>
+          Workspace ID:{" "}
+          <Text as="span" fontFamily="mono" color="gray.700">
+            {workspaceId}
+          </Text>
+        </Text>
+
+        {loading ? (
+          <Flex justify="center" py={12}>
+            <SpinnerGap
+              size={32}
+              style={{ animation: "spin 1s linear infinite" }}
+            />
+          </Flex>
+        ) : (
+          <>
+            <Section
+              title="Recent stories"
+              viewAllLabel="View all stories"
+              viewAllHref={workspacePath("/stories")}
+              actionLabel="New story"
+              actionHref={workspacePath("/story/new")}
+              emptyText="No stories yet."
+            >
+              {recentStories.map((s) => (
+                <Row
+                  key={s.id}
+                  title={s.title}
+                  href={workspacePath(`/story/${s.id}/edit`)}
+                  meta={s.updated_at ? timeAgo(s.updated_at) : "—"}
+                />
+              ))}
+            </Section>
+
+            <Box my={8} h="1px" bg="brand.border" />
+
+            <Section
+              title="Recent data"
+              viewAllLabel="View all data"
+              viewAllHref={workspacePath("/data")}
+              actionLabel="Quick map"
+              actionHref={workspacePath("/quick-map")}
+              emptyText="No datasets yet."
+            >
+              {recentDatasets.map((d) => (
+                <Row
+                  key={d.id}
+                  title={displayName(d)}
+                  href={workspacePath(`/map/${d.id}`)}
+                  meta={d.created_at ? timeAgo(d.created_at) : "—"}
+                />
+              ))}
+            </Section>
+          </>
+        )}
       </Box>
       <Footer />
     </Flex>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  viewAllLabel: string;
+  viewAllHref: string;
+  actionLabel: string;
+  actionHref: string;
+  emptyText: string;
+  children: React.ReactNode;
+}
+
+function Section({
+  title,
+  viewAllLabel,
+  viewAllHref,
+  actionLabel,
+  actionHref,
+  emptyText,
+  children,
+}: SectionProps) {
+  const hasChildren = Array.isArray(children)
+    ? children.length > 0
+    : !!children;
+  return (
+    <Box>
+      <Flex justify="space-between" align="center" mb={3}>
+        <Heading size="md" color="gray.700">
+          {title}
+        </Heading>
+        <Link to={actionHref}>
+          <Button
+            size="sm"
+            variant="outline"
+            borderColor="brand.border"
+            color="brand.brown"
+          >
+            {actionLabel}
+          </Button>
+        </Link>
+      </Flex>
+      {hasChildren ? (
+        <Box>{children}</Box>
+      ) : (
+        <Text fontSize="sm" color="gray.500" mb={3}>
+          {emptyText}
+        </Text>
+      )}
+      <Link to={viewAllHref} style={{ textDecoration: "none" }}>
+        <Flex
+          align="center"
+          gap={1}
+          mt={3}
+          fontSize="sm"
+          color="brand.orange"
+          fontWeight={500}
+        >
+          {viewAllLabel} <ArrowRight size={14} />
+        </Flex>
+      </Link>
+    </Box>
+  );
+}
+
+interface RowProps {
+  title: string;
+  href: string;
+  meta: string;
+}
+
+function Row({ title, href, meta }: RowProps) {
+  return (
+    <Link to={href} style={{ textDecoration: "none" }}>
+      <Flex
+        justify="space-between"
+        align="center"
+        py={2}
+        borderBottom="1px solid"
+        borderColor="brand.border"
+        _hover={{ bg: "brand.bgSubtle" }}
+      >
+        <Text color="brand.orange" fontWeight={500} truncate title={title}>
+          {title}
+        </Text>
+        <Text fontSize="sm" color="gray.600">
+          {meta}
+        </Text>
+      </Flex>
+    </Link>
   );
 }

--- a/frontend/src/pages/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/__tests__/LandingPage.test.tsx
@@ -1,5 +1,11 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { MemoryRouter, Routes, Route, useParams } from "react-router-dom";
+import {
+  MemoryRouter,
+  Routes,
+  Route,
+  useParams,
+  useLocation,
+} from "react-router-dom";
 import { ChakraProvider } from "@chakra-ui/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { system } from "../../theme";
@@ -11,7 +17,15 @@ vi.mock("../../lib/story/api", () => ({
 
 function WorkspaceTarget() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
-  return <div data-testid="workspace-target" data-workspace-id={workspaceId} />;
+  const location = useLocation();
+  const rest = location.pathname.replace(`/w/${workspaceId}`, "");
+  return (
+    <div
+      data-testid="workspace-target"
+      data-workspace-id={workspaceId}
+      data-rest={rest}
+    />
+  );
 }
 
 function renderLanding(initialEntry: string = "/") {
@@ -63,6 +77,19 @@ describe("LandingPage", () => {
     renderLanding();
     fireEvent.click(screen.getByRole("button", { name: /start a story/i }));
     expect(screen.getByTestId("workspace-target")).toBeInTheDocument();
+  });
+
+  it("'Start a story' navigates straight to the story editor", async () => {
+    renderLanding();
+    const button = await screen.findByRole("button", { name: /start a story/i });
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(screen.getByTestId("workspace-target")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("workspace-target")).toHaveAttribute(
+      "data-rest",
+      "/story/new"
+    );
   });
 
   it("renders example story cards fetched from the public endpoint", async () => {

--- a/frontend/src/pages/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/__tests__/LandingPage.test.tsx
@@ -13,6 +13,7 @@ import LandingPage from "../LandingPage";
 
 vi.mock("../../lib/story/api", () => ({
   listExampleStoriesFromServer: vi.fn().mockResolvedValue([]),
+  forkStoryOnServer: vi.fn(),
 }));
 
 function WorkspaceTarget() {
@@ -90,6 +91,49 @@ describe("LandingPage", () => {
       "data-rest",
       "/story/new"
     );
+  });
+
+  it("clicking an example card forks the example and opens its editor", async () => {
+    const { listExampleStoriesFromServer, forkStoryOnServer } = await import(
+      "../../lib/story/api"
+    );
+    (
+      listExampleStoriesFromServer as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce([
+      {
+        id: "example-1",
+        title: "Example Flood Story",
+        description: null,
+        chapters: [{ id: "c1" }, { id: "c2" }],
+        is_example: true,
+        published: true,
+        dataset_id: null,
+        dataset_ids: [],
+        updated_at: "2026-05-12T00:00:00Z",
+      },
+    ]);
+    (forkStoryOnServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: "forked-77",
+      title: "Example Flood Story",
+      description: null,
+      chapters: [],
+      is_example: false,
+      published: false,
+    });
+    renderLanding();
+    const card = await screen.findByRole("button", {
+      name: /example flood story/i,
+    });
+    fireEvent.click(card);
+    await waitFor(() => {
+      expect(forkStoryOnServer).toHaveBeenCalledWith("example-1");
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("workspace-target")).toHaveAttribute(
+        "data-rest",
+        "/story/forked-77/edit"
+      );
+    });
   });
 
   it("renders example story cards fetched from the public endpoint", async () => {

--- a/frontend/src/pages/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/__tests__/LandingPage.test.tsx
@@ -82,7 +82,9 @@ describe("LandingPage", () => {
 
   it("'Start a story' navigates straight to the story editor", async () => {
     renderLanding();
-    const button = await screen.findByRole("button", { name: /start a story/i });
+    const button = await screen.findByRole("button", {
+      name: /start a story/i,
+    });
     fireEvent.click(button);
     await waitFor(() => {
       expect(screen.getByTestId("workspace-target")).toBeInTheDocument();
@@ -94,9 +96,8 @@ describe("LandingPage", () => {
   });
 
   it("clicking an example card forks the example and opens its editor", async () => {
-    const { listExampleStoriesFromServer, forkStoryOnServer } = await import(
-      "../../lib/story/api"
-    );
+    const { listExampleStoriesFromServer, forkStoryOnServer } =
+      await import("../../lib/story/api");
     (
       listExampleStoriesFromServer as ReturnType<typeof vi.fn>
     ).mockResolvedValueOnce([

--- a/frontend/src/pages/__tests__/StoriesPage.test.tsx
+++ b/frontend/src/pages/__tests__/StoriesPage.test.tsx
@@ -51,11 +51,14 @@ function renderStoriesPage() {
 }
 
 describe("Workspace routing", () => {
-  it("renders StoriesPage at workspace root (/)", async () => {
+  it("renders WorkspaceHomePage at workspace root (/), not StoriesPage", async () => {
     renderApp("/w/test-workspace");
     expect(
-      await screen.findByRole("heading", { name: /your stories/i })
+      await screen.findByRole("heading", { name: /workspace home/i })
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /your stories/i })
+    ).not.toBeInTheDocument();
   });
 
   it("renders UploadPage at /quick-map", async () => {
@@ -63,7 +66,7 @@ describe("Workspace routing", () => {
     expect(await screen.findByText(/upload/i)).toBeInTheDocument();
   });
 
-  it("redirects /stories to /", async () => {
+  it("renders StoriesPage at /w/:id/stories", async () => {
     renderApp("/w/test-workspace/stories");
     expect(
       await screen.findByRole("heading", { name: /your stories/i })

--- a/frontend/src/pages/__tests__/StoriesPage.test.tsx
+++ b/frontend/src/pages/__tests__/StoriesPage.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, it, expect, vi } from "vitest";
 import { ChakraProvider } from "@chakra-ui/react";
 import { system } from "../../theme";
@@ -14,12 +13,6 @@ vi.mock("../../lib/story/api", () => ({
 
 import App from "../../App";
 import StoriesPage from "../StoriesPage";
-
-function LocationProbe({ onLocation }: { onLocation: (path: string) => void }) {
-  const loc = useLocation();
-  onLocation(loc.pathname);
-  return null;
-}
 
 function renderApp(initialPath: string) {
   return render(
@@ -74,92 +67,8 @@ describe("Workspace routing", () => {
   });
 });
 
-import { listStoriesFromServer, forkStoryOnServer } from "../../lib/story/api";
+import { listStoriesFromServer } from "../../lib/story/api";
 import type { Story } from "../../lib/story/types";
-
-describe("StoriesPage example-story cards", () => {
-  it("renders example stories as clickable cards, not as table rows", async () => {
-    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
-      {
-        id: "ex-1",
-        title: "Arctic ice loss",
-        chapters: [{}, {}, {}, {}],
-        is_example: true,
-        published: true,
-        updated_at: new Date().toISOString(),
-      } as unknown as Story,
-    ]);
-    renderStoriesPage();
-    const card = await screen.findByRole("button", {
-      name: /arctic ice loss/i,
-    });
-    expect(card).toBeInTheDocument();
-    expect(screen.queryByText("Chapters")).toBeNull();
-  });
-
-  it("renders 'No example stories available.' when no examples come back", async () => {
-    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      []
-    );
-    renderStoriesPage();
-    expect(
-      await screen.findByText(/no example stories available\./i)
-    ).toBeInTheDocument();
-  });
-});
-
-describe("StoriesPage example-story clone-on-click", () => {
-  it("forks the example and navigates to the new draft editor", async () => {
-    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
-      {
-        id: "ex-1",
-        title: "Arctic ice loss",
-        chapters: [{}, {}, {}, {}],
-        is_example: true,
-        published: true,
-        updated_at: new Date().toISOString(),
-      } as unknown as Story,
-    ]);
-    (forkStoryOnServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      id: "new-draft-id",
-      title: "Arctic ice loss",
-      chapters: [],
-      is_example: false,
-      published: false,
-    } as unknown as Story);
-
-    let path = "";
-    render(
-      <ChakraProvider value={system}>
-        <MemoryRouter initialEntries={["/w/test-workspace"]}>
-          <Routes>
-            <Route
-              path="/w/:workspaceId/*"
-              element={
-                <WorkspaceProvider>
-                  <>
-                    <StoriesPage />
-                    <LocationProbe onLocation={(p) => (path = p)} />
-                  </>
-                </WorkspaceProvider>
-              }
-            />
-          </Routes>
-        </MemoryRouter>
-      </ChakraProvider>
-    );
-
-    const card = await screen.findByRole("button", {
-      name: /arctic ice loss/i,
-    });
-    const user = userEvent.setup();
-    await user.click(card);
-    expect(forkStoryOnServer).toHaveBeenCalledWith("ex-1");
-    await waitFor(() => {
-      expect(path).toBe("/w/test-workspace/story/new-draft-id/edit");
-    });
-  });
-});
 
 describe("StoriesPage layout", () => {
   it("renders a 'Quick map' link in the header pointing to /quick-map", async () => {
@@ -173,23 +82,28 @@ describe("StoriesPage layout", () => {
     const link = await screen.findByRole("link", { name: /new story/i });
     expect(link.getAttribute("href")).toBe("/w/test-workspace/story/new");
   });
+});
 
-  it("renders 'Your stories' heading before 'Example stories' heading in DOM order", async () => {
+describe("StoriesPage no longer renders example cards", () => {
+  it("does not render ExampleStoryCard when the API returns is_example rows", async () => {
+    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        id: "ex-1",
+        title: "An Example",
+        chapters: [],
+        is_example: true,
+        published: true,
+        updated_at: "2026-05-13T00:00:00Z",
+      } as unknown as Story,
+    ]);
     renderStoriesPage();
-    const headings = await screen.findAllByRole("heading");
-    const texts = headings.map((h) => h.textContent || "");
-    const yourIdx = texts.findIndex((t) => /your stories/i.test(t));
-    const exampleIdx = texts.findIndex((t) => /example stories/i.test(t));
-    expect(yourIdx).toBeGreaterThan(-1);
-    expect(exampleIdx).toBeGreaterThan(-1);
-    expect(yourIdx).toBeLessThan(exampleIdx);
-  });
-
-  it("always renders the Example stories section, even when there are no example stories", async () => {
-    renderStoriesPage();
+    await waitFor(() => {
+      expect(listStoriesFromServer).toHaveBeenCalled();
+    });
     expect(
-      await screen.findByRole("heading", { name: /example stories/i })
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", { name: /example stories/i })
+    ).toBeNull();
+    expect(screen.queryByText("An Example")).toBeNull();
   });
 });
 

--- a/frontend/src/pages/__tests__/WorkspaceHomePage.test.tsx
+++ b/frontend/src/pages/__tests__/WorkspaceHomePage.test.tsx
@@ -87,7 +87,12 @@ describe("WorkspaceHomePage", () => {
       ok: true,
       json: () =>
         Promise.resolve([
-          { id: "d-seed", title: "Seed dataset", filename: "seed.tif", is_example: false },
+          {
+            id: "d-seed",
+            title: "Seed dataset",
+            filename: "seed.tif",
+            is_example: false,
+          },
         ]),
     });
     renderHome();
@@ -114,25 +119,29 @@ describe("WorkspaceHomePage", () => {
         Promise.resolve([
           {
             id: "d1",
-            title: "Alpha", filename: "alpha.tif",
+            title: "Alpha",
+            filename: "alpha.tif",
             created_at: "2026-05-01T00:00:00Z",
             is_example: false,
           },
           {
             id: "d2",
-            title: "Bravo", filename: "bravo.tif",
+            title: "Bravo",
+            filename: "bravo.tif",
             created_at: "2026-05-13T00:00:00Z",
             is_example: false,
           },
           {
             id: "d3",
-            title: "Charlie", filename: "charlie.tif",
+            title: "Charlie",
+            filename: "charlie.tif",
             created_at: "2026-05-10T00:00:00Z",
             is_example: false,
           },
           {
             id: "d4",
-            title: "Delta", filename: "delta.tif",
+            title: "Delta",
+            filename: "delta.tif",
             created_at: "2026-04-01T00:00:00Z",
             is_example: false,
           },
@@ -159,7 +168,12 @@ describe("WorkspaceHomePage", () => {
       ok: true,
       json: () =>
         Promise.resolve([
-          { id: "d-seed", title: "Seed dataset", filename: "seed.tif", is_example: false },
+          {
+            id: "d-seed",
+            title: "Seed dataset",
+            filename: "seed.tif",
+            is_example: false,
+          },
         ]),
     });
     renderHome();
@@ -243,7 +257,12 @@ describe("WorkspaceHomePage", () => {
       ok: true,
       json: () =>
         Promise.resolve([
-          { id: "d-seed", title: "Seed dataset", filename: "seed.tif", is_example: false },
+          {
+            id: "d-seed",
+            title: "Seed dataset",
+            filename: "seed.tif",
+            is_example: false,
+          },
         ]),
     });
     renderHome();

--- a/frontend/src/pages/__tests__/WorkspaceHomePage.test.tsx
+++ b/frontend/src/pages/__tests__/WorkspaceHomePage.test.tsx
@@ -1,0 +1,196 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../../theme";
+import { WorkspaceProvider } from "../../hooks/useWorkspace";
+
+const mockListStories = vi.fn();
+const mockFetch = vi.fn();
+
+vi.mock("../../lib/story/api", () => ({
+  listStoriesFromServer: (...args: unknown[]) => mockListStories(...args),
+  forkStoryOnServer: vi.fn(),
+}));
+
+vi.mock("../../lib/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../lib/api")>("../../lib/api");
+  return {
+    ...actual,
+    workspaceFetch: (...args: unknown[]) => mockFetch(...args),
+  };
+});
+
+import WorkspaceHomePage from "../WorkspaceHomePage";
+
+function renderHome() {
+  return render(
+    <ChakraProvider value={system}>
+      <MemoryRouter initialEntries={["/w/test-workspace"]}>
+        <Routes>
+          <Route
+            path="/w/:workspaceId/*"
+            element={
+              <WorkspaceProvider>
+                <WorkspaceHomePage />
+              </WorkspaceProvider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </ChakraProvider>
+  );
+}
+
+describe("WorkspaceHomePage", () => {
+  it("renders the three most recent non-example stories", async () => {
+    mockListStories.mockResolvedValue([
+      {
+        id: "s1",
+        title: "Older",
+        chapters: [],
+        is_example: false,
+        updated_at: "2026-05-01T00:00:00Z",
+      },
+      {
+        id: "s2",
+        title: "Newest",
+        chapters: [],
+        is_example: false,
+        updated_at: "2026-05-13T00:00:00Z",
+      },
+      {
+        id: "s3",
+        title: "Middle",
+        chapters: [],
+        is_example: false,
+        updated_at: "2026-05-10T00:00:00Z",
+      },
+      {
+        id: "s4",
+        title: "Oldest",
+        chapters: [],
+        is_example: false,
+        updated_at: "2026-04-01T00:00:00Z",
+      },
+      {
+        id: "s-ex",
+        title: "Example",
+        chapters: [],
+        is_example: true,
+        updated_at: "2026-05-12T00:00:00Z",
+      },
+    ]);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { id: "d-seed", title: "Seed dataset", filename: "seed.tif", is_example: false },
+        ]),
+    });
+    renderHome();
+    expect(await screen.findByText("Newest")).toBeInTheDocument();
+    expect(screen.getByText("Middle")).toBeInTheDocument();
+    expect(screen.getByText("Older")).toBeInTheDocument();
+    expect(screen.queryByText("Oldest")).not.toBeInTheDocument();
+    expect(screen.queryByText("Example")).not.toBeInTheDocument();
+  });
+
+  it("renders the three most recent datasets", async () => {
+    mockListStories.mockResolvedValue([
+      {
+        id: "s-seed",
+        title: "Seed story",
+        chapters: [],
+        is_example: false,
+        updated_at: "2026-05-01T00:00:00Z",
+      },
+    ]);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: "d1",
+            title: "Alpha", filename: "alpha.tif",
+            created_at: "2026-05-01T00:00:00Z",
+            is_example: false,
+          },
+          {
+            id: "d2",
+            title: "Bravo", filename: "bravo.tif",
+            created_at: "2026-05-13T00:00:00Z",
+            is_example: false,
+          },
+          {
+            id: "d3",
+            title: "Charlie", filename: "charlie.tif",
+            created_at: "2026-05-10T00:00:00Z",
+            is_example: false,
+          },
+          {
+            id: "d4",
+            title: "Delta", filename: "delta.tif",
+            created_at: "2026-04-01T00:00:00Z",
+            is_example: false,
+          },
+        ]),
+    });
+    renderHome();
+    expect(await screen.findByText("Bravo")).toBeInTheDocument();
+    expect(screen.getByText("Charlie")).toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Delta")).not.toBeInTheDocument();
+  });
+
+  it("links 'View all stories' to /stories and 'View all data' to /data", async () => {
+    mockListStories.mockResolvedValue([
+      {
+        id: "s-seed",
+        title: "Seed story",
+        chapters: [],
+        is_example: false,
+        updated_at: "2026-05-01T00:00:00Z",
+      },
+    ]);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { id: "d-seed", title: "Seed dataset", filename: "seed.tif", is_example: false },
+        ]),
+    });
+    renderHome();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /view all stories/i })
+      ).toHaveAttribute("href", "/w/test-workspace/stories");
+    });
+    expect(
+      screen.getByRole("link", { name: /view all data/i })
+    ).toHaveAttribute("href", "/w/test-workspace/data");
+  });
+
+  it("shows the workspace ID prominently", async () => {
+    mockListStories.mockResolvedValue([
+      {
+        id: "s-seed",
+        title: "Seed story",
+        chapters: [],
+        is_example: false,
+        updated_at: "2026-05-01T00:00:00Z",
+      },
+    ]);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { id: "d-seed", title: "Seed dataset", filename: "seed.tif", is_example: false },
+        ]),
+    });
+    renderHome();
+    const matches = await screen.findAllByText(/test-workspace/);
+    expect(matches.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/pages/__tests__/WorkspaceHomePage.test.tsx
+++ b/frontend/src/pages/__tests__/WorkspaceHomePage.test.tsx
@@ -23,6 +23,7 @@ vi.mock("../../lib/api", async () => {
 });
 
 import WorkspaceHomePage from "../WorkspaceHomePage";
+import type { Story } from "../../lib/story/types";
 
 function renderHome() {
   return render(
@@ -170,6 +171,62 @@ describe("WorkspaceHomePage", () => {
     expect(
       screen.getByRole("link", { name: /view all data/i })
     ).toHaveAttribute("href", "/w/test-workspace/data");
+  });
+
+  it("shows example story clone cards when the workspace is empty", async () => {
+    mockListStories.mockResolvedValue([
+      {
+        id: "ex1",
+        title: "Example A",
+        chapters: [{ id: "c1" }],
+        is_example: true,
+        updated_at: "2026-05-12T00:00:00Z",
+      },
+    ]);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+    renderHome();
+    expect(
+      await screen.findByText(/this workspace is empty/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /example a/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /recent stories/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("clones an example into the workspace when its card is clicked", async () => {
+    const { forkStoryOnServer } = await import("../../lib/story/api");
+    (forkStoryOnServer as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: "fork-9",
+      title: "Example A",
+      chapters: [],
+      is_example: false,
+      published: false,
+    } as unknown as Story);
+    mockListStories.mockResolvedValue([
+      {
+        id: "ex1",
+        title: "Example A",
+        chapters: [{ id: "c1" }],
+        is_example: true,
+        updated_at: "2026-05-12T00:00:00Z",
+      },
+    ]);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+    renderHome();
+    const card = await screen.findByRole("button", { name: /example a/i });
+    card.click();
+    await waitFor(() => {
+      expect(forkStoryOnServer).toHaveBeenCalledWith("ex1");
+    });
   });
 
   it("shows the workspace ID prominently", async () => {

--- a/ingestion/migrations/011_add_forked_from_id.sql
+++ b/ingestion/migrations/011_add_forked_from_id.sql
@@ -1,4 +1,4 @@
 ALTER TABLE stories ADD COLUMN IF NOT EXISTS forked_from_id TEXT NULL;
-CREATE INDEX IF NOT EXISTS ix_stories_fork_lookup
+CREATE UNIQUE INDEX IF NOT EXISTS ix_stories_fork_lookup
   ON stories (workspace_id, forked_from_id)
   WHERE forked_from_id IS NOT NULL;

--- a/ingestion/migrations/011_add_forked_from_id.sql
+++ b/ingestion/migrations/011_add_forked_from_id.sql
@@ -1,0 +1,4 @@
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS forked_from_id TEXT NULL;
+CREATE INDEX IF NOT EXISTS ix_stories_fork_lookup
+  ON stories (workspace_id, forked_from_id)
+  WHERE forked_from_id IS NOT NULL;

--- a/ingestion/src/app.py
+++ b/ingestion/src/app.py
@@ -286,9 +286,7 @@ def _migrate_schema(engine):
             if not _is_duplicate_column(exc):
                 raise
         try:
-            conn.execute(
-                text("ALTER TABLE stories ADD COLUMN forked_from_id TEXT")
-            )
+            conn.execute(text("ALTER TABLE stories ADD COLUMN forked_from_id TEXT"))
             conn.commit()
         except DBAPIError as exc:
             conn.rollback()

--- a/ingestion/src/app.py
+++ b/ingestion/src/app.py
@@ -286,6 +286,13 @@ def _migrate_schema(engine):
             if not _is_duplicate_column(exc):
                 raise
         try:
+            conn.execute(text("ALTER TABLE stories ADD COLUMN workspace_id TEXT"))
+            conn.commit()
+        except DBAPIError as exc:
+            conn.rollback()
+            if not _is_duplicate_column(exc):
+                raise
+        try:
             conn.execute(text("ALTER TABLE stories ADD COLUMN forked_from_id TEXT"))
             conn.commit()
         except DBAPIError as exc:

--- a/ingestion/src/app.py
+++ b/ingestion/src/app.py
@@ -297,7 +297,7 @@ def _migrate_schema(engine):
         try:
             conn.execute(
                 text(
-                    "CREATE INDEX IF NOT EXISTS ix_stories_fork_lookup "
+                    "CREATE UNIQUE INDEX IF NOT EXISTS ix_stories_fork_lookup "
                     "ON stories (workspace_id, forked_from_id) "
                     "WHERE forked_from_id IS NOT NULL"
                 )

--- a/ingestion/src/app.py
+++ b/ingestion/src/app.py
@@ -285,6 +285,27 @@ def _migrate_schema(engine):
             conn.rollback()
             if not _is_duplicate_column(exc):
                 raise
+        try:
+            conn.execute(
+                text("ALTER TABLE stories ADD COLUMN forked_from_id TEXT")
+            )
+            conn.commit()
+        except DBAPIError as exc:
+            conn.rollback()
+            if not _is_duplicate_column(exc):
+                raise
+        try:
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS ix_stories_fork_lookup "
+                    "ON stories (workspace_id, forked_from_id) "
+                    "WHERE forked_from_id IS NOT NULL"
+                )
+            )
+            conn.commit()
+        except DBAPIError:
+            conn.rollback()
+            raise
         # Remove duplicate is_example rows before creating the unique index so
         # that deployments upgrading from a version without the index don't
         # fail. Keep the row with the lowest id for each duplicate title.

--- a/ingestion/src/models/story.py
+++ b/ingestion/src/models/story.py
@@ -28,6 +28,7 @@ class StoryRow(Base):
         onupdate=lambda: datetime.now(UTC),
     )
     workspace_id = Column(String, nullable=True)
+    forked_from_id = Column(String, nullable=True)
 
 
 class MapStatePayload(BaseModel):

--- a/ingestion/src/models/story.py
+++ b/ingestion/src/models/story.py
@@ -5,13 +5,23 @@ from datetime import UTC, datetime
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
-from sqlalchemy import Boolean, Column, DateTime, String, Text
+from sqlalchemy import Boolean, Column, DateTime, Index, String, Text, text
 
 from src.models.base import Base
 
 
 class StoryRow(Base):
     __tablename__ = "stories"
+    __table_args__ = (
+        Index(
+            "ix_stories_fork_lookup",
+            "workspace_id",
+            "forked_from_id",
+            unique=True,
+            sqlite_where=text("forked_from_id IS NOT NULL"),
+            postgresql_where=text("forked_from_id IS NOT NULL"),
+        ),
+    )
 
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     title = Column(String, nullable=False, default="Untitled story")

--- a/ingestion/src/routes/stories.py
+++ b/ingestion/src/routes/stories.py
@@ -203,6 +203,17 @@ async def fork_story(story_id: str, request: Request):
         if not source:
             raise HTTPException(status_code=404, detail="Story not found")
 
+        existing = (
+            session.query(StoryRow)
+            .filter(
+                StoryRow.workspace_id == workspace_id,
+                StoryRow.forked_from_id == story_id,
+            )
+            .first()
+        )
+        if existing:
+            return _row_to_response(existing)
+
         now = datetime.now(UTC)
         forked = StoryRow(
             id=str(uuid.uuid4()),
@@ -215,6 +226,7 @@ async def fork_story(story_id: str, request: Request):
             updated_at=now,
             workspace_id=workspace_id,
             is_example=False,
+            forked_from_id=source.id,
         )
         session.add(forked)
         session.commit()

--- a/ingestion/src/routes/stories.py
+++ b/ingestion/src/routes/stories.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import TypeAdapter
 from sqlalchemy import or_
+from sqlalchemy.exc import IntegrityError
 
 from src.dependencies import get_session
 from src.models.story import (
@@ -229,7 +230,21 @@ async def fork_story(story_id: str, request: Request):
             forked_from_id=source.id,
         )
         session.add(forked)
-        session.commit()
+        try:
+            session.commit()
+        except IntegrityError:
+            session.rollback()
+            racing = (
+                session.query(StoryRow)
+                .filter(
+                    StoryRow.workspace_id == workspace_id,
+                    StoryRow.forked_from_id == story_id,
+                )
+                .first()
+            )
+            if racing:
+                return _row_to_response(racing)
+            raise
         session.refresh(forked)
         return _row_to_response(forked)
     finally:

--- a/ingestion/tests/test_stories.py
+++ b/ingestion/tests/test_stories.py
@@ -529,3 +529,9 @@ def test_legacy_prose_chapter_without_map_fields_loads_as_prose(client, db_sessi
     assert resp.status_code == 200
     body = resp.json()
     assert body["chapters"][0]["type"] == "prose"
+
+
+def test_stories_table_has_forked_from_id_column(db_engine):
+    inspector = inspect(db_engine)
+    cols = {c["name"] for c in inspector.get_columns("stories")}
+    assert "forked_from_id" in cols

--- a/ingestion/tests/test_stories.py
+++ b/ingestion/tests/test_stories.py
@@ -535,3 +535,94 @@ def test_stories_table_has_forked_from_id_column(db_engine):
     inspector = inspect(db_engine)
     cols = {c["name"] for c in inspector.get_columns("stories")}
     assert "forked_from_id" in cols
+
+
+def test_fork_is_idempotent_per_workspace(client, db_session):
+    now = datetime.now(UTC)
+    db_session.add(
+        StoryRow(
+            id="ex-idem",
+            title="Example",
+            chapters_json="[]",
+            published=True,
+            created_at=now,
+            updated_at=now,
+            workspace_id="system",
+            is_example=True,
+        )
+    )
+    db_session.commit()
+
+    first = client.post("/api/stories/ex-idem/fork")
+    second = client.post("/api/stories/ex-idem/fork")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["id"] == second.json()["id"]
+
+    count = (
+        db_session.query(StoryRow)
+        .filter(
+            StoryRow.workspace_id == "testABCD",
+            StoryRow.forked_from_id == "ex-idem",
+        )
+        .count()
+    )
+    assert count == 1
+
+
+def test_fork_sets_forked_from_id(client, db_session):
+    now = datetime.now(UTC)
+    db_session.add(
+        StoryRow(
+            id="ex-source",
+            title="Source",
+            chapters_json="[]",
+            published=True,
+            created_at=now,
+            updated_at=now,
+            workspace_id="system",
+            is_example=True,
+        )
+    )
+    db_session.commit()
+
+    resp = client.post("/api/stories/ex-source/fork")
+    assert resp.status_code == 200
+    forked_id = resp.json()["id"]
+
+    row = db_session.query(StoryRow).filter_by(id=forked_id).one()
+    assert row.forked_from_id == "ex-source"
+
+
+def test_fork_is_distinct_per_workspace(app, db_session):
+    from starlette.testclient import TestClient
+
+    now = datetime.now(UTC)
+    db_session.add(
+        StoryRow(
+            id="ex-shared",
+            title="Shared",
+            chapters_json="[]",
+            published=True,
+            created_at=now,
+            updated_at=now,
+            workspace_id="system",
+            is_example=True,
+        )
+    )
+    db_session.commit()
+
+    client_a = TestClient(
+        app, raise_server_exceptions=False, headers={"X-Workspace-Id": "wsAAAA01"}
+    )
+    client_b = TestClient(
+        app, raise_server_exceptions=False, headers={"X-Workspace-Id": "wsBBBB02"}
+    )
+
+    fork_a = client_a.post("/api/stories/ex-shared/fork")
+    fork_b = client_b.post("/api/stories/ex-shared/fork")
+
+    assert fork_a.status_code == 200
+    assert fork_b.status_code == 200
+    assert fork_a.json()["id"] != fork_b.json()["id"]

--- a/ingestion/tests/test_stories.py
+++ b/ingestion/tests/test_stories.py
@@ -595,6 +595,43 @@ def test_fork_sets_forked_from_id(client, db_session):
     assert row.forked_from_id == "ex-source"
 
 
+def test_fork_unique_index_blocks_duplicate_inserts(db_session):
+    from sqlalchemy.exc import IntegrityError
+
+    now = datetime.now(UTC)
+    db_session.add(
+        StoryRow(
+            id="fork-a",
+            title="A",
+            chapters_json="[]",
+            published=False,
+            created_at=now,
+            updated_at=now,
+            workspace_id="ws-unique",
+            is_example=False,
+            forked_from_id="ex-source-x",
+        )
+    )
+    db_session.commit()
+
+    db_session.add(
+        StoryRow(
+            id="fork-b",
+            title="B",
+            chapters_json="[]",
+            published=False,
+            created_at=now,
+            updated_at=now,
+            workspace_id="ws-unique",
+            is_example=False,
+            forked_from_id="ex-source-x",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+
 def test_fork_is_distinct_per_workspace(app, db_session):
     from starlette.testclient import TestClient
 


### PR DESCRIPTION
## Summary
- Public landing CTAs now go straight to the editor in one click (`Start a story` lands on `/w/{id}/story/new`; example cards fork the example into a new workspace and open its editor).
- `/w/:id/` now renders a new `WorkspaceHomePage` dashboard (recent stories, recent datasets, workspace ID). The Stories tab moves to `/w/:id/stories`.
- Empty workspaces (no user stories or datasets) show an onboarding empty-state with example clone cards instead of the dashboard sections.

## Test plan
- [x] `Start a story` on public landing opens the editor immediately (no intermediate stop on workspace home)
- [x] Example card on public landing forks + opens editor in one click
- [x] Workspace home renders recent stories and recent datasets
- [x] Header `Stories` link routes to `/w/:id/stories`
- [x] Fresh workspace renders the empty-state ("This workspace is empty") with example clone cards
- [x] All 825 frontend unit tests pass
- [x] Visual smoke against prod backend confirms routing

## Idempotent example fork

- Clicking an example card twice now opens the existing fork instead of creating a duplicate copy in the workspace.
- New `forked_from_id` column on `stories` tracks the origin; `POST /api/stories/{id}/fork` looks up `(workspace_id, forked_from_id)` before inserting.
- Example cards no longer render on `/w/:id/stories` (they live on the public landing + empty-workspace home only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace root shows a new Workspace Home with recent stories and data; /stories now renders the stories list directly.
  * Clone example stories from Landing Page or Workspace Home; cloning shows loading state and opens the forked story in the editor.

* **Bug Fixes**
  * Forking is idempotent per workspace and resilient to concurrent fork attempts.

* **Database / Migrations**
  * Added fork lineage support and a uniqueness constraint to prevent duplicate forks within a workspace.

* **Tests**
  * Added/updated tests for routing, workspace home, cloning, fork behavior, and migrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/465)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
