### PR TITLE
fix(archival): implement chart-chapter capture for archival HTML export

### DIFF
--- a/frontend/src/lib/story/archival/__tests__/buildArchivalHtml.test.ts
+++ b/frontend/src/lib/story/archival/__tests__/buildArchivalHtml.test.ts
@@ -20,6 +20,12 @@ vi.mock("../inlineAsset", () => ({
     .mockResolvedValue("data:image/jpeg;base64,/9j/4AAQ"),
 }));
 
+vi.mock("../captureChart", () => ({
+  captureChartToDataUrl: vi
+    .fn()
+    .mockResolvedValue("data:image/png;base64,CHARTPNG"),
+}));
+
 function makeStory(chapters: Story["chapters"]): Story {
   return {
     id: "s1",
@@ -175,6 +181,105 @@ describe("buildArchivalHtml", () => {
 
     const story = makeStory([
       createScrollytellingChapter({ id: "ch", title: "X" }),
+    ]);
+
+    await expect(
+      buildArchivalHtml({ config, story, ...emptyMaps })
+    ).rejects.toThrow(/timed out/);
+  });
+
+  it("inlines chart snapshots as base64 PNG <img> tags with the chapter title as alt text", async () => {
+    const { createChartChapter } = await import("../../types");
+    const config: CngRcConfig = {
+      version: "1",
+      origin: { story_id: "s1", workspace_id: null, exported_at: "" },
+      metadata: {
+        title: "T",
+        description: null,
+        author: null,
+        created: "",
+        updated: "",
+      },
+      chapters: [
+        {
+          id: "c1",
+          type: "chart",
+          title: "Annual rainfall",
+          body: null,
+          map: null,
+          layers: [],
+        },
+      ],
+      layers: {},
+      assets: {},
+    };
+
+    const story = makeStory([
+      createChartChapter({
+        id: "c1",
+        title: "Annual rainfall",
+        chart: {
+          source: {
+            kind: "csv",
+            asset_id: "a1",
+            url: "http://x/y.csv",
+            columns: ["Year", "v"],
+          },
+          viz: { kind: "line", x_field: "Year", y_fields: ["v"] },
+        },
+      }),
+    ]);
+
+    const html = await buildArchivalHtml({ config, story, ...emptyMaps });
+    expect(html).toContain('src="data:image/png;base64,CHARTPNG"');
+    expect(html).toContain('alt="Annual rainfall"');
+  });
+
+  it("propagates errors from captureChartToDataUrl (no silent fallback)", async () => {
+    const { captureChartToDataUrl } = await import("../captureChart");
+    (captureChartToDataUrl as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("Chart snapshot timed out after 30s")
+    );
+
+    const { createChartChapter } = await import("../../types");
+    const config: CngRcConfig = {
+      version: "1",
+      origin: { story_id: "s1", workspace_id: null, exported_at: "" },
+      metadata: {
+        title: "T",
+        description: null,
+        author: null,
+        created: "",
+        updated: "",
+      },
+      chapters: [
+        {
+          id: "c1",
+          type: "chart",
+          title: "Doomed chart",
+          body: null,
+          map: null,
+          layers: [],
+        },
+      ],
+      layers: {},
+      assets: {},
+    };
+
+    const story = makeStory([
+      createChartChapter({
+        id: "c1",
+        title: "Doomed chart",
+        chart: {
+          source: {
+            kind: "csv",
+            asset_id: "a1",
+            url: "http://x/y.csv",
+            columns: ["Year", "v"],
+          },
+          viz: { kind: "line", x_field: "Year", y_fields: ["v"] },
+        },
+      }),
     ]);
 
     await expect(

--- a/frontend/src/lib/story/archival/__tests__/captureChart.test.ts
+++ b/frontend/src/lib/story/archival/__tests__/captureChart.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createChartChapter } from "../../types";
+import type { ChartChapter } from "../../types";
+
+const rootMocks = vi.hoisted(
+  () =>
+    [] as Array<{
+      render: ReturnType<typeof vi.fn>;
+      unmount: ReturnType<typeof vi.fn>;
+    }>
+);
+
+vi.mock("react-dom/client", () => ({
+  createRoot: vi.fn(() => {
+    const root = { render: vi.fn(), unmount: vi.fn() };
+    rootMocks.push(root);
+    return root;
+  }),
+}));
+
+vi.mock("../../../../components/ChartChapterRenderer", () => ({
+  ChartChapterRenderer: vi.fn(() => null),
+}));
+
+const getInstanceByDom = vi.hoisted(() => vi.fn());
+vi.mock("echarts", () => ({
+  getInstanceByDom,
+}));
+
+import { captureChartToDataUrl } from "../captureChart";
+
+function makeChapter(): ChartChapter {
+  return createChartChapter({
+    id: "c1",
+    title: "Test chart",
+    order: 0,
+    narrative: "",
+    chart: {
+      source: {
+        kind: "csv",
+        asset_id: "a1",
+        url: "http://x/y.csv",
+        columns: ["Year", "v"],
+      },
+      viz: { kind: "line", x_field: "Year", y_fields: ["v"] },
+    },
+  });
+}
+
+function placeTaggedDiv() {
+  const host = document.querySelector(
+    "[data-archival-chart-capture]"
+  ) as HTMLElement | null;
+  if (!host) throw new Error("capture host not yet mounted");
+  const div = document.createElement("div");
+  div.setAttribute("_echarts_instance_", "fake");
+  host.appendChild(div);
+  return div;
+}
+
+interface FakeInstance {
+  getOption: ReturnType<typeof vi.fn>;
+  getDataURL: ReturnType<typeof vi.fn>;
+  on: (event: string, cb: () => void) => void;
+  off: (event: string, cb: () => void) => void;
+  _fireFinished: () => void;
+}
+
+function makeInstance(): FakeInstance {
+  const handlers: Record<string, Array<() => void>> = {};
+  return {
+    getOption: vi.fn(() => ({ series: [{ data: [] }] })),
+    getDataURL: vi.fn(() => "data:image/png;base64,FAKE"),
+    on: (event, cb) => {
+      handlers[event] = handlers[event] ?? [];
+      handlers[event].push(cb);
+    },
+    off: (event, cb) => {
+      handlers[event] = (handlers[event] ?? []).filter((h) => h !== cb);
+    },
+    _fireFinished: () => {
+      (handlers["finished"] ?? []).forEach((h) => h());
+    },
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  rootMocks.length = 0;
+  getInstanceByDom.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("captureChartToDataUrl", () => {
+  it("appends a hidden host to document.body during capture and removes it on success", async () => {
+    vi.useFakeTimers();
+    const instance = makeInstance();
+    getInstanceByDom.mockImplementation(() => instance);
+
+    const promise = captureChartToDataUrl(makeChapter());
+
+    // Polling loop runs setTimeout(50). Advance once so the renderer mock has
+    // mounted in the DOM and the polling loop can find the host.
+    await vi.advanceTimersByTimeAsync(0);
+    placeTaggedDiv();
+    await vi.advanceTimersByTimeAsync(60);
+
+    expect(
+      document.body.querySelector("[data-archival-chart-capture]")
+    ).not.toBeNull();
+
+    instance._fireFinished();
+    await vi.advanceTimersByTimeAsync(300);
+
+    const result = await promise;
+    expect(result).toBe("data:image/png;base64,FAKE");
+    expect(
+      document.body.querySelector("[data-archival-chart-capture]")
+    ).toBeNull();
+  });
+
+  it("calls getDataURL with type=png, pixelRatio=2, backgroundColor=#fff", async () => {
+    vi.useFakeTimers();
+    const instance = makeInstance();
+    getInstanceByDom.mockImplementation(() => instance);
+
+    const promise = captureChartToDataUrl(makeChapter());
+    await vi.advanceTimersByTimeAsync(0);
+    placeTaggedDiv();
+    await vi.advanceTimersByTimeAsync(60);
+    instance._fireFinished();
+    await vi.advanceTimersByTimeAsync(300);
+    await promise;
+
+    expect(instance.getDataURL).toHaveBeenCalledWith({
+      type: "png",
+      pixelRatio: 2,
+      backgroundColor: "#fff",
+    });
+  });
+
+  it("rejects with a timeout error after 30s if the chart never reports finished", async () => {
+    vi.useFakeTimers();
+    const instance = makeInstance();
+    getInstanceByDom.mockImplementation(() => instance);
+
+    const promise = captureChartToDataUrl(makeChapter());
+    await vi.advanceTimersByTimeAsync(0);
+    placeTaggedDiv();
+    await vi.advanceTimersByTimeAsync(60);
+
+    const failure = expect(promise).rejects.toThrow(/timed out/i);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await failure;
+  });
+
+  it("removes the offscreen host even when capture fails", async () => {
+    vi.useFakeTimers();
+    getInstanceByDom.mockImplementation(() => undefined);
+
+    const promise = captureChartToDataUrl(makeChapter());
+    await vi.advanceTimersByTimeAsync(0);
+    placeTaggedDiv();
+    await vi.advanceTimersByTimeAsync(60);
+
+    const failure = expect(promise).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(30_000);
+    await failure;
+
+    expect(
+      document.body.querySelector("[data-archival-chart-capture]")
+    ).toBeNull();
+  });
+});

--- a/frontend/src/lib/story/archival/__tests__/captureChart.test.ts
+++ b/frontend/src/lib/story/archival/__tests__/captureChart.test.ts
@@ -60,16 +60,23 @@ function placeTaggedDiv() {
 
 interface FakeInstance {
   getOption: ReturnType<typeof vi.fn>;
+  getWidth: ReturnType<typeof vi.fn>;
+  getHeight: ReturnType<typeof vi.fn>;
   getDataURL: ReturnType<typeof vi.fn>;
   on: (event: string, cb: () => void) => void;
   off: (event: string, cb: () => void) => void;
   _fireFinished: () => void;
+  _handlerCount: (event: string) => number;
 }
 
-function makeInstance(): FakeInstance {
+function makeInstance(
+  opts: { width?: number; height?: number } = {}
+): FakeInstance {
   const handlers: Record<string, Array<() => void>> = {};
   return {
     getOption: vi.fn(() => ({ series: [{ data: [] }] })),
+    getWidth: vi.fn(() => opts.width ?? 0),
+    getHeight: vi.fn(() => opts.height ?? 0),
     getDataURL: vi.fn(() => "data:image/png;base64,FAKE"),
     on: (event, cb) => {
       handlers[event] = handlers[event] ?? [];
@@ -81,6 +88,7 @@ function makeInstance(): FakeInstance {
     _fireFinished: () => {
       (handlers["finished"] ?? []).forEach((h) => h());
     },
+    _handlerCount: (event) => (handlers[event] ?? []).length,
   };
 }
 
@@ -174,5 +182,48 @@ describe("captureChartToDataUrl", () => {
     expect(
       document.body.querySelector("[data-archival-chart-capture]")
     ).toBeNull();
+  });
+
+  // Regression: echarts emits 'finished' once when a render completes and does
+  // not replay it for late subscribers. A fast-rendering chart can finish
+  // before the polling loop reaches the on('finished') subscription, leaving
+  // everFinished stuck at false and the capture timing out at 30s. The fix
+  // checks getWidth()/getHeight() synchronously when subscribing: if the chart
+  // already has positive dimensions, it counts as already-finished.
+  it("captures when the chart already has dimensions at subscribe time (finished event missed)", async () => {
+    vi.useFakeTimers();
+    // Instance is already rendered when we subscribe; 'finished' never fires.
+    const instance = makeInstance({ width: 1200, height: 675 });
+    getInstanceByDom.mockImplementation(() => instance);
+
+    const promise = captureChartToDataUrl(makeChapter());
+    await vi.advanceTimersByTimeAsync(0);
+    placeTaggedDiv();
+    await vi.advanceTimersByTimeAsync(60);
+
+    // No _fireFinished() call. Just wait the quiet period.
+    await vi.advanceTimersByTimeAsync(300);
+
+    const result = await promise;
+    expect(result).toBe("data:image/png;base64,FAKE");
+  });
+
+  it("removes the 'finished' listener when the timeout trips (no orphaned listeners)", async () => {
+    vi.useFakeTimers();
+    const instance = makeInstance();
+    getInstanceByDom.mockImplementation(() => instance);
+
+    const promise = captureChartToDataUrl(makeChapter());
+    await vi.advanceTimersByTimeAsync(0);
+    placeTaggedDiv();
+    await vi.advanceTimersByTimeAsync(60);
+
+    expect(instance._handlerCount("finished")).toBe(1);
+
+    const failure = expect(promise).rejects.toThrow(/timed out/i);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await failure;
+
+    expect(instance._handlerCount("finished")).toBe(0);
   });
 });

--- a/frontend/src/lib/story/archival/buildArchivalHtml.ts
+++ b/frontend/src/lib/story/archival/buildArchivalHtml.ts
@@ -6,6 +6,7 @@ import type { Chapter, Story } from "../types";
 import type { Connection, Dataset } from "../../../types";
 import { buildCitationBlock, escapeHtml, safeHttpUrl } from "./citations";
 import { captureChapterMap } from "./captureMap";
+import { captureChartToDataUrl } from "./captureChart";
 import { fetchAndInlineAsBase64 } from "./inlineAsset";
 
 export interface BuildArchivalHtmlArgs {
@@ -22,15 +23,16 @@ export interface BuildArchivalHtmlArgs {
  * thumbnails, images), and a data-citations block are all inlined.
  *
  * Map and scrollytelling chapters are rendered offscreen via captureChapterMap
- * using the live datasetMap + connectionMap, so they route through the same
- * tile endpoints as the in-page reader (e.g. /raster/collections/{id}/... for
- * ingested datasets). Using the cng-rc-synthesized story would force every
- * raster chapter onto the client-side /cog/tiles/?url=… path, which 500s for
- * example datasets whose source_url is a bucket directory listing.
+ * and chart chapters via captureChartToDataUrl, using the live datasetMap +
+ * connectionMap so map captures route through the same tile endpoints as the
+ * in-page reader (e.g. /raster/collections/{id}/... for ingested datasets).
+ * Using the cng-rc-synthesized story would force every raster chapter onto
+ * the client-side /cog/tiles/?url=… path, which 500s for example datasets
+ * whose source_url is a bucket directory listing.
  *
- * Errors from map snapshot capture (timeouts, missing canvases) propagate up
- * to the caller; the export fails loudly rather than silently shipping a
- * partial document.
+ * Errors from any chapter capture (timeouts, missing canvases, chart load
+ * failures) propagate up to the caller; the export fails loudly rather than
+ * silently shipping a partial document.
  */
 export async function buildArchivalHtml({
   config,
@@ -168,7 +170,17 @@ async function renderChapter(
     }
 
     case "chart": {
-      return `<section class="chapter chart">${title}${placeholder("Chart rendering pending")}${body}</section>`;
+      if (!storyChapter) {
+        throw new Error(`Live chapter data missing for chart chapter ${ch.id}`);
+      }
+      if (storyChapter.type !== "chart") {
+        throw new Error(
+          `Live chapter type mismatch for chart chapter ${ch.id}`
+        );
+      }
+      const dataUrl = await captureChartToDataUrl(storyChapter);
+      const altText = escapeHtml(ch.title ?? "Chart");
+      return `<section class="chapter chart">${title}<img src="${dataUrl}" alt="${altText}" />${body}</section>`;
     }
 
     default: {

--- a/frontend/src/lib/story/archival/captureChart.ts
+++ b/frontend/src/lib/story/archival/captureChart.ts
@@ -1,13 +1,12 @@
+import type { ChartChapter } from "../types";
+
 /**
- * Render a chart spec to a canvas and return its data URL.
- *
- * Currently a stub. Chart chapters render via recharts (SVG) — see
- * `ChartChapterRenderer.tsx`. A real implementation needs to serialize
- * the rendered SVG to a Blob, draw it onto a canvas, and call toDataURL.
- * Task 4 emits a placeholder for chart chapters; this fills in afterwards.
+ * Render a chart chapter to an off-screen echarts instance and return a PNG
+ * data URL via `instance.getDataURL({ type: 'png', pixelRatio: 2, ... })`.
+ * Real implementation lands in Task 2.
  */
-export async function captureChartToDataUrl(): Promise<string> {
-  throw new Error(
-    "Not yet implemented — recharts SVG-to-canvas capture is a follow-up"
-  );
+export async function captureChartToDataUrl(
+  _chapter: ChartChapter
+): Promise<string> {
+  throw new Error("Not yet implemented");
 }

--- a/frontend/src/lib/story/archival/captureChart.ts
+++ b/frontend/src/lib/story/archival/captureChart.ts
@@ -1,12 +1,110 @@
+import { createElement, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import * as echarts from "echarts";
+import { ChartChapterRenderer } from "../../../components/ChartChapterRenderer";
 import type { ChartChapter } from "../types";
 
+const CAPTURE_WIDTH = 1200;
+const CAPTURE_HEIGHT = 675;
+const TIMEOUT_MS = 30_000;
+const QUIET_MS = 250;
+const POLL_INTERVAL_MS = 50;
+
+interface EchartsInstance {
+  getOption: () => unknown;
+  getDataURL: (opts: {
+    type: "png";
+    pixelRatio: number;
+    backgroundColor: string;
+  }) => string;
+  on: (event: string, cb: () => void) => void;
+  off: (event: string, cb: () => void) => void;
+}
+
 /**
- * Render a chart chapter to an off-screen echarts instance and return a PNG
- * data URL via `instance.getDataURL({ type: 'png', pixelRatio: 2, ... })`.
- * Real implementation lands in Task 2.
+ * Render a chart chapter into an offscreen Chakra-wrapped ChartChapterRenderer,
+ * wait for echarts to finish its first render (plus a quiet period), and
+ * return a PNG data URL via `instance.getDataURL`. Mirrors captureChapterMap's
+ * offscreen-mount + 30s timeout discipline. Errors propagate so callers can
+ * fail the whole archival export loudly rather than shipping a chart-less
+ * document.
  */
 export async function captureChartToDataUrl(
-  _chapter: ChartChapter
+  chapter: ChartChapter
 ): Promise<string> {
-  throw new Error("Not yet implemented");
+  const host = document.createElement("div");
+  host.setAttribute("data-archival-chart-capture", "");
+  host.style.cssText = `position:fixed;left:-10000px;top:0;width:${CAPTURE_WIDTH}px;height:${CAPTURE_HEIGHT}px;pointer-events:none;`;
+  document.body.appendChild(host);
+  const root = createRoot(host);
+
+  try {
+    const tree: ReactNode = createElement(
+      ChakraProvider,
+      { value: defaultSystem },
+      createElement(ChartChapterRenderer, { chapter, chapterIndex: 0 })
+    );
+    root.render(tree);
+
+    const ready = (async () => {
+      const instance = await waitForChartInstance(host);
+      await waitForFinishedQuiet(instance);
+      return instance.getDataURL({
+        type: "png",
+        pixelRatio: 2,
+        backgroundColor: "#fff",
+      });
+    })();
+
+    return await Promise.race([
+      ready,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => {
+          reject(
+            new Error(`Chart snapshot timed out after ${TIMEOUT_MS / 1000}s`)
+          );
+        }, TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    root.unmount();
+    host.remove();
+  }
+}
+
+async function waitForChartInstance(
+  host: HTMLElement
+): Promise<EchartsInstance> {
+  while (true) {
+    const el = host.querySelector<HTMLElement>("[_echarts_instance_]");
+    if (el) {
+      const inst = echarts.getInstanceByDom(el) as EchartsInstance | undefined;
+      if (inst) return inst;
+    }
+    await new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+}
+
+async function waitForFinishedQuiet(instance: EchartsInstance): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let lastFinishedAt = 0;
+    let everFinished = false;
+
+    const onFinished = () => {
+      everFinished = true;
+      lastFinishedAt = performance.now();
+    };
+    instance.on("finished", onFinished);
+
+    const tick = () => {
+      if (everFinished && performance.now() - lastFinishedAt >= QUIET_MS) {
+        instance.off("finished", onFinished);
+        resolve();
+        return;
+      }
+      setTimeout(tick, POLL_INTERVAL_MS);
+    };
+    tick();
+  });
 }

--- a/frontend/src/lib/story/archival/captureChart.ts
+++ b/frontend/src/lib/story/archival/captureChart.ts
@@ -73,7 +73,10 @@ export async function captureChartToDataUrl(
       });
     } catch (err) {
       if (timeoutTripped) {
-        throw new Error(`Chart snapshot timed out after ${TIMEOUT_MS / 1000}s`);
+        throw new Error(
+          `Chart snapshot timed out after ${TIMEOUT_MS / 1000}s`,
+          { cause: err }
+        );
       }
       throw err;
     }

--- a/frontend/src/lib/story/archival/captureChart.ts
+++ b/frontend/src/lib/story/archival/captureChart.ts
@@ -13,6 +13,8 @@ const POLL_INTERVAL_MS = 50;
 
 interface EchartsInstance {
   getOption: () => unknown;
+  getWidth: () => number;
+  getHeight: () => number;
   getDataURL: (opts: {
     type: "png";
     pixelRatio: number;
@@ -29,6 +31,11 @@ interface EchartsInstance {
  * offscreen-mount + 30s timeout discipline. Errors propagate so callers can
  * fail the whole archival export loudly rather than shipping a chart-less
  * document.
+ *
+ * A single AbortController gates both the instance-discovery polling loop and
+ * the 'finished' quiet-period wait, so when the 30 s timeout fires the inner
+ * timers and the 'finished' listener are cleaned up immediately rather than
+ * left dangling on the disposed instance.
  */
 export async function captureChartToDataUrl(
   chapter: ChartChapter
@@ -38,6 +45,13 @@ export async function captureChartToDataUrl(
   host.style.cssText = `position:fixed;left:-10000px;top:0;width:${CAPTURE_WIDTH}px;height:${CAPTURE_HEIGHT}px;pointer-events:none;`;
   document.body.appendChild(host);
   const root = createRoot(host);
+
+  const controller = new AbortController();
+  let timeoutTripped = false;
+  const timeoutId = setTimeout(() => {
+    timeoutTripped = true;
+    controller.abort();
+  }, TIMEOUT_MS);
 
   try {
     const tree: ReactNode = createElement(ChakraProvider, {
@@ -49,49 +63,56 @@ export async function captureChartToDataUrl(
     });
     root.render(tree);
 
-    const ready = (async () => {
-      const instance = await waitForChartInstance(host);
-      await waitForFinishedQuiet(instance);
+    try {
+      const instance = await waitForChartInstance(host, controller.signal);
+      await waitForFinishedQuiet(instance, controller.signal);
       return instance.getDataURL({
         type: "png",
         pixelRatio: 2,
         backgroundColor: "#fff",
       });
-    })();
-
-    return await Promise.race([
-      ready,
-      new Promise<never>((_, reject) => {
-        setTimeout(() => {
-          reject(
-            new Error(`Chart snapshot timed out after ${TIMEOUT_MS / 1000}s`)
-          );
-        }, TIMEOUT_MS);
-      }),
-    ]);
+    } catch (err) {
+      if (timeoutTripped) {
+        throw new Error(`Chart snapshot timed out after ${TIMEOUT_MS / 1000}s`);
+      }
+      throw err;
+    }
   } finally {
+    clearTimeout(timeoutId);
+    controller.abort();
     root.unmount();
     host.remove();
   }
 }
 
 async function waitForChartInstance(
-  host: HTMLElement
+  host: HTMLElement,
+  signal: AbortSignal
 ): Promise<EchartsInstance> {
   while (true) {
+    if (signal.aborted) throw new Error("capture aborted");
     const el = host.querySelector<HTMLElement>("[_echarts_instance_]");
     if (el) {
       const inst = echarts.getInstanceByDom(el) as EchartsInstance | undefined;
       if (inst) return inst;
     }
-    await new Promise<void>((r) => setTimeout(r, POLL_INTERVAL_MS));
+    await sleep(POLL_INTERVAL_MS, signal);
   }
 }
 
-async function waitForFinishedQuiet(instance: EchartsInstance): Promise<void> {
-  return new Promise<void>((resolve) => {
+async function waitForFinishedQuiet(
+  instance: EchartsInstance,
+  signal: AbortSignal
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error("capture aborted"));
+      return;
+    }
+
     let lastFinishedAt = 0;
     let everFinished = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
 
     const onFinished = () => {
       everFinished = true;
@@ -99,14 +120,51 @@ async function waitForFinishedQuiet(instance: EchartsInstance): Promise<void> {
     };
     instance.on("finished", onFinished);
 
+    // echarts does not replay the 'finished' event for renders that completed
+    // before the listener was attached. If the instance already has positive
+    // dimensions by the time we subscribe, treat it as having already finished
+    // and start the quiet period — otherwise a fast-rendering chart would sit
+    // until the outer 30 s timeout.
+    if (instance.getWidth() > 0 && instance.getHeight() > 0) {
+      everFinished = true;
+      lastFinishedAt = performance.now();
+    }
+
+    const cleanup = () => {
+      instance.off("finished", onFinished);
+      if (timer) clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    };
+
+    const onAbort = () => {
+      cleanup();
+      reject(new Error("capture aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+
     const tick = () => {
+      if (signal.aborted) return;
       if (everFinished && performance.now() - lastFinishedAt >= QUIET_MS) {
-        instance.off("finished", onFinished);
+        cleanup();
         resolve();
         return;
       }
-      setTimeout(tick, POLL_INTERVAL_MS);
+      timer = setTimeout(tick, POLL_INTERVAL_MS);
     };
     tick();
+  });
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error("capture aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
   });
 }

--- a/frontend/src/lib/story/archival/captureChart.ts
+++ b/frontend/src/lib/story/archival/captureChart.ts
@@ -40,11 +40,13 @@ export async function captureChartToDataUrl(
   const root = createRoot(host);
 
   try {
-    const tree: ReactNode = createElement(
-      ChakraProvider,
-      { value: defaultSystem },
-      createElement(ChartChapterRenderer, { chapter, chapterIndex: 0 })
-    );
+    const tree: ReactNode = createElement(ChakraProvider, {
+      value: defaultSystem,
+      children: createElement(ChartChapterRenderer, {
+        chapter,
+        chapterIndex: 0,
+      }),
+    });
     root.render(tree);
 
     const ready = (async () => {


### PR DESCRIPTION
Closes #472.

## Summary
- Replaces the `(Chart rendering pending)` placeholder in archival HTML export with a real PNG snapshot of each chart chapter.
- `captureChartToDataUrl` mirrors `captureChapterMap`: offscreen 1200×675 mount of `<ChakraProvider><ChartChapterRenderer/></ChakraProvider>`, polls for the echarts instance via `echarts.getInstanceByDom`, waits for the `'finished'` event + 250 ms quiet period, then calls `instance.getDataURL({ type: 'png', pixelRatio: 2, backgroundColor: '#fff' })`. 30 s hard timeout, host cleaned up in `finally` on both success and failure.
- `buildArchivalHtml.ts` chart case now emits `<img src="data:image/png;base64,…" alt="<chapter title>" />`. Errors propagate — chart failures fail the whole export loudly, matching the existing map-capture policy.

## Test plan
- [ ] \`cd frontend && npx vitest run\` — full frontend suite passes (829 tests locally)
- [ ] New \`captureChart.test.ts\` covers: hidden host mount/unmount on success, \`getDataURL\` args, 30 s timeout, host cleanup on failure
- [ ] \`buildArchivalHtml.test.ts\` covers: chart \`<img>\` rendering with title as alt text, error propagation (no silent fallback)
- [ ] Manual smoke (user): build a story with a chart chapter, export archival HTML, open the file in a browser, confirm the chart renders as an image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charts in archived stories are now rendered offscreen and embedded as PNG images; image descriptions include escaped chapter titles.

* **Bug Fixes**
  * Capture enforces timeouts, propagates failures instead of shipping partial output, and always cleans up DOM and event listeners.

* **Tests**
  * Expanded tests for chart capture, export options, timeout handling, listener removal, and DOM cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aboydnw/cng-sandbox/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->