### PR TITLE
feat: add obstore to Store step in technical details panel

### DIFF
--- a/frontend/src/components/details/stepContent.ts
+++ b/frontend/src/components/details/stepContent.ts
@@ -448,6 +448,12 @@ function getStoreStep(dataset: Dataset, pipeline: PipelineType): StepContent {
         description:
           "S3-compatible object storage with zero egress fees, used to host COG files for tiler access.",
       },
+      {
+        name: "obstore",
+        url: "https://github.com/developmentseed/obstore",
+        description:
+          "Rust-backed Python object-store client that uploads the converted file to R2 with high throughput.",
+      },
     ];
 
     return {
@@ -488,6 +494,12 @@ function getStoreStep(dataset: Dataset, pipeline: PipelineType): StepContent {
         url: "https://www.cloudflare.com/developer-platform/r2/",
         description:
           "S3-compatible object storage with zero egress fees, hosting the PMTiles archive for direct browser access.",
+      },
+      {
+        name: "obstore",
+        url: "https://github.com/developmentseed/obstore",
+        description:
+          "Rust-backed Python object-store client that uploads the converted file to R2 with high throughput.",
       },
     ];
 


### PR DESCRIPTION
## What

Adds an [obstore](https://github.com/developmentseed/obstore) tool card to the Store step in the conversion details panel, for both R2-backed pipelines (raster COG and vector PMTiles). The PostGIS branch is untouched — it doesn't upload via obstore.

Closes #72

## Verification

- `npx vitest run src/components/details` — 30 passed
- `npx tsc --noEmit` and `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `obstore`, an open-source storage tool, to the Store step for raster and vector-pmtiles pipelines, enabling uploads to R2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->