### PR TITLE
refactor(ingestion): deduplicate dataset-assembly code across pipelines

### DIFF
--- a/ingestion/src/services/pipeline.py
+++ b/ingestion/src/services/pipeline.py
@@ -305,6 +305,137 @@ def _detect_use_pmtiles(output_path: str) -> bool:
     return True
 
 
+@dataclass
+class RasterSummary:
+    raster_min: float
+    raster_max: float
+    bounds: list[float]
+    band_meta: BandMetadata
+    min_zoom: int
+    max_zoom: int
+
+
+async def _extract_raster_summary(cog_paths: list[str]) -> RasterSummary:
+    """Compute global stats and first-COG metadata for a raster pipeline.
+
+    Runs compute_global_stats across all COGs, then extracts bounds, band
+    metadata, and zoom range from the first COG. All blocking work runs off
+    the event loop.
+    """
+    from src.services.temporal_validation import compute_global_stats
+
+    raster_min, raster_max = await asyncio.to_thread(compute_global_stats, cog_paths)
+    first_cog = cog_paths[0]
+    bounds = await asyncio.to_thread(_extract_bounds, first_cog, DatasetType.RASTER)
+    band_meta = await asyncio.to_thread(_extract_band_metadata, first_cog)
+    min_zoom, max_zoom = await asyncio.to_thread(_extract_zoom_range_raster, first_cog)
+    return RasterSummary(
+        raster_min=raster_min,
+        raster_max=raster_max,
+        bounds=bounds,
+        band_meta=band_meta,
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+    )
+
+
+def _build_raster_dataset(
+    job: Job,
+    *,
+    filename: str,
+    format_pair: FormatPair,
+    tile_url: str,
+    summary: RasterSummary,
+    converted_file_size: int,
+    validation_results: list[ValidationCheck],
+    **extra,
+) -> Dataset:
+    """Build the raster Dataset record shared by the multi-COG pipelines.
+
+    Extra keyword arguments (e.g. timesteps, source_url, expires_at) are
+    passed through to the Dataset constructor unchanged.
+    """
+    return Dataset(
+        id=job.dataset_id,
+        filename=filename,
+        dataset_type=DatasetType.RASTER,
+        format_pair=format_pair,
+        tile_url=tile_url,
+        bounds=summary.bounds,
+        band_count=summary.band_meta.band_count,
+        band_names=summary.band_meta.band_names,
+        color_interpretation=summary.band_meta.color_interpretation,
+        dtype=summary.band_meta.dtype,
+        converted_file_size=converted_file_size,
+        min_zoom=summary.min_zoom,
+        max_zoom=summary.max_zoom,
+        stac_collection_id=f"sandbox-{job.dataset_id}",
+        validation_results=validation_results,
+        credits=get_credits(format_pair),
+        workspace_id=job.workspace_id,
+        raster_min=summary.raster_min,
+        raster_max=summary.raster_max,
+        created_at=job.created_at,
+        **extra,
+    )
+
+
+async def _pause_for_variable_selection(
+    job: Job,
+    input_path: str,
+    variables: list[dict],
+    db_session_factory,
+) -> bool:
+    """Pause the pipeline until the user resumes it via /scan/{id}/convert.
+
+    Registers the scan in the shared scan store, publishes the scan result on
+    the job, and waits for the resume event. If the user selected a temporal
+    range, dispatches to the in-file temporal pipeline and returns True so the
+    caller can return early; otherwise returns False and the caller continues
+    with a single-timestep conversion.
+    """
+    from datetime import datetime as dt
+
+    from src.state import scan_store, scan_store_lock
+
+    scan_id = str(uuid.uuid4())
+    job.scan_result = {"scan_id": scan_id, "variables": variables}
+    job.scan_event = asyncio.Event()
+
+    async with scan_store_lock:
+        scan_store[scan_id] = {
+            "path": input_path,
+            "job": job,
+            "created_at": dt.now(UTC),
+            "variables": variables,
+            "state": "waiting",
+        }
+
+    await job.scan_event.wait()
+
+    temporal_params = None
+    async with scan_store_lock:
+        if scan_id in scan_store:
+            scan_store[scan_id]["state"] = "converting"
+            temporal_params = scan_store[scan_id].get("temporal")
+
+    if temporal_params is None:
+        return False
+
+    from src.services.temporal_pipeline import run_infile_temporal_pipeline
+
+    await run_infile_temporal_pipeline(
+        job=job,
+        input_path=input_path,
+        variable=job.variable,
+        group=job.group or "",
+        start_index=temporal_params.start_index,
+        end_index=temporal_params.end_index,
+        db_session_factory=db_session_factory,
+    )
+    return True
+
+
 async def run_pipeline(job: Job, input_path: str, db_session_factory) -> None:
     """Execute the full conversion pipeline. Updates job status in-place.
 
@@ -324,10 +455,7 @@ async def run_pipeline(job: Job, input_path: str, db_session_factory) -> None:
 
         # Variable selection for HDF5/NetCDF
         if format_pair in (FormatPair.HDF5_TO_COG, FormatPair.NETCDF_TO_COG):
-            from datetime import datetime as dt
-
             from src.services import scanner
-            from src.state import scan_store, scan_store_lock
 
             if format_pair == FormatPair.HDF5_TO_COG:
                 variables = await asyncio.to_thread(scanner.scan_hdf5, input_path)
@@ -340,41 +468,9 @@ async def run_pipeline(job: Job, input_path: str, db_session_factory) -> None:
                 return
 
             if len(variables) > 1:
-                scan_id = str(uuid.uuid4())
-                job.scan_result = {"scan_id": scan_id, "variables": variables}
-                job.scan_event = asyncio.Event()
-
-                async with scan_store_lock:
-                    scan_store[scan_id] = {
-                        "path": input_path,
-                        "job": job,
-                        "created_at": dt.now(UTC),
-                        "variables": variables,
-                        "state": "waiting",
-                    }
-
-                await job.scan_event.wait()
-
-                temporal_params = None
-                async with scan_store_lock:
-                    if scan_id in scan_store:
-                        scan_store[scan_id]["state"] = "converting"
-                        temporal_params = scan_store[scan_id].get("temporal")
-
-                if temporal_params is not None:
-                    from src.services.temporal_pipeline import (
-                        run_infile_temporal_pipeline,
-                    )
-
-                    await run_infile_temporal_pipeline(
-                        job=job,
-                        input_path=input_path,
-                        variable=job.variable,
-                        group=job.group or "",
-                        start_index=temporal_params.start_index,
-                        end_index=temporal_params.end_index,
-                        db_session_factory=db_session_factory,
-                    )
+                if await _pause_for_variable_selection(
+                    job, input_path, variables, db_session_factory
+                ):
                     return
 
             elif len(variables) == 1:
@@ -382,46 +478,14 @@ async def run_pipeline(job: Job, input_path: str, db_session_factory) -> None:
                 job.variable = v["name"]
                 job.group = v.get("group", "")
 
-                if v.get("time_dim") and v["time_dim"]["size"] > 1:
-                    scan_id = str(uuid.uuid4())
-                    job.scan_result = {
-                        "scan_id": scan_id,
-                        "variables": variables,
-                    }
-                    job.scan_event = asyncio.Event()
-
-                    async with scan_store_lock:
-                        scan_store[scan_id] = {
-                            "path": input_path,
-                            "job": job,
-                            "created_at": dt.now(UTC),
-                            "variables": variables,
-                            "state": "waiting",
-                        }
-
-                    await job.scan_event.wait()
-
-                    temporal_params = None
-                    async with scan_store_lock:
-                        if scan_id in scan_store:
-                            scan_store[scan_id]["state"] = "converting"
-                            temporal_params = scan_store[scan_id].get("temporal")
-
-                    if temporal_params is not None:
-                        from src.services.temporal_pipeline import (
-                            run_infile_temporal_pipeline,
-                        )
-
-                        await run_infile_temporal_pipeline(
-                            job=job,
-                            input_path=input_path,
-                            variable=job.variable,
-                            group=job.group or "",
-                            start_index=temporal_params.start_index,
-                            end_index=temporal_params.end_index,
-                            db_session_factory=db_session_factory,
-                        )
-                        return
+                if (
+                    v.get("time_dim")
+                    and v["time_dim"]["size"] > 1
+                    and await _pause_for_variable_selection(
+                        job, input_path, variables, db_session_factory
+                    )
+                ):
+                    return
 
         # Upload raw file to S3 off the event loop. obstore.put is blocking,
         # and on large files it stalls the SSE ping coroutine long enough for

--- a/ingestion/src/services/remote_pipeline.py
+++ b/ingestion/src/services/remote_pipeline.py
@@ -26,18 +26,15 @@ from src.services.cog_checker import check_remote_is_cog
 from src.services.detector import detect_format
 from src.services.error_mapping import map_pipeline_error
 from src.services.pipeline import (
-    _extract_band_metadata,
+    _build_raster_dataset,
     _extract_bounds,
-    _extract_zoom_range_raster,
+    _extract_raster_summary,
     _import_and_convert,
     get_credits,
 )
 from src.services.storage import StorageService
 from src.services.temporal_ordering import common_filename_prefix, order_files
-from src.services.temporal_validation import (
-    compute_global_stats,
-    validate_cross_file_compatibility,
-)
+from src.services.temporal_validation import validate_cross_file_compatibility
 from src.services.url_validation import raise_if_redirect
 
 logger = logging.getLogger(__name__)
@@ -305,18 +302,7 @@ async def _run_with_conversion(
                     job.error = "; ".join(cross_errors)
                     return
 
-            raster_min, raster_max = await asyncio.to_thread(
-                compute_global_stats, cog_paths
-            )
-
-            first_cog = cog_paths[0]
-            bounds = await asyncio.to_thread(
-                _extract_bounds, first_cog, DatasetType.RASTER
-            )
-            band_meta = await asyncio.to_thread(_extract_band_metadata, first_cog)
-            min_zoom, max_zoom = await asyncio.to_thread(
-                _extract_zoom_range_raster, first_cog
-            )
+            summary = await _extract_raster_summary(cog_paths)
 
             job.status = JobStatus.INGESTING
 
@@ -395,33 +381,20 @@ async def _run_with_conversion(
 
             expires_at = datetime.now(UTC) + timedelta(days=30)
 
-            dataset = Dataset(
-                id=job.dataset_id,
+            dataset = _build_raster_dataset(
+                job,
                 filename=display_name,
-                dataset_type=DatasetType.RASTER,
                 format_pair=FormatPair.GEOTIFF_TO_COG,
                 tile_url=tile_url,
-                bounds=bounds,
-                band_count=band_meta.band_count,
-                band_names=band_meta.band_names,
-                color_interpretation=band_meta.color_interpretation,
-                dtype=band_meta.dtype,
+                summary=summary,
                 converted_file_size=converted_file_size,
-                min_zoom=min_zoom,
-                max_zoom=max_zoom,
-                stac_collection_id=f"sandbox-{job.dataset_id}",
                 validation_results=[],
-                credits=get_credits(FormatPair.GEOTIFF_TO_COG),
-                workspace_id=job.workspace_id,
                 is_zero_copy=False,
                 is_mosaic=(mode == "mosaic"),
                 is_temporal=(mode == "temporal"),
                 timesteps=timesteps,
                 source_url=source_url,
-                raster_min=raster_min,
-                raster_max=raster_max,
                 expires_at=expires_at,
-                created_at=job.created_at,
             )
             persist_dataset(db_session_factory, dataset)
 

--- a/ingestion/src/services/temporal_pipeline.py
+++ b/ingestion/src/services/temporal_pipeline.py
@@ -10,7 +10,6 @@ import tempfile
 from collections.abc import Callable
 
 from src.models import (
-    Dataset,
     DatasetType,
     FormatPair,
     Job,
@@ -22,19 +21,14 @@ from src.services import stac_ingest
 from src.services.detector import detect_format, validate_magic_bytes
 from src.services.error_mapping import map_pipeline_error
 from src.services.pipeline import (
-    _extract_band_metadata,
-    _extract_bounds,
-    _extract_zoom_range_raster,
+    _build_raster_dataset,
+    _extract_raster_summary,
     _import_and_convert,
     _import_and_validate,
-    get_credits,
 )
 from src.services.storage import StorageService
 from src.services.temporal_ordering import common_filename_prefix, order_files
-from src.services.temporal_validation import (
-    compute_global_stats,
-    validate_cross_file_compatibility,
-)
+from src.services.temporal_validation import validate_cross_file_compatibility
 
 try:
     import xarray as xr
@@ -238,20 +232,8 @@ async def run_infile_temporal_pipeline(
                 await asyncio.to_thread(_cleanup_uploaded, storage, uploaded_keys)
                 return
 
-            # Stage 4: Compute global stats
-            raster_min, raster_max = await asyncio.to_thread(
-                compute_global_stats, cog_paths
-            )
-
-            # Stage 5: Extract metadata from first COG
-            first_cog = cog_paths[0]
-            bounds = await asyncio.to_thread(
-                _extract_bounds, first_cog, DatasetType.RASTER
-            )
-            band_meta = await asyncio.to_thread(_extract_band_metadata, first_cog)
-            min_zoom, max_zoom = await asyncio.to_thread(
-                _extract_zoom_range_raster, first_cog
-            )
+            # Stage 4-5: Global stats and first-COG metadata
+            summary = await _extract_raster_summary(cog_paths)
 
             # Stage 6: Ingest
             job.status = JobStatus.INGESTING
@@ -281,30 +263,17 @@ async def run_infile_temporal_pipeline(
                 Timestep(datetime=dt, index=i) for i, dt in enumerate(datetimes)
             ]
 
-            dataset = Dataset(
-                id=job.dataset_id,
+            dataset = _build_raster_dataset(
+                job,
                 filename=job.filename,
-                dataset_type=DatasetType.RASTER,
                 format_pair=job.format_pair,
                 tile_url=tile_url,
-                bounds=bounds,
-                band_count=band_meta.band_count,
-                band_names=band_meta.band_names,
-                color_interpretation=band_meta.color_interpretation,
-                dtype=band_meta.dtype,
-                original_file_size=original_file_size,
+                summary=summary,
                 converted_file_size=converted_file_size,
-                min_zoom=min_zoom,
-                max_zoom=max_zoom,
-                stac_collection_id=f"sandbox-{job.dataset_id}",
                 validation_results=[],
-                credits=get_credits(job.format_pair),
-                workspace_id=job.workspace_id,
+                original_file_size=original_file_size,
                 is_temporal=True,
                 timesteps=timesteps,
-                raster_min=raster_min,
-                raster_max=raster_max,
-                created_at=job.created_at,
             )
             from src.models.dataset import persist_dataset
 
@@ -420,20 +389,8 @@ async def run_temporal_pipeline(
                 await asyncio.to_thread(_cleanup_uploaded, storage, uploaded_keys)
                 return
 
-            # Stage 4: Compute global stats
-            raster_min, raster_max = await asyncio.to_thread(
-                compute_global_stats, cog_paths
-            )
-
-            # Stage 5: Extract metadata from first COG
-            first_cog = cog_paths[0]
-            bounds = await asyncio.to_thread(
-                _extract_bounds, first_cog, DatasetType.RASTER
-            )
-            band_meta = await asyncio.to_thread(_extract_band_metadata, first_cog)
-            min_zoom, max_zoom = await asyncio.to_thread(
-                _extract_zoom_range_raster, first_cog
-            )
+            # Stage 4-5: Global stats and first-COG metadata
+            summary = await _extract_raster_summary(cog_paths)
 
             # Stage 6: Ingest
             job.status = JobStatus.INGESTING
@@ -469,30 +426,17 @@ async def run_temporal_pipeline(
                 for entry in ordered
             ]
 
-            dataset = Dataset(
-                id=job.dataset_id,
+            dataset = _build_raster_dataset(
+                job,
                 filename=display_name,
-                dataset_type=DatasetType.RASTER,
                 format_pair=format_pair,
                 tile_url=tile_url,
-                bounds=bounds,
-                band_count=band_meta.band_count,
-                band_names=band_meta.band_names,
-                color_interpretation=band_meta.color_interpretation,
-                dtype=band_meta.dtype,
-                original_file_size=original_file_size,
+                summary=summary,
                 converted_file_size=converted_file_size,
-                min_zoom=min_zoom,
-                max_zoom=max_zoom,
-                stac_collection_id=f"sandbox-{job.dataset_id}",
                 validation_results=last_validation_results,
-                credits=get_credits(format_pair),
-                workspace_id=job.workspace_id,
+                original_file_size=original_file_size,
                 is_temporal=True,
                 timesteps=timesteps,
-                raster_min=raster_min,
-                raster_max=raster_max,
-                created_at=job.created_at,
             )
             from src.models.dataset import persist_dataset
 


### PR DESCRIPTION
## Summary

Stacked on #520 — merge that first, then this (do not retarget to `main` until #520 lands).

Pure refactor extracting three near-duplicate blocks from the ingestion pipelines into shared helpers in `pipeline.py` (already the shared module the other two import from):

- **`_extract_raster_summary(cog_paths)`** — computes global raster stats, then bounds, band metadata, and zoom range from the first COG, all via `asyncio.to_thread`. Replaces verbatim-duplicated blocks in `run_infile_temporal_pipeline`, `run_temporal_pipeline`, and `_run_with_conversion` (remote).
- **`_build_raster_dataset(job, ..., **extra)`** — the shared raster `Dataset` construction (tile URL, band fields, zoom range, stats, credits, workspace, etc.). Pipeline-specific fields (`timesteps`, `source_url`, `expires_at`, `original_file_size`, `is_*` flags) pass through unchanged.
- **`_pause_for_variable_selection(job, input_path, variables, db_session_factory)`** — the scan-store pause/resume sequence (publish scan result, await `scan_event`, re-read the store under lock, dispatch to the in-file temporal pipeline when a temporal range was selected). Replaces the two duplicated blocks in `run_pipeline`'s multi-variable and single-variable-with-time-dim branches.

Behavior is identical, including all of #520's changes (storage calls via `asyncio.to_thread`, tipg readiness bool + failed `ValidationCheck`, cleanup-on-failure paths). The single-file `run_pipeline` raster/vector flow and the remote zero-copy `Dataset` were left alone — their field sets and ordering aren't shared with the blocks above.

Net: -19 lines, three call-site-duplicated blocks reduced to one definition each.

## Verification

- `cd ingestion && uv run pytest`: 769 passed, 9 skipped. The 2 `test_integration.py` failures are pre-existing on the base branch (they require live R2 credentials; confirmed by stashing the refactor and re-running).
- `ruff check src/` and `ruff format --check src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)