### PR TITLE
feat(mcp): publish cng-mcp to PyPI + self-hosting guide

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,64 @@
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Publish target"
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v5
+
+      - name: Build sdist and wheel
+        run: cd mcp && uv build
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: mcp/dist/
+
+  publish-testpypi:
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    needs: build
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -22,6 +22,8 @@ jobs:
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v5
+        with:
+          enable-cache: false
 
       - name: Build sdist and wheel
         run: cd mcp && uv build

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ docker compose up -d --build   # start all services
 
 Open [http://localhost:5185](http://localhost:5185) in your browser.
 
+## Self-hosting
+
+Want to run your own instance and drive it from an AI client (Claude Desktop or Claude Code)? See [docs/self-hosting.md](docs/self-hosting.md) for the full clone → run → connect-via-MCP walkthrough.
+
 ## How it works
 
 1. Upload a file (or paste a URL)

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -14,7 +14,20 @@ Releases are managed by [release-please](https://github.com/googleapis/release-p
 
 **Manual deploy:** Use the "Run workflow" button on the release-please workflow in GitHub Actions. This rebuilds and republishes the images, then redeploys without creating a release.
 
-**Version:** Tracked in `frontend/version.txt` (managed by release-please, don't edit manually).
+**Version:** Tracked in `frontend/version.txt` and `mcp/pyproject.toml` (both managed by release-please via `extra-files`, don't edit manually). The `mcp/pyproject.toml` version uses a typed `toml` updater (`jsonpath: $.project.version`) so the published `cng-mcp` package version stays in lockstep with the repo release.
+
+## Publishing the `cng-mcp` package to PyPI
+
+The MCP server (`mcp/`) is published to PyPI as [`cng-mcp`](https://pypi.org/project/cng-mcp/) by `.github/workflows/publish-mcp.yml`, using **PyPI Trusted Publishing (OIDC)** — no API tokens or stored secrets.
+
+- **Triggers:** `release: published` (publishes to PyPI automatically when release-please cuts a release) and `workflow_dispatch` with a `target` input (`testpypi` | `pypi`) for manual/dry runs.
+- **Jobs:** `build` (`uv build` → sdist+wheel artifact) → `publish-testpypi` / `publish-pypi` (download artifact, `pypa/gh-action-pypi-publish` via OIDC). The publish jobs use GitHub environments `testpypi` / `pypi` and `id-token: write`.
+
+**One-time setup (required before the first publish, owner action):** claim the `cng-mcp` project on both [PyPI](https://pypi.org/manage/account/publishing/) and [TestPyPI](https://test.pypi.org/manage/account/publishing/), and register this repo as a Trusted Publisher in each (owner `aboydnw`, repo `cng-sandbox`, workflow `publish-mcp.yml`, environment `pypi` / `testpypi`). Then validate with a TestPyPI dry run before relying on the release path:
+
+```bash
+gh workflow run publish-mcp.yml -f target=testpypi
+```
 
 ## Deploy mechanics (GHCR-based)
 

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -18,12 +18,12 @@ Releases are managed by [release-please](https://github.com/googleapis/release-p
 
 ## Publishing the `cng-mcp` package to PyPI
 
-The MCP server (`mcp/`) is published to PyPI as [`cng-mcp`](https://pypi.org/project/cng-mcp/) by `.github/workflows/publish-mcp.yml`, using **PyPI Trusted Publishing (OIDC)** — no API tokens or stored secrets.
+The MCP server (`mcp/`) is published to PyPI as [`cngstorytelling-mcp`](https://pypi.org/project/cngstorytelling-mcp/) by `.github/workflows/publish-mcp.yml`, using **PyPI Trusted Publishing (OIDC)** — no API tokens or stored secrets. (The installed console command is `cng-mcp`.)
 
 - **Triggers:** `release: published` (publishes to PyPI automatically when release-please cuts a release) and `workflow_dispatch` with a `target` input (`testpypi` | `pypi`) for manual/dry runs.
 - **Jobs:** `build` (`uv build` → sdist+wheel artifact) → `publish-testpypi` / `publish-pypi` (download artifact, `pypa/gh-action-pypi-publish` via OIDC). The publish jobs use GitHub environments `testpypi` / `pypi` and `id-token: write`.
 
-**One-time setup (required before the first publish, owner action):** claim the `cng-mcp` project on both [PyPI](https://pypi.org/manage/account/publishing/) and [TestPyPI](https://test.pypi.org/manage/account/publishing/), and register this repo as a Trusted Publisher in each (owner `aboydnw`, repo `cng-sandbox`, workflow `publish-mcp.yml`, environment `pypi` / `testpypi`). Then validate with a TestPyPI dry run before relying on the release path:
+**One-time setup (required before the first publish, owner action):** claim the `cngstorytelling-mcp` project on both [PyPI](https://pypi.org/manage/account/publishing/) and [TestPyPI](https://test.pypi.org/manage/account/publishing/), and register this repo as a Trusted Publisher in each (owner `aboydnw`, repo `cng-sandbox`, workflow `publish-mcp.yml`, environment `pypi` / `testpypi`). Then validate with a TestPyPI dry run before relying on the release path:
 
 ```bash
 gh workflow run publish-mcp.yml -f target=testpypi

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -39,7 +39,7 @@ The app is at <http://localhost:5185> and the ingestion API at
 ## 3. Install the MCP server
 
 ```bash
-pip install cng-mcp
+pip install cngstorytelling-mcp
 ```
 
 ## 4. Connect your AI client

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,67 @@
+# Self-host CNG Sandbox and connect via MCP
+
+Run your own single-tenant CNG Sandbox and drive it from an AI client (Claude
+Desktop or Claude Code) using the `cng-mcp` server.
+
+> [!WARNING]
+> **A self-hosted instance has no authentication.** Access is scoped only by an
+> `X-Workspace-Id` request header (any 8 alphanumeric characters). Keep your
+> instance on `localhost` or a trusted private network. **Do not expose it to the
+> public internet without putting real authentication in front of it.**
+
+## Prerequisites
+
+- Docker and Docker Compose
+- A Cloudflare R2 bucket and credentials
+- Python 3.11+ (for the `cng-mcp` client)
+
+## 1. Clone and configure
+
+```bash
+git clone https://github.com/aboydnw/cng-sandbox.git
+cd cng-sandbox
+cp .env.example .env   # then edit .env
+```
+
+Set the R2 variables in `.env`: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`,
+`R2_SECRET_ACCESS_KEY`, `R2_ENDPOINT`, `R2_PUBLIC_URL`.
+
+## 2. Start the stack
+
+```bash
+docker compose -f docker-compose.yml up -d --build
+docker compose -f docker-compose.yml ps   # all services healthy
+```
+
+The app is at <http://localhost:5185> and the ingestion API at
+<http://localhost:8086>.
+
+## 3. Install the MCP server
+
+```bash
+pip install cng-mcp
+```
+
+## 4. Connect your AI client
+
+Add to your MCP client config (e.g. Claude Desktop's `claude_desktop_config.json`,
+or via `claude mcp add`):
+
+```json
+{
+  "mcpServers": {
+    "cng-sandbox": {
+      "command": "cng-mcp",
+      "args": ["--api-url", "http://localhost:8086", "--workspace-id", "myws0001"]
+    }
+  }
+}
+```
+
+`--workspace-id` is any 8-character alphanumeric string; use the same value in the
+frontend to see the same data.
+
+## 5. Verify
+
+Ask your AI client to list datasets (the `read_datasets` tool). An empty list (or
+the seeded examples) confirms the connection works.

--- a/mcp/LICENSE
+++ b/mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Anthony Boyd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -9,10 +9,10 @@ MCP is a protocol that lets applications (agents, CLI tools, SDKs) discover and 
 ## Installation
 
 ```bash
-pip install cng-mcp
+pip install cngstorytelling-mcp
 ```
 
-To run against your own instance, see the [self-hosting guide](../docs/self-hosting.md).
+This installs the `cng-mcp` command. To run against your own instance, see the [self-hosting guide](../docs/self-hosting.md).
 
 ## Quick Start
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -12,6 +12,8 @@ MCP is a protocol that lets applications (agents, CLI tools, SDKs) discover and 
 pip install cng-mcp
 ```
 
+To run against your own instance, see the [self-hosting guide](../docs/self-hosting.md).
+
 ## Quick Start
 
 ### 1. Start the Server

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -8,6 +8,8 @@ version = "0.1.0"
 description = "MCP Server for CNG Sandbox: agent-driven story creation and data exploration"
 readme = "README.md"
 requires-python = ">=3.11"
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{name = "Development Seed"}]
 keywords = ["mcp", "geospatial", "agent", "api"]
 classifiers = [
@@ -22,6 +24,11 @@ dependencies = [
     "httpx>=0.28.1",
     "pydantic>=2.13.4",
 ]
+
+[project.urls]
+Homepage = "https://github.com/aboydnw/cng-sandbox"
+Repository = "https://github.com/aboydnw/cng-sandbox"
+Issues = "https://github.com/aboydnw/cng-sandbox/issues"
 
 [project.optional-dependencies]
 dev = [

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "cng-mcp"
+name = "cngstorytelling-mcp"
 version = "0.1.0"
 description = "MCP Server for CNG Sandbox: agent-driven story creation and data exploration"
 readme = "README.md"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,10 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "extra-files": ["frontend/version.txt"]
+      "extra-files": [
+        "frontend/version.txt",
+        { "type": "toml", "path": "mcp/pyproject.toml", "jsonpath": "$.project.version" }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Lets others run their own single-tenant CNG Sandbox and drive it from an AI client via the MCP server. The MCP tools already work against a self-hosted instance (they're a thin client over the ingestion API) — this PR makes the package installable and documents the path.

**Package name:** the PyPI distribution is **`cngstorytelling-mcp`** (`pip install cngstorytelling-mcp`); the installed console command and import module stay `cng-mcp` / `cng_mcp`.

## What's in here

1. **Package readiness** (`mcp/pyproject.toml`, `mcp/LICENSE`) — distribution name `cngstorytelling-mcp`, `license = "MIT"` + `license-files`, `[project.urls]`, license bundled into the wheel. Verified: `uv build` produces a wheel that installs into a clean venv, `cng-mcp --help` runs, and `LICENSE` ships in `dist-info/licenses/`.
2. **Version lockstep** (`release-please-config.json`) — a typed `toml` `extra-files` updater bumps `mcp/pyproject.toml`'s `project.version` to the repo version on each release.
3. **Publish workflow** (`.github/workflows/publish-mcp.yml`) — builds sdist+wheel and publishes to PyPI via **Trusted Publishing (OIDC)** on release; `workflow_dispatch` with a `target` input allows a TestPyPI dry run. All actions SHA-pinned, minimal `permissions`, `persist-credentials: false`, and `setup-uv` cache disabled (zizmor cache-poisoning).
4. **Docs** (`docs/self-hosting.md`, `docs/cicd.md`, README links) — clone → `.env` (R2) → `docker compose up` → `pip install cngstorytelling-mcp` → connect → verify, with a prominent **"no authentication — keep on localhost/trusted network"** warning; cicd.md documents the publish workflow + trusted-publishing setup.

## Owner action required before publishing (not code)

Claim **`cngstorytelling-mcp`** on **PyPI and TestPyPI** and register this repo + `publish-mcp.yml` as a **Trusted Publisher** in each project (environments `pypi` / `testpypi`). Then run a TestPyPI dry run (`gh workflow run publish-mcp.yml -f target=testpypi`) before the first real release. Until that's configured, the publish jobs are inert.

## Out of scope

Agent-driven setup/bootstrap (filed as an idea), multi-tenant auth, remote MCP transport.

## Test

`cd mcp && uv run pytest` → 71 passed. zizmor `--min-severity medium` → no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)