### PR TITLE
feat(frontend): indicate data extent when tiles aren't visible at current zoom

### DIFF
--- a/frontend/src/components/ZoomPromptBanner.tsx
+++ b/frontend/src/components/ZoomPromptBanner.tsx
@@ -1,0 +1,63 @@
+import { Button, Flex, IconButton, Text } from "@chakra-ui/react";
+import { MagnifyingGlassPlus, X } from "@phosphor-icons/react";
+
+export interface ZoomPromptBannerProps {
+  minZoom: number;
+  onZoomToData: () => void;
+  onDismiss: () => void;
+}
+
+/**
+ * Dismissible overlay shown when the camera is below the layer's min zoom,
+ * prompting the user to zoom in far enough for tiles to load.
+ */
+export function ZoomPromptBanner({
+  minZoom,
+  onZoomToData,
+  onDismiss,
+}: ZoomPromptBannerProps) {
+  return (
+    <Flex
+      position="absolute"
+      top={3}
+      left="50%"
+      transform="translateX(-50%)"
+      zIndex={10}
+      bg="white"
+      borderWidth="1px"
+      borderColor="brand.border"
+      borderRadius="8px"
+      shadow="md"
+      px={3}
+      py={2}
+      align="center"
+      gap={2}
+      role="status"
+    >
+      <MagnifyingGlassPlus size={16} color="#CF3F02" weight="bold" />
+      <Text fontSize="sm" color="brand.brown" whiteSpace="nowrap">
+        Zoom in to level {minZoom} to see data
+      </Text>
+      <Button
+        size="xs"
+        bg="brand.orange"
+        color="white"
+        _hover={{ bg: "brand.orangeHover" }}
+        onClick={onZoomToData}
+      >
+        Zoom to data
+      </Button>
+      <IconButton
+        aria-label="Dismiss zoom prompt"
+        title="Dismiss"
+        size="xs"
+        variant="ghost"
+        color="brand.brown"
+        _hover={{ bg: "brand.bgSubtle" }}
+        onClick={onDismiss}
+      >
+        <X size={14} />
+      </IconButton>
+    </Flex>
+  );
+}

--- a/frontend/src/lib/layers/__tests__/dataExtent.test.ts
+++ b/frontend/src/lib/layers/__tests__/dataExtent.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldShowZoomPrompt,
+  boundsCenter,
+  buildExtentOutlineLayer,
+} from "../dataExtent";
+
+describe("shouldShowZoomPrompt", () => {
+  it("returns true when current zoom is below min zoom", () => {
+    expect(shouldShowZoomPrompt(8, 12)).toBe(true);
+  });
+
+  it("returns false when current zoom reaches min zoom", () => {
+    expect(shouldShowZoomPrompt(12, 12)).toBe(false);
+  });
+
+  it("returns false when current zoom is above min zoom", () => {
+    expect(shouldShowZoomPrompt(14, 12)).toBe(false);
+  });
+
+  it("returns false when min zoom is missing", () => {
+    expect(shouldShowZoomPrompt(2, null)).toBe(false);
+    expect(shouldShowZoomPrompt(2, undefined)).toBe(false);
+  });
+
+  it("returns false when min zoom is zero or negative", () => {
+    expect(shouldShowZoomPrompt(2, 0)).toBe(false);
+    expect(shouldShowZoomPrompt(2, -1)).toBe(false);
+  });
+
+  it("returns false when min zoom is not finite", () => {
+    expect(shouldShowZoomPrompt(2, NaN)).toBe(false);
+    expect(shouldShowZoomPrompt(2, Infinity)).toBe(false);
+  });
+
+  it("handles fractional zooms", () => {
+    expect(shouldShowZoomPrompt(11.9, 12)).toBe(true);
+    expect(shouldShowZoomPrompt(12.1, 12)).toBe(false);
+  });
+});
+
+describe("boundsCenter", () => {
+  it("returns the midpoint of the bounding box", () => {
+    expect(boundsCenter([10, 20, 30, 40])).toEqual([20, 30]);
+  });
+
+  it("handles bounds spanning the equator and prime meridian", () => {
+    expect(boundsCenter([-10, -20, 10, 20])).toEqual([0, 0]);
+  });
+});
+
+describe("buildExtentOutlineLayer", () => {
+  it("builds a closed dashed outline of the bounds", () => {
+    const layer = buildExtentOutlineLayer([10, 20, 30, 40]);
+    expect(layer.id).toBe("data-extent-outline");
+    const data = layer.props.data as { path: [number, number][] }[];
+    expect(data).toHaveLength(1);
+    expect(data[0].path).toEqual([
+      [10, 20],
+      [30, 20],
+      [30, 40],
+      [10, 40],
+      [10, 20],
+    ]);
+    expect(data[0].path[0]).toEqual(data[0].path[data[0].path.length - 1]);
+    expect(layer.props.pickable).toBe(false);
+  });
+
+  it("accepts a custom layer id", () => {
+    const layer = buildExtentOutlineLayer([0, 0, 1, 1], "custom-extent");
+    expect(layer.id).toBe("custom-extent");
+  });
+});

