### PR TITLE
fix(deploy): hard-reset prod checkout to origin/main instead of git pull

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -115,7 +115,7 @@ jobs:
           ssh -o StrictHostKeyChecking=yes \
             -i ~/.ssh/deploy_key \
             "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}" \
-            "cd ${{ secrets.DEPLOY_PATH }} && git checkout main && git pull origin main && IMAGE_TAG='${IMAGE_TAG}' docker compose --profile prod pull && IMAGE_TAG='${IMAGE_TAG}' docker compose --profile prod up -d && IMAGE_TAG='${IMAGE_TAG}' docker compose --profile prod exec -T caddy caddy reload --config /etc/caddy/Caddyfile"
+            "cd ${{ secrets.DEPLOY_PATH }} && git fetch origin main && git checkout main && git reset --hard origin/main && IMAGE_TAG='${IMAGE_TAG}' docker compose --profile prod pull && IMAGE_TAG='${IMAGE_TAG}' docker compose --profile prod up -d && IMAGE_TAG='${IMAGE_TAG}' docker compose --profile prod exec -T caddy caddy reload --config /etc/caddy/Caddyfile"
 
       - name: Verify deploy health
         run: |


### PR DESCRIPTION
## Problem

The `deploy` job in `release-please.yml` ran:

```
git checkout main && git pull origin main
```

on the prod checkout. When that checkout has local uncommitted edits to files the incoming commits also modify (or no `pull.ff`/`pull.rebase` strategy is configured), `git pull` aborts with `fatal: Need to specify how to reconcile divergent branches`. This is exactly what happened on the **v2.7.0** release: release-please tagged the version and the image built + pushed to GHCR fine, but the deploy failed at `git pull` — leaving prod on the previous release until the checkout was cleaned by hand.

## Fix

Replace the pull with a deterministic fetch + hard reset:

```
git fetch origin main && git checkout main && git reset --hard origin/main
```

The prod checkout now always matches the released commit regardless of local working-tree state. Untracked files (e.g. stray archives) are intentionally left in place — no `git clean`.

## Notes

- This makes the prod checkout authoritative = `origin/main`; editing tracked files directly on the prod box is an anti-pattern and those edits will now be discarded on deploy (desired).
- No behavior change on a clean checkout (the previous happy path was already a fast-forward).
- SSH host-key verification (`DEPLOY_KNOWN_HOSTS`) is unchanged and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined deployment workflow Git synchronization logic for remote environment updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->