### PR TITLE
chore(archival): instrument captureChapterMap timeout + fix empty error toast

### DIFF
--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -1,4 +1,5 @@
 import {
+  Stack,
   Toaster as ChakraToaster,
   ToastCloseTrigger,
   ToastDescription,
@@ -16,12 +17,14 @@ export function Toaster({ toaster }: ToasterProps) {
   return (
     <ChakraToaster toaster={toaster}>
       {(toast) => (
-        <ToastRoot key={toast.id}>
+        <ToastRoot key={toast.id} width={{ md: "sm" }}>
           <ToastIndicator />
-          <ToastTitle>{toast.title}</ToastTitle>
-          {toast.description && (
-            <ToastDescription>{toast.description}</ToastDescription>
-          )}
+          <Stack gap="1" flex="1" maxWidth="100%">
+            {toast.title && <ToastTitle>{toast.title}</ToastTitle>}
+            {toast.description && (
+              <ToastDescription>{toast.description}</ToastDescription>
+            )}
+          </Stack>
           <ToastCloseTrigger />
         </ToastRoot>
       )}

--- a/frontend/src/lib/story/archival/captureMap.tsx
+++ b/frontend/src/lib/story/archival/captureMap.tsx
@@ -65,6 +65,15 @@ export async function captureChapterMap({
       new Map()
     );
 
+    const tag = `[archival-capture ${chapter.id?.slice(0, 8) ?? "?"} ${chapter.type}]`;
+    const t0 = performance.now();
+    const tlog = (msg: string, data?: unknown) => {
+      const elapsed = (performance.now() - t0).toFixed(0).padStart(5, " ");
+      if (data === undefined) console.log(`${tag} +${elapsed}ms ${msg}`);
+      else console.log(`${tag} +${elapsed}ms ${msg}`, data);
+    };
+    tlog(`init layers=${layers.length} basemap=${chapter.map_state.basemap}`);
+
     const camera = {
       longitude: chapter.map_state.center[0],
       latitude: chapter.map_state.center[1],
@@ -79,6 +88,9 @@ export async function captureChapterMap({
     };
     let lastRenderAt = 0;
     let mapIdle = false;
+    let renderCount = 0;
+    let mapRefFireCount = 0;
+    let deckRefFireCount = 0;
     let resolveReady: (() => void) | null = null;
 
     const readyPromise = new Promise<void>((resolve) => {
@@ -86,12 +98,30 @@ export async function captureChapterMap({
     });
 
     const mapRef = (ref: unknown) => {
-      const maybeMap = ref as { getMap?: () => MapInstance } | null;
-      refs.map = maybeMap?.getMap?.() ?? (maybeMap as MapInstance | null);
-      refs.map?.once?.("idle", () => {
-        mapIdle = true;
-        lastRenderAt = performance.now();
+      mapRefFireCount++;
+      const maybeMap = ref as {
+        getMap?: () => MapInstance;
+        loaded?: () => boolean;
+      } | null;
+      const fromGetMap = maybeMap?.getMap?.();
+      refs.map = fromGetMap ?? (maybeMap as MapInstance | null);
+      const hasOnce = typeof refs.map?.once === "function";
+      const alreadyLoaded =
+        (refs.map as { loaded?: () => boolean } | null)?.loaded?.() ?? null;
+      tlog(`mapRef fire #${mapRefFireCount}`, {
+        hasRef: !!ref,
+        hasGetMap: !!maybeMap?.getMap,
+        getMapReturnedSomething: !!fromGetMap,
+        unwrappedHasOnce: hasOnce,
+        mapAlreadyLoaded: alreadyLoaded,
       });
+      if (hasOnce) {
+        refs.map?.once?.("idle", () => {
+          tlog("maplibre 'idle' fired → mapIdle=true");
+          mapIdle = true;
+          lastRenderAt = performance.now();
+        });
+      }
     };
 
     // Hold the @deck.gl/react imperative handle itself rather than eagerly
@@ -100,18 +130,39 @@ export async function captureChapterMap({
     // useEffect — which runs *after* the ref callback fires. Capturing
     // `.deck` here would freeze the value at `undefined` and never update.
     const deckRef = (ref: unknown) => {
+      deckRefFireCount++;
       refs.deckHandle = ref as DeckHandle | null;
+      tlog(`deckRef fire #${deckRefFireCount}`, {
+        hasRef: !!ref,
+        hasDeckProp:
+          typeof (ref as { deck?: unknown })?.deck !== "undefined" ||
+          Object.prototype.hasOwnProperty.call(ref ?? {}, "deck"),
+      });
     };
 
     const onAfterRender = () => {
+      renderCount++;
       lastRenderAt = performance.now();
+      const loadedStates = layers.map(
+        (l) => (l as unknown as { isLoaded?: boolean }).isLoaded
+      );
       const allLoaded = layers.every(
         (l) => (l as unknown as { isLoaded?: boolean }).isLoaded
       );
+      // Log first 5 renders, then every 20th, plus any render that flips a gate.
+      if (renderCount <= 5 || renderCount % 20 === 0) {
+        tlog(`onAfterRender #${renderCount}`, {
+          mapIdle,
+          allLoaded,
+          loadedStates,
+        });
+      }
       if (mapIdle && allLoaded && resolveReady) {
+        tlog(`gate satisfied (render #${renderCount}); scheduling quiet check`);
         const observed = lastRenderAt;
         setTimeout(() => {
           if (observed === lastRenderAt && resolveReady) {
+            tlog("quiet period elapsed → resolving ready");
             resolveReady();
             resolveReady = null;
           }
@@ -138,6 +189,22 @@ export async function captureChapterMap({
       readyPromise,
       new Promise<never>((_, reject) => {
         setTimeout(() => {
+          const loadedStates = layers.map(
+            (l) => (l as unknown as { isLoaded?: boolean }).isLoaded
+          );
+          tlog("TIMEOUT — final state", {
+            renderCount,
+            mapRefFireCount,
+            deckRefFireCount,
+            mapIdle,
+            allLoaded: layers.every(
+              (l) => (l as unknown as { isLoaded?: boolean }).isLoaded
+            ),
+            loadedStates,
+            hasMap: !!refs.map,
+            hasDeckHandle: !!refs.deckHandle,
+            hasDeck: !!refs.deckHandle?.deck,
+          });
           reject(
             new Error(`Chapter snapshot timed out after ${TIMEOUT_MS / 1000}s`)
           );


### PR DESCRIPTION
## Summary
Two things bundled — both small, both needed to debug bug C (archival HTML export times out at 30 s for guided-tour / interactive-map chapters).

### 1. Diagnostic instrumentation in `captureChapterMap`

Tagged `console.log`s wired into the lifecycle so the user's actual browser tells us which readiness gate isn't tripping. Each capture logs:

- `init layers=N basemap=...`
- every `mapRef` fire — whether it gave us a real map, whether `map.loaded()` is already true at subscribe time
- every `deckRef` fire
- `'idle'` event fires
- the first 5 `onAfterRender` calls and every 20th thereafter, with `{ mapIdle, allLoaded, loadedStates[] }`
- a `TIMEOUT — final state` dump if we hit the 30 s wall

All tagged `[archival-capture <chapter-id-prefix> <type>]` for easy DevTools filtering.

**This is debug-only and should be reverted once the underlying bug is fixed** — but it's safe to merge as-is (no behavior change, just console output on a slow path).

### 2. Fix empty error toast

When the export timed out, the failure toast appeared as an empty red bar in the corner — title and description never rendered. The shared `<Toaster>` placed `<ToastTitle>` and `<ToastDescription>` as direct children of `<ToastRoot>` alongside the indicator and close trigger. With nothing giving the text content flex space, Chakra v3's default `ToastRoot` styling collapses the text columns to zero width.

Match the recommended Chakra v3 pattern: wrap title + description in a `<Stack flex="1" gap="1">`, and gate `<ToastTitle>` behind a truthy check so callers can emit description-only toasts without an empty div.

## Test plan
- [x] `vitest run` — 817/817 passing
- [x] `prettier --check` and `eslint` on changed files
- [ ] After merge: reviewer (you) opens a single-map-chapter story, clicks "Download archival HTML", watches DevTools console + the failure toast, pastes the `[archival-capture …]` block back in chat so we can write the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Optimized toaster notification layout with refined spacing constraints for improved display on medium-sized screens

* **Performance & Reliability**
  * Enhanced archival capture operations with comprehensive performance monitoring and diagnostic tracking capabilities for improved system stability and visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/466)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->