--- a/frontend/src/lib/layers/dataExtent.ts
+++ b/frontend/src/lib/layers/dataExtent.ts
@@ -1,0 +1,66 @@
+import { PathLayer } from "@deck.gl/layers";
+import { PathStyleExtension } from "@deck.gl/extensions";
+import { BRAND_COLOR_RGBA } from "../../components/MapShell";
+
+const OUTLINE_COLOR: [number, number, number, number] = [
+  BRAND_COLOR_RGBA[0],
+  BRAND_COLOR_RGBA[1],
+  BRAND_COLOR_RGBA[2],
+  220,
+];
+
+/**
+ * Whether to indicate that data exists but its tiles aren't visible at the
+ * current zoom level. True only when the layer's min zoom is known, positive,
+ * and the camera hasn't zoomed in far enough to load tiles yet.
+ */
+export function shouldShowZoomPrompt(
+  currentZoom: number,
+  minZoom: number | null | undefined
+): boolean {
+  if (minZoom == null || !Number.isFinite(minZoom) || minZoom <= 0) {
+    return false;
+  }
+  return currentZoom < minZoom;
+}
+
+/** Center point of a [west, south, east, north] bounding box. */
+export function boundsCenter(
+  bounds: [number, number, number, number]
+): [number, number] {
+  const [west, south, east, north] = bounds;
+  return [(west + east) / 2, (south + north) / 2];
+}
+
+/**
+ * A dashed rectangle outlining the data extent, shown while the camera is
+ * below the layer's min zoom so users can see where data lives before its
+ * tiles load.
+ */
+export function buildExtentOutlineLayer(
+  bounds: [number, number, number, number],
+  id = "data-extent-outline"
+) {
+  const [west, south, east, north] = bounds;
+  return new PathLayer({
+    id,
+    data: [
+      {
+        path: [
+          [west, south],
+          [east, south],
+          [east, north],
+          [west, north],
+          [west, south],
+        ] as [number, number][],
+      },
+    ],
+    getPath: (d: { path: [number, number][] }) => d.path,
+    getColor: OUTLINE_COLOR,
+    getWidth: 2,
+    widthUnits: "pixels",
+    getDashArray: [6, 4],
+    extensions: [new PathStyleExtension({ dash: true })],
+    pickable: false,
+  });
+}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -28,6 +28,12 @@ import {
   DEFAULT_CAMERA,
   cameraFromBounds,
 } from "../lib/layers";
+import {
+  shouldShowZoomPrompt,
+  boundsCenter,
+  buildExtentOutlineLayer,
+} from "../lib/layers/dataExtent";
+import { ZoomPromptBanner } from "../components/ZoomPromptBanner";
 import { useColorScale, MapLegend } from "../lib/maptool";
 import { TemporalControls } from "../components/TemporalControls";
 import { useTemporalAnimation } from "../hooks/useTemporalAnimation";
@@ -186,6 +192,29 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
       setCamera(cameraFromBounds(item.bounds, size));
     }
   }, [item?.id, boundsKey]);
