### PR TITLE
fix(frontend): surface fetch failures on list pages and connections API

### DIFF
--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -40,6 +40,26 @@ describe("workspaceFetch", () => {
   });
 });
 
+describe("connectionsApi.list", () => {
+  it("resolves with the connections array on ok response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: "c1" }],
+    });
+    const result = await connectionsApi.list();
+    expect(result).toEqual([{ id: "c1" }]);
+  });
+
+  it("throws on non-ok response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "Internal Server Error" }),
+    });
+    await expect(connectionsApi.list()).rejects.toThrow();
+  });
+});
+
 describe("datasetsApi.setPreferredColormap", () => {
   it("PATCHes /api/datasets/{id}/colormap with the payload", async () => {
     mockFetch.mockResolvedValue({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -48,7 +48,10 @@ export function workspaceFetch(
 
 export const connectionsApi = {
   list(): Promise<Connection[]> {
-    return workspaceFetch("/api/connections").then((r) => r.json());
+    return workspaceFetch("/api/connections").then(async (r) => {
+      if (!r.ok) throw new Error(await readErrorDetail(r));
+      return r.json();
+    });
   },
 
   get(id: string): Promise<Connection> {

--- a/frontend/src/pages/DataPage.tsx
+++ b/frontend/src/pages/DataPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Box, Button, Flex, Heading, Table, Text } from "@chakra-ui/react";
-import { SpinnerGap } from "@phosphor-icons/react";
+import { SpinnerGap, Warning } from "@phosphor-icons/react";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
 import { useWorkspace } from "../hooks/useWorkspace";
@@ -9,6 +9,7 @@ import { config } from "../config";
 import { workspaceFetch, connectionsApi } from "../lib/api";
 import type { Dataset, Connection } from "../types";
 import { displayName } from "../utils/dataset";
+import { timeAgo } from "../utils/format";
 import { detectCadence, formatDateRangeBadge } from "../utils/temporal";
 import {
   datasetToLibraryItem,
@@ -20,43 +21,52 @@ interface DatasetWithStoryCount extends Dataset {
   story_count?: number;
 }
 
-function timeAgo(dateStr: string): string {
-  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
 export default function DataPage() {
   const { workspacePath } = useWorkspace();
   const [datasets, setDatasets] = useState<DatasetWithStoryCount[]>([]);
   const [connections, setConnections] = useState<Connection[]>([]);
   const [datasetsLoading, setDatasetsLoading] = useState(true);
   const [connectionsLoading, setConnectionsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     workspaceFetch(`${config.apiBase}/api/datasets`)
-      .then((r) => r.json())
-      .then((data) => {
-        setDatasets(data);
-        setDatasetsLoading(false);
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
       })
-      .catch(() => setDatasetsLoading(false));
+      .then((data) => {
+        if (!cancelled) setDatasets(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError((err as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setDatasetsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
     connectionsApi
       .list()
       .then((data) => {
-        setConnections(data);
-        setConnectionsLoading(false);
+        if (!cancelled) setConnections(data);
       })
-      .catch(() => setConnectionsLoading(false));
+      .catch((err) => {
+        if (!cancelled) setError((err as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setConnectionsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleDelete = useCallback(async (item: LibraryItem) => {
@@ -270,6 +280,21 @@ export default function DataPage() {
               size={32}
               style={{ animation: "spin 1s linear infinite" }}
             />
+          </Flex>
+        ) : error ? (
+          <Flex
+            align="center"
+            gap={2}
+            p={2.5}
+            bg="red.50"
+            border="1px solid"
+            borderColor="red.200"
+            borderRadius="6px"
+            color="red.600"
+            fontSize="13px"
+          >
+            <Warning size={16} style={{ flexShrink: 0 }} />
+            <Text>Couldn&rsquo;t load your data library. {error}</Text>
           </Flex>
         ) : (
           (() => {

--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -1,37 +1,36 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Box, Button, Flex, Heading, Table, Text } from "@chakra-ui/react";
-import { SpinnerGap } from "@phosphor-icons/react";
+import { SpinnerGap, Warning } from "@phosphor-icons/react";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
 import { useWorkspace } from "../hooks/useWorkspace";
 import { listStoriesFromServer, deleteStoryFromServer } from "../lib/story/api";
+import { timeAgo } from "../utils/format";
 import type { Story } from "../lib/story/types";
-
-function timeAgo(dateStr: string): string {
-  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
 
 export default function StoriesPage() {
   const { workspacePath } = useWorkspace();
   const [stories, setStories] = useState<Story[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     listStoriesFromServer()
       .then((data) => {
-        setStories(data);
-        setLoading(false);
+        if (!cancelled) setStories(data);
       })
-      .catch(() => setLoading(false));
+      .catch((err) => {
+        if (!cancelled) setError((err as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const handleDelete = useCallback(async (story: Story) => {
@@ -80,6 +79,21 @@ export default function StoriesPage() {
               size={32}
               style={{ animation: "spin 1s linear infinite" }}
             />
+          </Flex>
+        ) : error ? (
+          <Flex
+            align="center"
+            gap={2}
+            p={2.5}
+            bg="red.50"
+            border="1px solid"
+            borderColor="red.200"
+            borderRadius="6px"
+            color="red.600"
+            fontSize="13px"
+          >
+            <Warning size={16} style={{ flexShrink: 0 }} />
+            <Text>Couldn&rsquo;t load your stories. {error}</Text>
           </Flex>
         ) : userStories.length === 0 ? (
           <Text color="gray.500" fontSize="sm" mb={2}>

--- a/frontend/src/pages/WorkspaceHomePage.tsx
+++ b/frontend/src/pages/WorkspaceHomePage.tsx
@@ -14,17 +14,7 @@ import { config } from "../config";
 import type { Story } from "../lib/story/types";
 import type { Dataset } from "../types";
 import { displayName } from "../utils/dataset";
-
-function timeAgo(dateStr: string): string {
-  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
+import { timeAgo } from "../utils/format";
 
 function sortByUpdated<T extends { updated_at?: string; created_at?: string }>(
   items: T[]

--- a/frontend/src/pages/__tests__/DataPage.test.tsx
+++ b/frontend/src/pages/__tests__/DataPage.test.tsx
@@ -46,6 +46,7 @@ const userConnection: Connection = {
 vi.mock("../../lib/api", () => ({
   workspaceFetch: vi.fn(() =>
     Promise.resolve({
+      ok: true,
       json: () => Promise.resolve([]),
     })
   ),
@@ -55,6 +56,8 @@ vi.mock("../../lib/api", () => ({
   },
   setWorkspaceId: vi.fn(),
 }));
+
+import { workspaceFetch, connectionsApi } from "../../lib/api";
 
 function renderDataPage() {
   return render(
@@ -103,5 +106,37 @@ describe("DataPage example connection gating", () => {
     expect(userRow).not.toBeNull();
     const deleteButton = userRow!.querySelector("button");
     expect(deleteButton?.textContent).toMatch(/delete/i);
+  });
+});
+
+describe("DataPage fetch failures", () => {
+  it("shows an error message when the datasets fetch returns non-ok", async () => {
+    (workspaceFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ detail: "boom" }),
+    });
+    renderDataPage();
+
+    expect(
+      await screen.findByText(/couldn’t load your data library/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/nothing in your data library yet/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an error message when the connections fetch rejects", async () => {
+    (connectionsApi.list as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("HTTP 502")
+    );
+    renderDataPage();
+
+    expect(
+      await screen.findByText(/couldn’t load your data library/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/nothing in your data library yet/i)
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/__tests__/StoriesPage.test.tsx
+++ b/frontend/src/pages/__tests__/StoriesPage.test.tsx
@@ -107,4 +107,18 @@ describe("StoriesPage no longer renders example cards", () => {
   });
 });
 
+describe("StoriesPage fetch failure", () => {
+  it("shows an error message instead of the empty state when the fetch rejects", async () => {
+    (listStoriesFromServer as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("Failed to list stories: 500")
+    );
+    renderStoriesPage();
+
+    expect(
+      await screen.findByText(/couldn’t load your stories/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/no stories yet/i)).not.toBeInTheDocument();
+  });
+});
+
 export { renderStoriesPage };

--- a/frontend/src/utils/__tests__/format.test.ts
+++ b/frontend/src/utils/__tests__/format.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { timeAgo } from "../format";
+
+describe("timeAgo", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 'just now' for timestamps under a minute old", () => {
+    expect(timeAgo("2026-06-09T11:59:30Z")).toBe("just now");
+  });
+
+  it("returns minutes for timestamps under an hour old", () => {
+    expect(timeAgo("2026-06-09T11:15:00Z")).toBe("45m ago");
+  });
+
+  it("returns hours for timestamps under a day old", () => {
+    expect(timeAgo("2026-06-09T09:00:00Z")).toBe("3h ago");
+  });
+
+  it("returns days for older timestamps", () => {
+    expect(timeAgo("2026-06-02T12:00:00Z")).toBe("7d ago");
+  });
+});

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -13,7 +13,9 @@ export function formatCount(n: number): string {
 }
 
 export function timeAgo(dateStr: string): string {
-  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  const time = new Date(dateStr).getTime();
+  if (Number.isNaN(time)) return "—";
+  const seconds = Math.floor((Date.now() - time) / 1000);
   if (seconds < 60) return "just now";
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes}m ago`;
@@ -21,14 +23,4 @@ export function timeAgo(dateStr: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
-}
-
-export function daysUntilExpiry(createdAt: string): number {
-  const created = new Date(createdAt);
-  const expiry = new Date(created.getTime() + 30 * 24 * 60 * 60 * 1000);
-  const now = new Date();
-  return Math.max(
-    0,
-    Math.ceil((expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
-  );
 }

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -12,6 +12,17 @@ export function formatCount(n: number): string {
   return n.toLocaleString();
 }
 
+export function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
 export function daysUntilExpiry(createdAt: string): number {
   const created = new Date(createdAt);
   const expiry = new Date(created.getTime() + 30 * 24 * 60 * 60 * 1000);

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -24,3 +24,13 @@ export function timeAgo(dateStr: string): string {
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
 }
+
+export function daysUntilExpiry(createdAt: string): number {
+  const created = new Date(createdAt);
+  const expiry = new Date(created.getTime() + 30 * 24 * 60 * 60 * 1000);
+  const now = new Date();
+  return Math.max(
+    0,
+    Math.ceil((expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+  );
+}


### PR DESCRIPTION
## Summary

Backend failures on the Data and Stories list pages previously rendered as the empty state ("no datasets yet"), actively misleading users. This PR makes them visible errors.

- **`connectionsApi.list()`** never checked `r.ok`, so a 5xx JSON error body resolved as `Connection[]` and crashed callers downstream. It now throws via `readErrorDetail`, consistent with the other methods in `api.ts`. (Audited the full `api.ts` surface — `list()` was the only method missing the check.)
- **`DataPage`**: both fetches (datasets + connections) now check `r.ok`, set an `error` state rendered as a distinct red error banner (Phosphor `Warning` icon, matching the existing `RemoteConnectFlow` convention), and use effect-scoped cancelled-flag cleanup.
- **`StoriesPage`**: same fix.
- **Dedupe `timeAgo`**: identical copies in `DataPage`, `StoriesPage`, and `WorkspaceHomePage` replaced by one canonical export in `src/utils/format.ts`.

## Tests

- `connectionsApi.list` resolves on ok / throws on non-ok
- `DataPage` shows the error banner (not the empty state) when either fetch fails
- `StoriesPage` shows the error banner (not the empty state) on fetch rejection
- `timeAgo` unit tests with fake timers

`prettier --check`, `tsc --noEmit`, and `vitest run` (843 tests, 123 files) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline warning callouts with icons now display when datasets, connections, or stories fail to load.

* **Bug Fixes**
  * Improved fetch error handling and propagation so failed requests show clear messages instead of continuing with empty or broken states.

* **Tests**
  * Added/expanded tests for API error handling and DataPage/StoriesPage UI behavior on fetch failures, plus coverage for the time-ago formatter.

* **Refactor**
  * Shared time-ago formatting utility is reused across pages (replacing local implementations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->