### PR TITLE
fix(export): accept integer timestep in CngRcRender

### DIFF
--- a/ingestion/src/models/cng_rc.py
+++ b/ingestion/src/models/cng_rc.py
@@ -44,7 +44,7 @@ class CngRcRender(BaseModel):
     rescale: tuple[float, float] | None
     opacity: float
     band: int | None
-    timestep: str | None
+    timestep: int | str | None
     colormap_reversed: bool = False
 
 

--- a/ingestion/tests/test_story_export.py
+++ b/ingestion/tests/test_story_export.py
@@ -211,3 +211,40 @@ def test_export_resolves_dataset_to_cng_url(db_session):
     assert layer.source_url == "https://example.com/original.geojson"
     assert layer.cng_url == "https://r2.cng.devseed.com/data.parquet"
     assert layer.render.opacity == 0.8
+
+
+def test_export_accepts_integer_timestep(db_session):
+    ds = DatasetRow(
+        id="ds-temporal",
+        filename="precip",
+        dataset_type="raster",
+        format_pair="geotiff-to-cog",
+        tile_url="https://example.com/raster/collections/sandbox-ds-temporal/tiles/{z}/{x}/{y}",
+        metadata_json=json.dumps({"title": "Daily Precipitation"}),
+    )
+    db_session.add(ds)
+    db_session.commit()
+
+    row = _make_story(
+        db_session,
+        chapters=[
+            {
+                "id": "c1",
+                "type": "scrollytelling",
+                "title": "Kristin Strikes",
+                "body": "",
+                "map_state": {"center": [-11, 39.5], "zoom": 6},
+                "layer_config": {
+                    "dataset_id": "ds-temporal",
+                    "colormap": "blues",
+                    "opacity": 0.9,
+                    "rescale_min": 0,
+                    "rescale_max": 80,
+                    "timestep": 58,
+                },
+            }
+        ],
+    )
+    config = story_export.build_config(row, db_session)
+    layer = next(iter(config.layers.values()))
+    assert layer.render.timestep == 58


### PR DESCRIPTION
## Problem

Story chapter `layer_config.timestep` is an **int** index (`LayerConfigPayload.timestep: int | None`), but the interactive-export render model `CngRcRender.timestep` was typed `str | None`. So `story_export.build_config` raised a pydantic `ValidationError` (surfacing as **HTTP 500**) for any temporal chapter, breaking `POST /api/stories/{id}/export/interactive` for stories with date-stepped raster layers.

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for CngRcRender
timestep
  Input should be a valid string [type=string_type, input_value=58, input_type=int]
```

## Fix

Widen `CngRcRender.timestep` to `int | str | None`. The archive-runtime already accepts `string | number | null` for `timestep` (`frontend/archive-runtime/src/types.ts`), so this aligns the server model with the existing runtime contract rather than changing behavior downstream.

## Test

Added `test_export_accepts_integer_timestep` (reproduces the 500 pre-fix; passes after). All 75 export-related tests pass (`test_story_export`, `test_cng_rc_schema`, `interactive_export/`, `test_interactive_export_endpoint`).

## Context

Surfaced while reproducing the cheias.pt Winter 2025–26 floods scrollytelling story end-to-end through the CNG MCP tools — the `export_story_interactive` MCP call 500'd on the temporal chapters. (Note: a separate, known limitation remains — scrollytelling chapters require browser-generated snapshot PNGs that the MCP export path cannot supply; that is tracked separately and not addressed here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timestep parameters now accept integer values alongside string values, providing greater flexibility in temporal raster layer configuration.

* **Tests**
  * Added test to verify integer timestep values are properly processed in layer exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->