+
+  // --- Zoom prompt for layers whose tiles only exist at higher zooms ---
+  const [zoomPromptDismissed, setZoomPromptDismissed] = useState(false);
+
+  useEffect(() => {
+    setZoomPromptDismissed(false);
+  }, [item?.id]);
+
+  const zoomPromptActive = shouldShowZoomPrompt(camera.zoom, item?.minZoom);
+  const showZoomBanner = zoomPromptActive && !zoomPromptDismissed;
+
+  const handleZoomToData = useCallback(() => {
+    const minZoom = item?.minZoom;
+    if (minZoom == null) return;
+    const center = item?.bounds ? boundsCenter(item.bounds) : null;
+    setCamera((prev) => ({
+      longitude: center?.[0] ?? prev.longitude,
+      latitude: center?.[1] ?? prev.latitude,
+      zoom: minZoom,
+      bearing: 0,
+      pitch: 0,
+    }));
+  }, [item?.minZoom, item?.bounds]);
 
   // --- Report card ---
   const [reportCardOpen, setReportCardOpen] = useState(false);
@@ -423,6 +452,19 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
     zarrNode: zarrState.node,
   });
 
+  const extentOutlineLayer = useMemo(
+    () =>
+      zoomPromptActive && item?.bounds
+        ? buildExtentOutlineLayer(item.bounds)
+        : null,
+    [zoomPromptActive, item?.bounds]
+  );
+
+  const mapLayers = useMemo(
+    () => (extentOutlineLayer ? [...layers, extentOutlineLayer] : layers),
+    [layers, extentOutlineLayer]
+  );
+
   // --- Color scale for legend ---
   const domain: [number, number] =
     item?.rasterMin != null && item?.rasterMax != null
@@ -604,7 +646,7 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
               mapRef={mapRef}
               camera={camera}
               onCameraChange={setCamera}
-              layers={layers}
+              layers={mapLayers}
               basemap={basemap}
               onBasemapChange={setBasemap}
               onHover={onHover}
@@ -613,6 +655,13 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
               hideBasemapPicker={shared}
               enableSnapshot={shared}
             >
+              {showZoomBanner && item?.minZoom != null && (
+                <ZoomPromptBanner
+                  minZoom={item.minZoom}
+                  onZoomToData={handleZoomToData}
+                  onDismiss={() => setZoomPromptDismissed(true)}
+                />
+              )}
               {shared && !(isServerGeoParquet && needsConversion) && (
                 <Box
                   position="absolute"


### PR DESCRIPTION
## Summary

Implements both indicators from #145 so users aren't left staring at an empty map when a layer's tiles only exist at higher zooms (e.g. PMTiles z12-16):

- **Zoom prompt banner** (`ZoomPromptBanner.tsx`): when the layer's `min_zoom` is known and the camera is below it, a dismissible overlay appears at the top of the map: "Zoom in to level {minZoom} to see data", with a **Zoom to data** button that jumps the camera to `min_zoom` centered on the data bounds. It hides automatically once zoom >= min zoom, and the dismissal resets when the item changes. Uses the Phosphor `MagnifyingGlassPlus`/`X` icons and warm brand tokens.
- **Dashed extent outline** (`buildExtentOutlineLayer` in `lib/layers/dataExtent.ts`): while below min zoom, the data bounds render as a dashed brand-orange rectangle (deck.gl `PathLayer` + `PathStyleExtension`), appended to the existing layer stack in `MapPage` — `useLayerBuilder` is untouched.

Applies to both datasets and connections (the logic reads `MapItem.minZoom`/`MapItem.bounds`, which `useMapData` populates from either source). When `min_zoom` metadata is absent (or 0), there is no behavior change.

The gating logic lives in a pure helper, `shouldShowZoomPrompt(currentZoom, minZoom)`, with unit tests.

Closes #145

## Verification

- `npx vitest run` — 123 files / 845 tests passed (includes new `dataExtent.test.ts`)
- `npx tsc --noEmit` — clean
- `npx prettier --check src/` — clean
- `npx eslint src/ --max-warnings 0` — clean

Note: the dev VM is headless with no GPU, so WebGL rendering wasn't smoke-tested here — please visually verify on a high-min-zoom layer (e.g. the Riyadh Sentinel-2 PMTiles connection) on your machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a zoom prompt banner that appears when viewing datasets only visible at higher zoom levels, guiding users to zoom in to see the data.
  * Included a "Zoom to data" button for quick navigation to the dataset's location at the optimal zoom level.
  * Added visual outline display showing the geographic area where data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->