### PR TITLE
docs: correct story-expiration wording and add bug-report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug Report
+description: Something broke, looked wrong, or didn't behave as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! The more detail you can give,
+        the faster we can reproduce and fix it.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you see?
+      placeholder: "When I clicked Export → Archival HTML, the download started but the file was empty."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: "I expected to get an HTML file with my story chapters embedded."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: As specific as you can be. Even rough steps help a lot.
+      placeholder: |
+        1. Go to /w/abc12345/story/...
+        2. Click Export
+        3. Choose Archival HTML
+        4. Observe...
+    validations:
+      required: false
+
+  - type: input
+    id: page-url
+    attributes:
+      label: Page URL or workspace ID
+      description: If you're comfortable sharing, paste the full URL or your workspace ID. This helps us look up the exact dataset/story.
+      placeholder: "https://storytelling.developmentseed.org/w/abc12345/..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot or recording
+      description: Drag and drop an image or video file here, or paste a link.
+    validations:
+      required: false
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and OS
+      placeholder: "Chrome 130 on macOS, Firefox on Ubuntu, Safari on iPhone, etc."
+    validations:
+      required: false
+
+  - type: textarea
+    id: console
+    attributes:
+      label: Browser console errors
+      description: |
+        Optional but very helpful. Open the browser DevTools (F12 or Cmd+Opt+I),
+        click the Console tab, and paste anything red.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Other context, related issues, ideas for what might have caused it.
+    validations:
+      required: false

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -287,13 +287,15 @@ export default function AboutPage() {
           </Text>
 
           <Text fontWeight={600} color="gray.800" fontSize="sm" mt={4} mb={1}>
-            Your uploads
+            Your uploads and stories
           </Text>
           <Text color="gray.700" fontSize="sm" lineHeight="tall" mb={3}>
-            Files you upload are stored under a workspace ID generated for you.
-            To protect from data storage costs, datasets have an expiration
-            policy of 30 days from the time of upload. If you would like to
-            explore a more permanent data storage solution, please reach out to{" "}
+            Datasets you upload and stories you create are stored under a
+            workspace ID generated for you. To protect against unbounded storage
+            costs, both datasets and stories are automatically deleted 30 days
+            after they are created. Treat the sandbox as a place to experiment,
+            not a place to store work long-term. If you would like to explore a
+            more permanent storage solution, please reach out to{" "}
             <a
               href="mailto:info@developmentseed.org"
               style={{
@@ -312,9 +314,9 @@ export default function AboutPage() {
           <Text color="gray.700" fontSize="sm" lineHeight="tall" mb={3}>
             You are automatically assigned a unique workspace code. This allows
             you to share your work with collaborators, but only if you directly
-            share the URL or workspace ID with them. Workspaces do not
-            automatically expire, although uploaded datasets inside workspaces
-            will expire to the policy listed above.
+            share the URL or workspace ID with them. The workspace itself does
+            not expire, but the datasets and stories inside it follow the 30-day
+            policy above.
           </Text>
 
           <Text fontWeight={600} color="gray.800" fontSize="sm" mt={4} mb={1}>


### PR DESCRIPTION
## Summary

Two small doc fixes ahead of an external tester invite.

- **AboutPage Privacy section: stories also expire.** The current copy says only datasets expire and that workspaces persist indefinitely. The actual cleanup job ([ingestion/src/services/cleanup.py:51](ingestion/src/services/cleanup.py#L51)) deletes stories 30 days after `created_at` with no `expires_at` override. Anyone who builds a story, sends a link, and checks back in 5 weeks gets a 404 — not great for trust on a tester rollout. Updated the "Your uploads" section to call out datasets *and* stories, and clarified that the workspace ID itself persists even though its contents don't.
- **Bug-report issue template.** The only existing template is [feature-spec.yml](.github/ISSUE_TEMPLATE/feature-spec.yml), which is tuned for `@claude` agent implementation. Public testers clicking "New issue" need a structured bug form. Added [.github/ISSUE_TEMPLATE/bug_report.yml](.github/ISSUE_TEMPLATE/bug_report.yml) with fields for what happened / expected / steps / page URL or workspace ID / screenshot / browser / console errors.

## Test plan

- [x] `prettier --check src/pages/AboutPage.tsx` passes
- [x] `vitest run src/pages/__tests__/AboutPage.test.tsx` passes (10/10)
- [x] No other files reference the old prose
- [x] `bug_report.yml` parses as valid YAML
- [ ] After merge: confirm the new template appears at https://github.com/aboydnw/cng-sandbox/issues/new/choose
- [ ] After merge: load /about on prod, confirm the updated wording renders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Implemented new structured GitHub issue template for bug reports, including fields for reproduction steps and environment details to enhance issue submission quality
  * Refreshed Privacy & Data section on the About page with updated descriptions clarifying data retention and workspace expiration policies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->