### PR TITLE
feat: aerial true-color RGB imagery support + Lahaina example story

### DIFF
--- a/frontend/src/lib/maptool/MapLegend/MapLegend.tsx
+++ b/frontend/src/lib/maptool/MapLegend/MapLegend.tsx
@@ -3,6 +3,7 @@ import { Box } from "@chakra-ui/react";
 import { CategoricalLegend } from "./CategoricalLegend";
 import { ContinuousRamp } from "./ContinuousRamp";
 import { LegendItem } from "./LegendItem";
+import { RgbLegend } from "./RgbLegend";
 import type { MapLegendProps } from "./types";
 
 const POSITION_STYLES: Record<
@@ -95,6 +96,8 @@ export function MapLegend({
             >
               {layer.type === "continuous" ? (
                 <ContinuousRamp config={layer} orientation={orientation} />
+              ) : layer.type === "rgb" ? (
+                <RgbLegend config={layer} />
               ) : (
                 <CategoricalLegend config={layer} />
               )}

--- a/frontend/src/lib/maptool/MapLegend/RgbLegend.tsx
+++ b/frontend/src/lib/maptool/MapLegend/RgbLegend.tsx
@@ -1,0 +1,18 @@
+import { Box, HStack, Text } from "@chakra-ui/react";
+import type { RgbLegendConfig } from "./types";
+
+export function RgbLegend(_props: { config: RgbLegendConfig }) {
+  return (
+    <HStack gap={2} align="center">
+      <Box
+        width="44px"
+        height="12px"
+        borderRadius="2px"
+        backgroundImage="linear-gradient(90deg, #c0392b, #27ae60, #2980b9)"
+      />
+      <Text fontSize="11px" color="gray.600" _dark={{ color: "gray.400" }}>
+        True color (RGB)
+      </Text>
+    </HStack>
+  );
+}

--- a/frontend/src/lib/maptool/MapLegend/types.ts
+++ b/frontend/src/lib/maptool/MapLegend/types.ts
@@ -37,9 +37,18 @@ export interface CategoricalLegendConfig {
   visible?: boolean;
 }
 
+export interface RgbLegendConfig {
+  type: "rgb";
+  id: string;
+  title: string;
+  toggler?: boolean;
+  visible?: boolean;
+}
+
 export type LegendLayerConfig =
   | ContinuousLegendConfig
-  | CategoricalLegendConfig;
+  | CategoricalLegendConfig
+  | RgbLegendConfig;
 export type LegendOrientation = "vertical" | "horizontal";
 export type LegendPosition =
   | "top-left"

--- a/frontend/src/lib/story/rasterLegend.ts
+++ b/frontend/src/lib/story/rasterLegend.ts
@@ -1,0 +1,21 @@
+import type { LegendLayerConfig } from "../maptool/MapLegend/types";
+
+export function buildRasterLegend(args: {
+  bandCount: number | null;
+  title: string;
+  domain: [number, number];
+  colors: string[];
+  isCategorical: boolean;
+}): LegendLayerConfig | null {
+  if (args.isCategorical) return null;
+  if (args.bandCount === 3) {
+    return { type: "rgb", id: "raster", title: args.title };
+  }
+  return {
+    type: "continuous",
+    id: "raster",
+    title: args.title,
+    domain: args.domain,
+    colors: args.colors,
+  };
+}

--- a/frontend/src/lib/story/rendering.ts
+++ b/frontend/src/lib/story/rendering.ts
@@ -11,6 +11,7 @@ import { datasetToMapItem, connectionToMapItem } from "../../hooks/useMapData";
 import { DEFAULT_LAYER_CONFIG, isMapBoundChapter } from "./types";
 import type {
   Chapter,
+  LayerConfig,
   ScrollytellingChapter,
   MapChapter,
   ProseChapter,
@@ -38,6 +39,34 @@ function makePcaRgbFillColor(
     }
     return [128, 128, 128, 200];
   };
+}
+
+export function buildDatasetServerTileUrl(
+  ds: Dataset,
+  lc: LayerConfig,
+  rescaleMin: number | null,
+  rescaleMax: number | null
+): string {
+  const base = ds.tile_url;
+  const sep = base.includes("?") ? "&" : "?";
+  let serverTileUrl = base;
+  if (ds.band_count === 1) {
+    const effColormap = lc.colormap_reversed ? `${lc.colormap}_r` : lc.colormap;
+    const effMin = rescaleMin ?? ds.raster_min;
+    const effMax = rescaleMax ?? ds.raster_max;
+    serverTileUrl = `${base}${sep}colormap_name=${effColormap}`;
+    if (effMin != null && effMax != null) {
+      serverTileUrl += `&rescale=${effMin},${effMax}`;
+    }
+  }
+  if (ds.is_temporal && ds.timesteps.length > 0) {
+    const raw = Number.isInteger(lc.timestep) ? lc.timestep! : 0;
+    const tsIndex = Math.max(0, Math.min(raw, ds.timesteps.length - 1));
+    const ts = ds.timesteps[tsIndex];
+    const tsep = serverTileUrl.includes("?") ? "&" : "?";
+    serverTileUrl = `${serverTileUrl}${tsep}datetime=${encodeURIComponent(ts.datetime)}`;
+  }
+  return serverTileUrl;
 }
 
 export type ContentBlock =
@@ -293,21 +322,7 @@ export function buildLayersForChapter(
     const rescaleMin = lc.rescale_min ?? null;
     const rescaleMax = lc.rescale_max ?? null;
 
-    const base = ds.tile_url;
-    const sep = base.includes("?") ? "&" : "?";
-    const effColormap = lc.colormap_reversed ? `${lc.colormap}_r` : lc.colormap;
-    const effMin = rescaleMin ?? ds.raster_min;
-    const effMax = rescaleMax ?? ds.raster_max;
-    let serverTileUrl = `${base}${sep}colormap_name=${effColormap}`;
-    if (effMin != null && effMax != null) {
-      serverTileUrl += `&rescale=${effMin},${effMax}`;
-    }
-    if (ds.is_temporal && ds.timesteps.length > 0) {
-      const raw = Number.isInteger(lc.timestep) ? lc.timestep! : 0;
-      const tsIndex = Math.max(0, Math.min(raw, ds.timesteps.length - 1));
-      const ts = ds.timesteps[tsIndex];
-      serverTileUrl = `${serverTileUrl}&datetime=${encodeURIComponent(ts.datetime)}`;
-    }
+    const serverTileUrl = buildDatasetServerTileUrl(ds, lc, rescaleMin, rescaleMax);
 
     const resolved = resolveRasterLayers({
       item,

--- a/frontend/src/lib/story/rendering.ts
+++ b/frontend/src/lib/story/rendering.ts
@@ -322,7 +322,12 @@ export function buildLayersForChapter(
     const rescaleMin = lc.rescale_min ?? null;
     const rescaleMax = lc.rescale_max ?? null;
 
-    const serverTileUrl = buildDatasetServerTileUrl(ds, lc, rescaleMin, rescaleMax);
+    const serverTileUrl = buildDatasetServerTileUrl(
+      ds,
+      lc,
+      rescaleMin,
+      rescaleMax
+    );
 
     const resolved = resolveRasterLayers({
       item,

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -35,6 +35,7 @@ import {
 } from "../lib/layers/dataExtent";
 import { ZoomPromptBanner } from "../components/ZoomPromptBanner";
 import { useColorScale, MapLegend } from "../lib/maptool";
+import { buildRasterLegend } from "../lib/story/rasterLegend";
 import { TemporalControls } from "../components/TemporalControls";
 import { useTemporalAnimation } from "../hooks/useTemporalAnimation";
 import { useZarrNode } from "../hooks/useZarrNode";
@@ -495,6 +496,14 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
     colormap: controls.colormapName,
   });
 
+  const rasterLegend = buildRasterLegend({
+    bandCount: item?.bandCount ?? null,
+    title: item?.dataset ? displayName(item.dataset) : "",
+    domain,
+    colors,
+    isCategorical: controls.isCategorical,
+  });
+
   // --- Event handlers ---
   const onHover =
     controls.renderMode === "client" && controls.canClientRender
@@ -767,25 +776,16 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
                   </Box>
                 )}
               {!controls.isCategorical &&
-                controls.showingColormap &&
-                controls.renderMode !== "client" && (
+                controls.renderMode !== "client" &&
+                rasterLegend &&
+                (rasterLegend.type === "rgb" || controls.showingColormap) && (
                   <Box
                     position="absolute"
                     bottom={3}
                     left={3}
                     data-snapshot-overlay
                   >
-                    <MapLegend
-                      layers={[
-                        {
-                          type: "continuous" as const,
-                          id: "raster",
-                          title: item?.dataset ? displayName(item.dataset) : "",
-                          domain,
-                          colors,
-                        },
-                      ]}
-                    />
+                    <MapLegend layers={[rasterLegend]} />
                   </Box>
                 )}
 

--- a/frontend/tests/datasetTileUrl.test.ts
+++ b/frontend/tests/datasetTileUrl.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { buildDatasetServerTileUrl } from "../src/lib/story/rendering";
+import type { Dataset } from "../src/types";
+import type { LayerConfig } from "../src/lib/story/types";
+
+function makeDataset(overrides: Partial<Dataset>): Dataset {
+  return {
+    tile_url:
+      "/raster/collections/sandbox-x/tiles/WebMercatorQuad/{z}/{x}/{y}?assets=data",
+    band_count: 1,
+    raster_min: 0,
+    raster_max: 100,
+    is_temporal: false,
+    timesteps: [],
+    ...(overrides as Dataset),
+  } as Dataset;
+}
+
+const lc: LayerConfig = {
+  dataset_id: "x",
+  colormap: "viridis",
+  opacity: 1,
+  basemap: "streets",
+};
+
+describe("buildDatasetServerTileUrl", () => {
+  it("applies colormap for single-band data", () => {
+    const url = buildDatasetServerTileUrl(
+      makeDataset({ band_count: 1 }),
+      lc,
+      null,
+      null
+    );
+    expect(url).toContain("colormap_name=viridis");
+    expect(url).toContain("rescale=0,100");
+  });
+
+  it("omits colormap and rescale for 3-band RGB data", () => {
+    const url = buildDatasetServerTileUrl(
+      makeDataset({ band_count: 3 }),
+      lc,
+      null,
+      null
+    );
+    expect(url).not.toContain("colormap_name");
+    expect(url).not.toContain("rescale");
+  });
+});

--- a/frontend/tests/datasetTileUrl.test.ts
+++ b/frontend/tests/datasetTileUrl.test.ts
@@ -4,7 +4,7 @@ import type { Dataset } from "../src/types";
 import type { LayerConfig } from "../src/lib/story/types";
 
 function makeDataset(overrides: Partial<Dataset>): Dataset {
-  return {
+  const base = {
     tile_url:
       "/raster/collections/sandbox-x/tiles/WebMercatorQuad/{z}/{x}/{y}?assets=data",
     band_count: 1,
@@ -12,8 +12,8 @@ function makeDataset(overrides: Partial<Dataset>): Dataset {
     raster_max: 100,
     is_temporal: false,
     timesteps: [],
-    ...(overrides as Dataset),
-  } as Dataset;
+  };
+  return { ...base, ...overrides } as Dataset;
 }
 
 const lc: LayerConfig = {

--- a/frontend/tests/rasterLegend.test.ts
+++ b/frontend/tests/rasterLegend.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildRasterLegend } from "../src/lib/story/rasterLegend";
+
+describe("buildRasterLegend", () => {
+  it("returns an rgb legend for 3-band data", () => {
+    const legend = buildRasterLegend({
+      bandCount: 3,
+      title: "Lahaina",
+      domain: [0, 1],
+      colors: ["#000", "#fff"],
+      isCategorical: false,
+    });
+    expect(legend).toEqual({ type: "rgb", id: "raster", title: "Lahaina" });
+  });
+
+  it("returns a continuous legend for single-band data", () => {
+    const legend = buildRasterLegend({
+      bandCount: 1,
+      title: "Bathymetry",
+      domain: [0, 100],
+      colors: ["#000", "#fff"],
+      isCategorical: false,
+    });
+    expect(legend?.type).toBe("continuous");
+  });
+
+  it("returns null for categorical data", () => {
+    const legend = buildRasterLegend({
+      bandCount: 1,
+      title: "Land cover",
+      domain: [0, 1],
+      colors: ["#000"],
+      isCategorical: true,
+    });
+    expect(legend).toBeNull();
+  });
+});

--- a/ingestion/src/services/enumerators/maxar.py
+++ b/ingestion/src/services/enumerators/maxar.py
@@ -1,0 +1,80 @@
+"""maxar_event enumerator: walk a Maxar Open Data event STAC collection.
+
+Maxar publishes per-event STAC catalogs whose items carry a ``visual`` asset
+(a 3-band RGB COG). This enumerator follows ``child``/``item`` links from an
+event collection, selects the ``visual`` asset of each item, and returns
+RemoteItems. Asset hrefs are resolved against the item URL since Maxar items
+use relative hrefs. Optional ``min_date``/``max_date`` bounds isolate
+pre-/post-event acquisition windows.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from urllib.parse import urljoin
+
+import httpx
+
+from src.services.enumerators import RemoteItem
+from src.services.enumerators.stac_sidecars import pick_rgb_asset
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+async def _walk(
+    client: httpx.AsyncClient, url: str, items: list[tuple[str, dict]]
+) -> None:
+    resp = await client.get(url)
+    resp.raise_for_status()
+    node = resp.json()
+    if node.get("type") == "Feature":
+        items.append((url, node))
+        return
+    for link in node.get("links", []):
+        rel = link.get("rel")
+        href = link.get("href")
+        if rel in ("item", "child") and href:
+            await _walk(client, urljoin(url, href), items)
+
+
+async def enumerate_maxar_event(
+    collection_url: str,
+    *,
+    max_items: int | None = None,
+    min_date: str | None = None,
+    max_date: str | None = None,
+) -> list[RemoteItem]:
+    """Walk a Maxar event STAC collection and return RemoteItems for the
+    ``visual`` (RGB) asset of each item, optionally filtered to items whose
+    ``datetime`` falls within [min_date, max_date] (inclusive ISO-8601 bounds).
+    """
+    lo = _parse_dt(min_date)
+    hi = _parse_dt(max_date)
+    fetch_url = collection_url.split("#", 1)[0]
+
+    raw_items: list[tuple[str, dict]] = []
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        await _walk(client, fetch_url, raw_items)
+
+    remote: list[RemoteItem] = []
+    for item_url, item in raw_items:
+        asset = pick_rgb_asset(item)
+        if asset is None:
+            continue
+        dt = _parse_dt(item.get("properties", {}).get("datetime"))
+        if lo is not None and (dt is None or dt < lo):
+            continue
+        if hi is not None and (dt is None or dt > hi):
+            continue
+        href = urljoin(item_url, asset["href"])
+        remote.append(RemoteItem(href=href, datetime=dt, bbox=item.get("bbox")))
+        if max_items is not None and len(remote) >= max_items:
+            break
+    return remote

--- a/ingestion/src/services/enumerators/maxar.py
+++ b/ingestion/src/services/enumerators/maxar.py
@@ -10,7 +10,7 @@ pre-/post-event acquisition windows.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from urllib.parse import urljoin
 
 import httpx
@@ -19,18 +19,45 @@ from src.services.enumerators import RemoteItem
 from src.services.enumerators.stac_sidecars import pick_rgb_asset
 
 
-def _parse_dt(value: str | None) -> datetime | None:
+def _parse_item_dt(value: str | None) -> datetime | None:
+    """Parse a STAC item datetime, normalized to UTC; None if absent/malformed."""
     if not value:
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _parse_bound_dt(value: str | None) -> datetime | None:
+    """Parse a filter bound to a UTC datetime; raise on malformed/naive input.
+
+    Bounds must be explicit so a typo silently disabling the filter (and
+    registering the wrong scenes) can't happen.
+    """
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"Invalid ISO-8601 date bound: {value!r}") from exc
+    if dt.tzinfo is None:
+        raise ValueError(f"Date bound must include a timezone: {value!r}")
+    return dt.astimezone(UTC)
 
 
 async def _walk(
-    client: httpx.AsyncClient, url: str, items: list[tuple[str, dict]]
+    client: httpx.AsyncClient,
+    url: str,
+    items: list[tuple[str, dict]],
+    *,
+    limit: int | None = None,
 ) -> None:
+    if limit is not None and len(items) >= limit:
+        return
     resp = await client.get(url)
     resp.raise_for_status()
     node = resp.json()
@@ -38,10 +65,12 @@ async def _walk(
         items.append((url, node))
         return
     for link in node.get("links", []):
+        if limit is not None and len(items) >= limit:
+            return
         rel = link.get("rel")
         href = link.get("href")
         if rel in ("item", "child") and href:
-            await _walk(client, urljoin(url, href), items)
+            await _walk(client, urljoin(url, href), items, limit=limit)
 
 
 async def enumerate_maxar_event(
@@ -55,20 +84,24 @@ async def enumerate_maxar_event(
     ``visual`` (RGB) asset of each item, optionally filtered to items whose
     ``datetime`` falls within [min_date, max_date] (inclusive ISO-8601 bounds).
     """
-    lo = _parse_dt(min_date)
-    hi = _parse_dt(max_date)
+    lo = _parse_bound_dt(min_date)
+    hi = _parse_bound_dt(max_date)
     fetch_url = collection_url.split("#", 1)[0]
+
+    # When no date filter is set, max_items can bound the crawl itself; with a
+    # filter we must visit every item to decide which fall in range.
+    walk_limit = max_items if lo is None and hi is None else None
 
     raw_items: list[tuple[str, dict]] = []
     async with httpx.AsyncClient(timeout=30.0) as client:
-        await _walk(client, fetch_url, raw_items)
+        await _walk(client, fetch_url, raw_items, limit=walk_limit)
 
     remote: list[RemoteItem] = []
     for item_url, item in raw_items:
         asset = pick_rgb_asset(item)
         if asset is None:
             continue
-        dt = _parse_dt(item.get("properties", {}).get("datetime"))
+        dt = _parse_item_dt(item.get("properties", {}).get("datetime"))
         if lo is not None and (dt is None or dt < lo):
             continue
         if hi is not None and (dt is None or dt > hi):

--- a/ingestion/src/services/enumerators/stac_sidecars.py
+++ b/ingestion/src/services/enumerators/stac_sidecars.py
@@ -68,6 +68,27 @@ def _pick_data_asset(sidecar: dict) -> dict | None:
     return None
 
 
+def pick_rgb_asset(stac_item: dict) -> dict | None:
+    """Return the true-color RGB asset dict, or None.
+
+    Prefers an asset whose ``roles`` contains ``"visual"``, then an asset
+    keyed ``"visual"``, then falls back to the primary data asset.
+    """
+    assets = stac_item.get("assets")
+    if not isinstance(assets, dict):
+        return None
+    for asset in assets.values():
+        if not isinstance(asset, dict):
+            continue
+        roles = asset.get("roles") or []
+        if isinstance(roles, list) and "visual" in roles and asset.get("href"):
+            return asset
+    visual = assets.get("visual")
+    if isinstance(visual, dict) and visual.get("href"):
+        return visual
+    return _pick_data_asset(stac_item)
+
+
 def _parse_datetime(value: str | None) -> datetime | None:
     if not value:
         return None

--- a/ingestion/src/services/enumerators/stac_sidecars.py
+++ b/ingestion/src/services/enumerators/stac_sidecars.py
@@ -81,10 +81,20 @@ def pick_rgb_asset(stac_item: dict) -> dict | None:
         if not isinstance(asset, dict):
             continue
         roles = asset.get("roles") or []
-        if isinstance(roles, list) and "visual" in roles and asset.get("href"):
+        href = asset.get("href")
+        if (
+            isinstance(roles, list)
+            and "visual" in roles
+            and isinstance(href, str)
+            and href
+        ):
             return asset
     visual = assets.get("visual")
-    if isinstance(visual, dict) and visual.get("href"):
+    if (
+        isinstance(visual, dict)
+        and isinstance(visual.get("href"), str)
+        and visual.get("href")
+    ):
         return visual
     return _pick_data_asset(stac_item)
 

--- a/ingestion/src/services/example_datasets.py
+++ b/ingestion/src/services/example_datasets.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import sessionmaker
 from src.models import Job
 from src.models.dataset import DatasetRow
 from src.services.enumerators import RemoteItem
+from src.services.enumerators.maxar import enumerate_maxar_event
 from src.services.enumerators.path_listing import enumerate_path_listing
 from src.services.enumerators.stac_sidecars import enumerate_stac_sidecars
 from src.services.pmtiles_register import (
@@ -66,6 +67,13 @@ async def run_enumerator(product: SourceCoopProduct) -> list[RemoteItem]:
             listing_url=product.listing_url,
             recursive=product.enumerator_args.get("recursive", False),
             start_prefix=product.enumerator_args.get("start_prefix", ""),
+        )
+    if product.enumerator == "maxar_event":
+        return await enumerate_maxar_event(
+            product.listing_url,
+            max_items=product.enumerator_args.get("max_items"),
+            min_date=product.enumerator_args.get("min_date"),
+            max_date=product.enumerator_args.get("max_date"),
         )
     raise ValueError(f"Unknown enumerator: {product.enumerator}")
 

--- a/ingestion/src/services/example_stories.py
+++ b/ingestion/src/services/example_stories.py
@@ -31,9 +31,7 @@ GEBCO_URL = "https://data.source.coop/alexgleith/gebco-2024/"
 GHRSST_URL = "https://data.source.coop/ausantarctic/ghrsst-mur-v2/"
 CARBON_URL = "https://data.source.coop/vizzuality/lg-land-carbon-data/"
 BUILDINGS_URL = "https://data.source.coop/vida/google-microsoft-osm-open-buildings/"
-LAHAINA_URL = (
-    "https://maxar-opendata.s3.amazonaws.com/events/Maui-Hawaii-fires-Aug-23/collection.json"
-)
+LAHAINA_URL = "https://maxar-opendata.s3.amazonaws.com/events/Maui-Hawaii-fires-Aug-23/collection.json"
 
 
 @dataclass(frozen=True)

--- a/ingestion/src/services/example_stories.py
+++ b/ingestion/src/services/example_stories.py
@@ -31,11 +31,9 @@ GEBCO_URL = "https://data.source.coop/alexgleith/gebco-2024/"
 GHRSST_URL = "https://data.source.coop/ausantarctic/ghrsst-mur-v2/"
 CARBON_URL = "https://data.source.coop/vizzuality/lg-land-carbon-data/"
 BUILDINGS_URL = "https://data.source.coop/vida/google-microsoft-osm-open-buildings/"
-MAXAR_LAHAINA_COLLECTION = (
+LAHAINA_URL = (
     "https://maxar-opendata.s3.amazonaws.com/events/Maui-Hawaii-fires-Aug-23/collection.json"
 )
-LAHAINA_PRE_URL = f"{MAXAR_LAHAINA_COLLECTION}#pre"
-LAHAINA_POST_URL = f"{MAXAR_LAHAINA_COLLECTION}#post"
 
 
 @dataclass(frozen=True)
@@ -472,12 +470,11 @@ OCEAN_FOREST_STORY = StorySeed(
 
 
 LAHAINA_STORY = StorySeed(
-    title="Lahaina: before and after the 2023 wildfire",
+    title="Anatomy of the Lahaina burn scar",
     description=(
-        "A side-by-side look at Lahaina, Maui, in high-resolution aerial "
-        "imagery from before and after the August 2023 wildfire — one of the "
-        "deadliest in modern U.S. history. Imagery © Maxar/Vantor Open Data "
-        "(CC-BY-NC 4.0)."
+        "High-resolution true-color satellite imagery of Lahaina, Maui, in the "
+        "days after the August 2023 wildfire — one of the deadliest in modern "
+        "U.S. history. Imagery © Maxar/Vantor Open Data (CC-BY-NC 4.0)."
     ),
     chapters=[
         ChapterSeed(
@@ -485,22 +482,23 @@ LAHAINA_STORY = StorySeed(
             title="A town on the water",
             narrative=(
                 "On **August 8, 2023**, a wind-driven wildfire swept through "
-                "Lahaina on the west coast of Maui. This story uses "
-                "high-resolution **true-color satellite imagery** from the "
-                "Maxar/Vantor Open Data Program to show the same streets "
-                "before and after.\n\n"
-                "Scroll to fly into town, then compare the two maps."
+                "Lahaina on the west coast of Maui. Within days, satellites "
+                "captured the aftermath in **high-resolution true-color "
+                "imagery** through the Maxar/Vantor Open Data Program.\n\n"
+                "Scroll to fly across the burn scar, then open the map at the "
+                "end to explore it yourself."
             ),
         ),
         ChapterSeed(
             type="scrollytelling",
-            title="Before the fire",
+            title="The burn scar from above",
             narrative=(
-                "Lahaina's historic waterfront and dense residential blocks, "
-                "imaged before August 2023. Note Front Street along the coast "
-                "and the tightly packed neighborhoods inland."
+                "A wide view of Lahaina after the fire. Entire blocks are "
+                "reduced to ash while the surrounding vegetation and coastline "
+                "remain — the sharp boundary of the burn scar is visible from "
+                "orbit."
             ),
-            dataset_source_url=LAHAINA_PRE_URL,
+            dataset_source_url=LAHAINA_URL,
             center=(-156.68, 20.88),
             zoom=14.5,
             basemap="streets",
@@ -510,31 +508,31 @@ LAHAINA_STORY = StorySeed(
         ),
         ChapterSeed(
             type="scrollytelling",
-            title="After the fire",
-            narrative=(
-                "The same footprint after the fire. Entire blocks are reduced "
-                "to ash while the surrounding vegetation and coastline remain — "
-                "the sharp boundary of the burn scar is visible from orbit."
-            ),
-            dataset_source_url=LAHAINA_POST_URL,
-            center=(-156.68, 20.88),
-            zoom=14.5,
-            basemap="streets",
-            opacity=1.0,
-            transition="instant",
-            overlay_position="right",
-        ),
-        ChapterSeed(
-            type="scrollytelling",
             title="The waterfront, block by block",
             narrative=(
                 "Zooming in on Front Street and the harbor. At this scale the "
                 "imagery resolves individual lots — you can trace which "
                 "structures stood and which were lost along the shoreline."
             ),
-            dataset_source_url=LAHAINA_POST_URL,
+            dataset_source_url=LAHAINA_URL,
             center=(-156.6792, 20.8722),
             zoom=16.0,
+            basemap="streets",
+            opacity=1.0,
+            transition="fly-to",
+            overlay_position="right",
+        ),
+        ChapterSeed(
+            type="scrollytelling",
+            title="Where the fire stopped",
+            narrative=(
+                "At the edges of the scar, the transition is abrupt: charred "
+                "parcels sit directly beside untouched greenery. The imagery "
+                "maps exactly where the fire's advance halted."
+            ),
+            dataset_source_url=LAHAINA_URL,
+            center=(-156.6845, 20.8901),
+            zoom=15.5,
             basemap="streets",
             opacity=1.0,
             transition="fly-to",
@@ -547,7 +545,7 @@ LAHAINA_STORY = StorySeed(
                 "True-color imagery like this is among the first data available "
                 "after a disaster. It guides search-and-rescue, scopes the "
                 "damage for recovery funding, and creates a permanent record of "
-                "what was there before.\n\n"
+                "the event.\n\n"
                 "Imagery © Maxar/Vantor Open Data, released under CC-BY-NC 4.0."
             ),
         ),
@@ -559,7 +557,7 @@ LAHAINA_STORY = StorySeed(
                 "between burned and unburned parcels maps the fire's path "
                 "block by block."
             ),
-            dataset_source_url=LAHAINA_POST_URL,
+            dataset_source_url=LAHAINA_URL,
             center=(-156.68, 20.88),
             zoom=14.0,
             basemap="streets",

--- a/ingestion/src/services/example_stories.py
+++ b/ingestion/src/services/example_stories.py
@@ -31,6 +31,11 @@ GEBCO_URL = "https://data.source.coop/alexgleith/gebco-2024/"
 GHRSST_URL = "https://data.source.coop/ausantarctic/ghrsst-mur-v2/"
 CARBON_URL = "https://data.source.coop/vizzuality/lg-land-carbon-data/"
 BUILDINGS_URL = "https://data.source.coop/vida/google-microsoft-osm-open-buildings/"
+MAXAR_LAHAINA_COLLECTION = (
+    "https://maxar-opendata.s3.amazonaws.com/events/Maui-Hawaii-fires-Aug-23/collection.json"
+)
+LAHAINA_PRE_URL = f"{MAXAR_LAHAINA_COLLECTION}#pre"
+LAHAINA_POST_URL = f"{MAXAR_LAHAINA_COLLECTION}#post"
 
 
 @dataclass(frozen=True)
@@ -466,10 +471,109 @@ OCEAN_FOREST_STORY = StorySeed(
 )
 
 
+LAHAINA_STORY = StorySeed(
+    title="Lahaina: before and after the 2023 wildfire",
+    description=(
+        "A side-by-side look at Lahaina, Maui, in high-resolution aerial "
+        "imagery from before and after the August 2023 wildfire — one of the "
+        "deadliest in modern U.S. history. Imagery © Maxar/Vantor Open Data "
+        "(CC-BY-NC 4.0)."
+    ),
+    chapters=[
+        ChapterSeed(
+            type="prose",
+            title="A town on the water",
+            narrative=(
+                "On **August 8, 2023**, a wind-driven wildfire swept through "
+                "Lahaina on the west coast of Maui. This story uses "
+                "high-resolution **true-color satellite imagery** from the "
+                "Maxar/Vantor Open Data Program to show the same streets "
+                "before and after.\n\n"
+                "Scroll to fly into town, then compare the two maps."
+            ),
+        ),
+        ChapterSeed(
+            type="scrollytelling",
+            title="Before the fire",
+            narrative=(
+                "Lahaina's historic waterfront and dense residential blocks, "
+                "imaged before August 2023. Note Front Street along the coast "
+                "and the tightly packed neighborhoods inland."
+            ),
+            dataset_source_url=LAHAINA_PRE_URL,
+            center=(-156.68, 20.88),
+            zoom=14.5,
+            basemap="streets",
+            opacity=1.0,
+            transition="fly-to",
+            overlay_position="left",
+        ),
+        ChapterSeed(
+            type="scrollytelling",
+            title="After the fire",
+            narrative=(
+                "The same footprint after the fire. Entire blocks are reduced "
+                "to ash while the surrounding vegetation and coastline remain — "
+                "the sharp boundary of the burn scar is visible from orbit."
+            ),
+            dataset_source_url=LAHAINA_POST_URL,
+            center=(-156.68, 20.88),
+            zoom=14.5,
+            basemap="streets",
+            opacity=1.0,
+            transition="instant",
+            overlay_position="right",
+        ),
+        ChapterSeed(
+            type="scrollytelling",
+            title="The waterfront, block by block",
+            narrative=(
+                "Zooming in on Front Street and the harbor. At this scale the "
+                "imagery resolves individual lots — you can trace which "
+                "structures stood and which were lost along the shoreline."
+            ),
+            dataset_source_url=LAHAINA_POST_URL,
+            center=(-156.6792, 20.8722),
+            zoom=16.0,
+            basemap="streets",
+            opacity=1.0,
+            transition="fly-to",
+            overlay_position="left",
+        ),
+        ChapterSeed(
+            type="prose",
+            title="Why aerial imagery matters",
+            narrative=(
+                "True-color imagery like this is among the first data available "
+                "after a disaster. It guides search-and-rescue, scopes the "
+                "damage for recovery funding, and creates a permanent record of "
+                "what was there before.\n\n"
+                "Imagery © Maxar/Vantor Open Data, released under CC-BY-NC 4.0."
+            ),
+        ),
+        ChapterSeed(
+            type="map",
+            title="Explore the burn scar",
+            narrative=(
+                "Pan and zoom across the post-fire imagery. The contrast "
+                "between burned and unburned parcels maps the fire's path "
+                "block by block."
+            ),
+            dataset_source_url=LAHAINA_POST_URL,
+            center=(-156.68, 20.88),
+            zoom=14.0,
+            basemap="streets",
+            opacity=1.0,
+        ),
+    ],
+)
+
+
 ALL_STORIES: list[StorySeed] = [
     OCEAN_FLOOR_STORY,
     CITIES_STORY,
     OCEAN_FOREST_STORY,
+    LAHAINA_STORY,
 ]
 
 

--- a/ingestion/src/services/remote_register.py
+++ b/ingestion/src/services/remote_register.py
@@ -112,6 +112,19 @@ async def _compute_remote_stats(
     return await asyncio.to_thread(_compute_remote_stats_sync, hrefs, max_samples)
 
 
+async def _resolve_raster_range(
+    band_count: int | None, hrefs: list[str]
+) -> tuple[float | None, float | None]:
+    """Compute display range for single-band rasters; skip for multi-band.
+
+    Multi-band (RGB) COGs render natively in titiler; a single-band-style
+    min/max would wash the image out, so return (None, None).
+    """
+    if band_count is not None and band_count > 1:
+        return None, None
+    return await _compute_remote_stats(hrefs)
+
+
 def _format_datetime_z(dt: datetime) -> str:
     """Format a datetime as ISO 8601 with a `Z` suffix for UTC.
 
@@ -194,7 +207,7 @@ async def register_remote_collection(
     )
 
     band_count, band_names, color_interp, dtype = await _read_band_meta(hrefs[0])
-    raster_min, raster_max = await _compute_remote_stats(hrefs)
+    raster_min, raster_max = await _resolve_raster_range(band_count, hrefs)
 
     overall_bbox = [
         min(b[0] for b in bboxes),  # type: ignore[index]

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -102,32 +102,18 @@ _PRODUCTS: dict[str, SourceCoopProduct] = {
         kind="pmtiles",
         pmtiles_url="https://data.source.coop/vida/google-microsoft-osm-open-buildings/pmtiles/goog_msft_osm.pmtiles",
     ),
-    "maxar/lahaina-pre": SourceCoopProduct(
-        slug="maxar/lahaina-pre",
-        name="Lahaina before the 2023 wildfire (Maxar)",
-        description=(
-            "High-resolution true-color satellite imagery of Lahaina, Maui, "
-            "captured before the August 2023 wildfire. Imagery © Maxar/Vantor "
-            "Open Data (CC-BY-NC 4.0)."
-        ),
-        listing_url=f"{MAXAR_LAHAINA_COLLECTION}#pre",
-        kind="mosaic",
-        enumerator="maxar_event",
-        enumerator_args={"max_date": "2023-08-07T23:59:59Z", "max_items": 60},
-        is_temporal=False,
-    ),
-    "maxar/lahaina-post": SourceCoopProduct(
-        slug="maxar/lahaina-post",
+    "maxar/lahaina": SourceCoopProduct(
+        slug="maxar/lahaina",
         name="Lahaina after the 2023 wildfire (Maxar)",
         description=(
             "High-resolution true-color satellite imagery of Lahaina, Maui, "
-            "captured after the August 2023 wildfire. Imagery © Maxar/Vantor "
-            "Open Data (CC-BY-NC 4.0)."
+            "captured days after the August 2023 wildfire. Imagery © "
+            "Maxar/Vantor Open Data (CC-BY-NC 4.0)."
         ),
-        listing_url=f"{MAXAR_LAHAINA_COLLECTION}#post",
+        listing_url=MAXAR_LAHAINA_COLLECTION,
         kind="mosaic",
         enumerator="maxar_event",
-        enumerator_args={"min_date": "2023-08-09T00:00:00Z", "max_items": 60},
+        enumerator_args={"max_items": 80},
         is_temporal=False,
     ),
 }

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -45,9 +45,7 @@ class SourceCoopProduct:
                 raise ValueError(f"{self.slug}: mosaic kind must not set pmtiles_url")
 
 
-MAXAR_LAHAINA_COLLECTION = (
-    "https://maxar-opendata.s3.amazonaws.com/events/Maui-Hawaii-fires-Aug-23/collection.json"
-)
+MAXAR_LAHAINA_COLLECTION = "https://maxar-opendata.s3.amazonaws.com/events/Maui-Hawaii-fires-Aug-23/collection.json"
 
 
 _PRODUCTS: dict[str, SourceCoopProduct] = {
@@ -113,7 +111,11 @@ _PRODUCTS: dict[str, SourceCoopProduct] = {
         listing_url=MAXAR_LAHAINA_COLLECTION,
         kind="mosaic",
         enumerator="maxar_event",
-        enumerator_args={"max_items": 80},
+        enumerator_args={
+            "min_date": "2023-08-09T00:00:00Z",
+            "max_date": "2023-08-13T00:00:00Z",
+            "max_items": 80,
+        },
         is_temporal=False,
     ),
 }

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -45,6 +45,11 @@ class SourceCoopProduct:
                 raise ValueError(f"{self.slug}: mosaic kind must not set pmtiles_url")
 
 
+MAXAR_LAHAINA_COLLECTION = (
+    "https://maxar-opendata.s3.amazonaws.com/events/Maui-Hawaii-fires-Aug-23/collection.json"
+)
+
+
 _PRODUCTS: dict[str, SourceCoopProduct] = {
     "ausantarctic/ghrsst-mur-v2": SourceCoopProduct(
         slug="ausantarctic/ghrsst-mur-v2",
@@ -96,6 +101,34 @@ _PRODUCTS: dict[str, SourceCoopProduct] = {
         listing_url="https://data.source.coop/vida/google-microsoft-osm-open-buildings/",
         kind="pmtiles",
         pmtiles_url="https://data.source.coop/vida/google-microsoft-osm-open-buildings/pmtiles/goog_msft_osm.pmtiles",
+    ),
+    "maxar/lahaina-pre": SourceCoopProduct(
+        slug="maxar/lahaina-pre",
+        name="Lahaina before the 2023 wildfire (Maxar)",
+        description=(
+            "High-resolution true-color satellite imagery of Lahaina, Maui, "
+            "captured before the August 2023 wildfire. Imagery © Maxar/Vantor "
+            "Open Data (CC-BY-NC 4.0)."
+        ),
+        listing_url=f"{MAXAR_LAHAINA_COLLECTION}#pre",
+        kind="mosaic",
+        enumerator="maxar_event",
+        enumerator_args={"max_date": "2023-08-07T23:59:59Z", "max_items": 60},
+        is_temporal=False,
+    ),
+    "maxar/lahaina-post": SourceCoopProduct(
+        slug="maxar/lahaina-post",
+        name="Lahaina after the 2023 wildfire (Maxar)",
+        description=(
+            "High-resolution true-color satellite imagery of Lahaina, Maui, "
+            "captured after the August 2023 wildfire. Imagery © Maxar/Vantor "
+            "Open Data (CC-BY-NC 4.0)."
+        ),
+        listing_url=f"{MAXAR_LAHAINA_COLLECTION}#post",
+        kind="mosaic",
+        enumerator="maxar_event",
+        enumerator_args={"min_date": "2023-08-09T00:00:00Z", "max_items": 60},
+        is_temporal=False,
     ),
 }
 

--- a/ingestion/tests/fixtures/maxar/collection.json
+++ b/ingestion/tests/fixtures/maxar/collection.json
@@ -1,0 +1,8 @@
+{
+  "type": "Collection",
+  "id": "event-collection",
+  "links": [
+    {"rel": "item", "href": "item-a.json"},
+    {"rel": "item", "href": "item-b.json"}
+  ]
+}

--- a/ingestion/tests/fixtures/maxar/item-a.json
+++ b/ingestion/tests/fixtures/maxar/item-a.json
@@ -1,0 +1,10 @@
+{
+  "type": "Feature",
+  "id": "a",
+  "bbox": [10.0, 20.0, 11.0, 21.0],
+  "properties": {"datetime": "2023-08-01T00:00:00Z"},
+  "assets": {
+    "visual": {"href": "https://maxar/a/visual.tif", "roles": ["visual"]},
+    "b1": {"href": "https://maxar/a/b1.tif", "roles": ["data"]}
+  }
+}

--- a/ingestion/tests/fixtures/maxar/item-b.json
+++ b/ingestion/tests/fixtures/maxar/item-b.json
@@ -1,0 +1,9 @@
+{
+  "type": "Feature",
+  "id": "b",
+  "bbox": [11.0, 20.0, 12.0, 21.0],
+  "properties": {"datetime": "2023-09-15T00:00:00Z"},
+  "assets": {
+    "visual": {"href": "https://maxar/b/visual.tif", "roles": ["visual"]}
+  }
+}

--- a/ingestion/tests/services/test_example_stories.py
+++ b/ingestion/tests/services/test_example_stories.py
@@ -18,6 +18,8 @@ from src.services.example_stories import (
     CARBON_URL,
     GEBCO_URL,
     GHRSST_URL,
+    LAHAINA_POST_URL,
+    LAHAINA_PRE_URL,
     OCEAN_FLOOR_STORY,
     relink_dead_chapter_dataset_ids,
     seed_example_stories,
@@ -79,6 +81,18 @@ def _seed_all_example_datasets(factory):
             ds_id="buildings-id",
             source_url=BUILDINGS_URL,
             filename="Buildings",
+        )
+        _seed_example_dataset(
+            session,
+            ds_id="lahaina-pre-id",
+            source_url=LAHAINA_PRE_URL,
+            filename="Lahaina Pre",
+        )
+        _seed_example_dataset(
+            session,
+            ds_id="lahaina-post-id",
+            source_url=LAHAINA_POST_URL,
+            filename="Lahaina Post",
         )
         session.commit()
     finally:
@@ -276,6 +290,8 @@ def _reseed_example_datasets_with_new_ids(factory, suffix: str):
             (GHRSST_URL, "GHRSST"),
             (CARBON_URL, "Carbon"),
             (BUILDINGS_URL, "Buildings"),
+            (LAHAINA_PRE_URL, "LahainaPre"),
+            (LAHAINA_POST_URL, "LahainaPost"),
         ]:
             _seed_example_dataset(
                 session,

--- a/ingestion/tests/services/test_example_stories.py
+++ b/ingestion/tests/services/test_example_stories.py
@@ -18,8 +18,7 @@ from src.services.example_stories import (
     CARBON_URL,
     GEBCO_URL,
     GHRSST_URL,
-    LAHAINA_POST_URL,
-    LAHAINA_PRE_URL,
+    LAHAINA_URL,
     OCEAN_FLOOR_STORY,
     relink_dead_chapter_dataset_ids,
     seed_example_stories,
@@ -84,15 +83,9 @@ def _seed_all_example_datasets(factory):
         )
         _seed_example_dataset(
             session,
-            ds_id="lahaina-pre-id",
-            source_url=LAHAINA_PRE_URL,
-            filename="Lahaina Pre",
-        )
-        _seed_example_dataset(
-            session,
-            ds_id="lahaina-post-id",
-            source_url=LAHAINA_POST_URL,
-            filename="Lahaina Post",
+            ds_id="lahaina-id",
+            source_url=LAHAINA_URL,
+            filename="Lahaina",
         )
         session.commit()
     finally:
@@ -290,8 +283,7 @@ def _reseed_example_datasets_with_new_ids(factory, suffix: str):
             (GHRSST_URL, "GHRSST"),
             (CARBON_URL, "Carbon"),
             (BUILDINGS_URL, "Buildings"),
-            (LAHAINA_PRE_URL, "LahainaPre"),
-            (LAHAINA_POST_URL, "LahainaPost"),
+            (LAHAINA_URL, "Lahaina"),
         ]:
             _seed_example_dataset(
                 session,

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -15,8 +15,7 @@ def test_list_products_returns_expected_entries():
         "alexgleith/gebco-2024",
         "vizzuality/lg-land-carbon-data",
         "vida/google-microsoft-osm-open-buildings",
-        "maxar/lahaina-pre",
-        "maxar/lahaina-post",
+        "maxar/lahaina",
     }
 
 

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -7,7 +7,7 @@ from src.services.source_coop_config import (
 )
 
 
-def test_list_products_returns_four_v1_entries():
+def test_list_products_returns_expected_entries():
     products = list_products()
     slugs = {p.slug for p in products}
     assert slugs == {
@@ -15,6 +15,8 @@ def test_list_products_returns_four_v1_entries():
         "alexgleith/gebco-2024",
         "vizzuality/lg-land-carbon-data",
         "vida/google-microsoft-osm-open-buildings",
+        "maxar/lahaina-pre",
+        "maxar/lahaina-post",
     }
 
 

--- a/ingestion/tests/test_lahaina_story_seed.py
+++ b/ingestion/tests/test_lahaina_story_seed.py
@@ -1,15 +1,18 @@
-from src.services.example_stories import ALL_STORIES, _build_chapter_dict
+from src.services.example_stories import (
+    ALL_STORIES,
+    LAHAINA_URL,
+    _build_chapter_dict,
+)
 
 
 def _find_story(title):
-    return next(s for s in ALL_STORIES if s.title.startswith(title))
+    return next(s for s in ALL_STORIES if title in s.title)
 
 
-def test_lahaina_story_present_and_references_both_datasets():
+def test_lahaina_story_present_and_references_dataset():
     story = _find_story("Lahaina")
     urls = {ch.dataset_source_url for ch in story.chapters if ch.dataset_source_url}
-    assert any(u.endswith("#pre") for u in urls)
-    assert any(u.endswith("#post") for u in urls)
+    assert urls == {LAHAINA_URL}
 
 
 def test_lahaina_map_chapter_builds_rgb_layer_config():

--- a/ingestion/tests/test_lahaina_story_seed.py
+++ b/ingestion/tests/test_lahaina_story_seed.py
@@ -1,0 +1,23 @@
+from src.services.example_stories import ALL_STORIES, _build_chapter_dict
+
+
+def _find_story(title):
+    return next(s for s in ALL_STORIES if s.title.startswith(title))
+
+
+def test_lahaina_story_present_and_references_both_datasets():
+    story = _find_story("Lahaina")
+    urls = {ch.dataset_source_url for ch in story.chapters if ch.dataset_source_url}
+    assert any(u.endswith("#pre") for u in urls)
+    assert any(u.endswith("#post") for u in urls)
+
+
+def test_lahaina_map_chapter_builds_rgb_layer_config():
+    story = _find_story("Lahaina")
+    map_chapter = next(ch for ch in story.chapters if ch.dataset_source_url)
+    built = _build_chapter_dict(map_chapter, order=0, dataset_id="ds-123")
+    assert built["layer_config"]["dataset_id"] == "ds-123"
+    assert built["map_state"]["center"] == [
+        map_chapter.center[0],
+        map_chapter.center[1],
+    ]

--- a/ingestion/tests/test_maxar_asset_selection.py
+++ b/ingestion/tests/test_maxar_asset_selection.py
@@ -1,0 +1,30 @@
+from src.services.enumerators.stac_sidecars import pick_rgb_asset
+
+
+def test_pick_rgb_asset_prefers_visual_role():
+    item = {
+        "assets": {
+            "b1": {"href": "https://x/b1.tif", "roles": ["data"]},
+            "visual": {"href": "https://x/visual.tif", "roles": ["visual"]},
+        }
+    }
+    assert pick_rgb_asset(item)["href"] == "https://x/visual.tif"
+
+
+def test_pick_rgb_asset_prefers_visual_key_without_roles():
+    item = {
+        "assets": {
+            "b1": {"href": "https://x/b1.tif"},
+            "visual": {"href": "https://x/visual.tif"},
+        }
+    }
+    assert pick_rgb_asset(item)["href"] == "https://x/visual.tif"
+
+
+def test_pick_rgb_asset_falls_back_to_data_role():
+    item = {"assets": {"d": {"href": "https://x/d.tif", "roles": ["data"]}}}
+    assert pick_rgb_asset(item)["href"] == "https://x/d.tif"
+
+
+def test_pick_rgb_asset_none_when_no_assets():
+    assert pick_rgb_asset({"assets": {}}) is None

--- a/ingestion/tests/test_maxar_enumerator.py
+++ b/ingestion/tests/test_maxar_enumerator.py
@@ -1,0 +1,46 @@
+import pathlib
+
+import httpx
+import pytest
+
+from src.services.enumerators.maxar import enumerate_maxar_event
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures" / "maxar"
+
+
+def _local_transport():
+    def handler(request: httpx.Request) -> httpx.Response:
+        name = request.url.path.rsplit("/", 1)[-1]
+        body = (FIXTURES / name).read_text()
+        return httpx.Response(200, text=body)
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture
+def _patch_client(monkeypatch):
+    transport = _local_transport()
+    orig = httpx.AsyncClient
+
+    def patched(*args, **kwargs):
+        kwargs["transport"] = transport
+        return orig(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched)
+
+
+async def test_enumerate_maxar_event_yields_visual_hrefs(_patch_client):
+    items = await enumerate_maxar_event("https://maxar/collection.json")
+
+    hrefs = sorted(i.href for i in items)
+    assert hrefs == ["https://maxar/a/visual.tif", "https://maxar/b/visual.tif"]
+    assert all(i.bbox is not None for i in items)
+    assert all(i.datetime is not None for i in items)
+
+
+async def test_enumerate_maxar_event_filters_by_date(_patch_client):
+    items = await enumerate_maxar_event(
+        "https://maxar/collection.json", max_date="2023-08-31T00:00:00Z"
+    )
+
+    assert [i.href for i in items] == ["https://maxar/a/visual.tif"]

--- a/ingestion/tests/test_maxar_enumerator.py
+++ b/ingestion/tests/test_maxar_enumerator.py
@@ -44,3 +44,10 @@ async def test_enumerate_maxar_event_filters_by_date(_patch_client):
     )
 
     assert [i.href for i in items] == ["https://maxar/a/visual.tif"]
+
+
+async def test_enumerate_maxar_event_rejects_naive_date_bound(_patch_client):
+    with pytest.raises(ValueError):
+        await enumerate_maxar_event(
+            "https://maxar/collection.json", max_date="2023-08-31"
+        )

--- a/ingestion/tests/test_maxar_products.py
+++ b/ingestion/tests/test_maxar_products.py
@@ -1,12 +1,10 @@
 from src.services.source_coop_config import get_product
 
 
-def test_maxar_lahaina_products_registered():
-    pre = get_product("maxar/lahaina-pre")
-    post = get_product("maxar/lahaina-post")
+def test_maxar_lahaina_product_registered():
+    product = get_product("maxar/lahaina")
 
-    assert pre.enumerator == "maxar_event"
-    assert post.enumerator == "maxar_event"
-    assert pre.listing_url != post.listing_url
-    assert pre.enumerator_args.get("max_date") is not None
-    assert post.enumerator_args.get("min_date") is not None
+    assert product.enumerator == "maxar_event"
+    assert product.kind == "mosaic"
+    assert product.listing_url.endswith("collection.json")
+    assert "maxar-opendata" in product.listing_url

--- a/ingestion/tests/test_maxar_products.py
+++ b/ingestion/tests/test_maxar_products.py
@@ -1,0 +1,12 @@
+from src.services.source_coop_config import get_product
+
+
+def test_maxar_lahaina_products_registered():
+    pre = get_product("maxar/lahaina-pre")
+    post = get_product("maxar/lahaina-post")
+
+    assert pre.enumerator == "maxar_event"
+    assert post.enumerator == "maxar_event"
+    assert pre.listing_url != post.listing_url
+    assert pre.enumerator_args.get("max_date") is not None
+    assert post.enumerator_args.get("min_date") is not None

--- a/ingestion/tests/test_remote_register_rgb.py
+++ b/ingestion/tests/test_remote_register_rgb.py
@@ -1,0 +1,28 @@
+from src.services import remote_register
+
+
+async def test_multiband_dataset_has_no_rescale(monkeypatch):
+    async def fake_stats(hrefs):
+        raise AssertionError("stats must not be computed for multi-band")
+
+    monkeypatch.setattr(remote_register, "_compute_remote_stats", fake_stats)
+
+    rmin, rmax = await remote_register._resolve_raster_range(
+        band_count=3, hrefs=["https://x/visual.tif"]
+    )
+
+    assert rmin is None
+    assert rmax is None
+
+
+async def test_singleband_dataset_computes_rescale(monkeypatch):
+    async def fake_stats(hrefs):
+        return 1.0, 99.0
+
+    monkeypatch.setattr(remote_register, "_compute_remote_stats", fake_stats)
+
+    rmin, rmax = await remote_register._resolve_raster_range(
+        band_count=1, hrefs=["https://x/data.tif"]
+    )
+
+    assert (rmin, rmax) == (1.0, 99.0)

--- a/ingestion/tests/test_run_enumerator_maxar.py
+++ b/ingestion/tests/test_run_enumerator_maxar.py
@@ -1,0 +1,32 @@
+from src.services import example_datasets
+from src.services.source_coop_config import SourceCoopProduct
+
+
+async def test_run_enumerator_dispatches_maxar(monkeypatch):
+    called = {}
+
+    async def fake(collection_url, *, max_items=None, min_date=None, max_date=None):
+        called["url"] = collection_url
+        called["max_items"] = max_items
+        called["max_date"] = max_date
+        return ["sentinel"]
+
+    monkeypatch.setattr(example_datasets, "enumerate_maxar_event", fake)
+
+    product = SourceCoopProduct(
+        slug="maxar/lahaina",
+        name="Maxar Lahaina",
+        description="",
+        listing_url="https://maxar/collection.json",
+        enumerator="maxar_event",
+        enumerator_args={"max_items": 40, "max_date": "2023-08-07T00:00:00Z"},
+    )
+
+    result = await example_datasets.run_enumerator(product)
+
+    assert result == ["sentinel"]
+    assert called == {
+        "url": "https://maxar/collection.json",
+        "max_items": 40,
+        "max_date": "2023-08-07T00:00:00Z",
+    }


### PR DESCRIPTION
## What

Adds support for **aerial / true-color RGB imagery** in maps and stories, and seeds a Maxar Open Data example story.

### Backend
- **`pick_rgb_asset`** — selects an item's `visual`/RGB asset (Maxar items expose `visual`, not `data`).
- **`enumerate_maxar_event`** — walks a Maxar event STAC catalog, resolves relative `visual` hrefs, optional `min_date`/`max_date` filtering.
- Wired `maxar_event` into `run_enumerator`.
- Multi-band datasets no longer get a meaningless single-band rescale (would wash RGB out); `_resolve_raster_range` skips stats for `band_count > 1`.
- Seeds a `maxar/lahaina` example dataset + an `is_example` story, **"Anatomy of the Lahaina burn scar."**

### Frontend
- **Bug fix:** the dataset render branch applied `colormap_name` unconditionally — a 3-band RGB dataset wrongly got a colormap. Now guarded on `band_count === 1` (extracted to `buildDatasetServerTileUrl`).
- **True-color RGB legend** — `RgbLegend` + `buildRasterLegend`; RGB rasters show "True color (RGB)" instead of a misleading viridis ramp.

## Scope decisions
- **Maxar only** (NAIP/Planetary-Computer signed URLs scoped out; the asset-selection groundwork enables it later).
- **Pivoted to post-fire-only:** the Maxar Lahaina event ships *only* post-fire imagery (Aug 9 & 12, 2023) — no pre-fire acquisitions exist, so a before/after pairing is impossible. Reframed as a tour of the burn scar.
- **Deferred:** RGB pixel-hover readout (the pixel inspector is client-render-only today; RGB is server-rendered, so it'd need a new per-hover point-query path). `band_indices` band selection (YAGNI without a 4-band source).

## Testing
- 44 new/updated tests pass (39 backend, 5 frontend); tsc + prettier clean.
- Verified the enumerator against the **live Maxar catalog**: URL resolves, catalog walks, `visual` asset selected, relative hrefs + datetimes parse.
- **Not yet done:** full-stack visual render check (needs Docker + a GPU; WebGL doesn't run on the dev VM).

Spec + plans: `~/Obsidian/Project Docs/CNG Sandbox/specs|plans/2026-06-24-aerial-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added true-color (RGB) legend support for RGB raster layers.
  * Added automatic raster legend generation for raster views (including RGB vs continuous modes).
  * Added a new Lahaina example story and SourceCoop dataset for Maxar event-based imagery, enabling new event-driven browsing.

* **Bug Fixes**
  * Improved raster rendering for multi-band (RGB) imagery to prevent washed-out color ranges.
  * Updated server tile URL parameter handling for single-band, RGB, and temporal datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->