### PR TITLE
feat(workspace-home): always surface example stories + promote action buttons

### DIFF
--- a/frontend/src/pages/WorkspaceHomePage.tsx
+++ b/frontend/src/pages/WorkspaceHomePage.tsx
@@ -198,6 +198,41 @@ export default function WorkspaceHomePage() {
                 />
               ))}
             </Section>
+
+            {exampleStories.length > 0 && (
+              <>
+                <Box my={8} h="1px" bg="brand.border" />
+                <Box>
+                  <Heading size="md" color="gray.700" mb={1}>
+                    Example stories
+                  </Heading>
+                  <Text fontSize="sm" color="gray.500" mb={3}>
+                    Curated stories shared with every workspace. Click to open a
+                    copy you can edit.
+                  </Text>
+                  <Box
+                    display="grid"
+                    gridTemplateColumns={{
+                      base: "1fr",
+                      md: "repeat(3, 1fr)",
+                    }}
+                    gap={3}
+                  >
+                    {exampleStories.slice(0, 3).map((story) => (
+                      <ExampleStoryCard
+                        key={story.id}
+                        title={story.title}
+                        chapterCount={story.chapters.length}
+                        dataType={inferDataType(story)}
+                        onClick={() => handleCloneExample(story)}
+                        loading={cloningId === story.id}
+                        compact
+                      />
+                    ))}
+                  </Box>
+                </Box>
+              </>
+            )}
           </>
         )}
       </Box>
@@ -237,9 +272,9 @@ function Section({
         <Link to={actionHref}>
           <Button
             size="sm"
-            variant="outline"
-            borderColor="brand.border"
-            color="brand.brown"
+            bg="brand.orange"
+            color="white"
+            _hover={{ bg: "brand.orangeHover" }}
           >
             {actionLabel}
           </Button>

--- a/frontend/src/pages/__tests__/WorkspaceHomePage.test.tsx
+++ b/frontend/src/pages/__tests__/WorkspaceHomePage.test.tsx
@@ -100,7 +100,9 @@ describe("WorkspaceHomePage", () => {
     expect(screen.getByText("Middle")).toBeInTheDocument();
     expect(screen.getByText("Older")).toBeInTheDocument();
     expect(screen.queryByText("Oldest")).not.toBeInTheDocument();
-    expect(screen.queryByText("Example")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /^Example$/ })
+    ).not.toBeInTheDocument();
   });
 
   it("renders the three most recent datasets", async () => {


### PR DESCRIPTION
## Summary
- Workspaces with any user story or dataset were hiding example cards entirely (the empty-state branch was the only place they rendered). Add an "Example stories" section to the non-empty branch of `WorkspaceHomePage` so the cards are reachable from every visit. Backend fork idempotency keeps re-clicks from duplicating.
- Promote the "New story" and "Quick map" `Section` action buttons from outline/secondary to brand-orange primary, matching the public LandingPage hero CTA.

## Test plan
- [x] Vitest: `WorkspaceHomePage.test.tsx` updated — the "non-example stories" assertion now scopes by link role (Row uses `<Link>`, ExampleStoryCard uses a button), so it still verifies recents-list exclusion without false-failing on the new Example section. All 821 frontend tests pass.
- [x] Prettier --check + tsc --noEmit clean.
- [x] Visual smoke against prod backend (vite dev + playwright): empty workspace renders examples in the empty-state branch; seeded non-empty workspace renders "Recent stories" → "Recent data" → "Example stories" in DOM order, both action buttons show `rgb(207, 63, 2)` (brand.orange) backgrounds, and the three example cards (Warming ocean, Cities from space, Tour of ocean floor) render in the new section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "Example stories" section to the workspace view, enabling users to discover and clone up to 3 pre-built example stories directly into their workspace for faster onboarding

* **Style**
  * Enhanced action button styling with a new solid orange filled design for improved visual consistency across the workspace interface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/467)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->