### PR TITLE
fix(ci): pin pypi-publish action to a commit SHA with a real ghcr image

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -46,7 +46,7 @@ jobs:
           name: dist
           path: dist/
 
-      - uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -63,4 +63,4 @@ jobs:
           name: dist
           path: dist/
 
-      - uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
## Problem

The v2.8.0 and v2.9.0 PyPI publishes failed in the `publish-pypi` job with:

```
docker: Error response from daemon: manifest unknown
Unable to find image 'ghcr.io/pypa/gh-action-pypi-publish:6733eb7d...'
```

`pypa/gh-action-pypi-publish` is a **Docker action**, so GitHub pulls its container image tagged by the pinned ref. The pin `6733eb7d741f0b11ec6a39b58540dab7590f9b7d` is the **annotated-tag object** SHA of `v1.14.0` (`git/refs/tags/v1.14.0` → `object.type: tag`), not the underlying commit — and no ghcr image is tagged with the tag-object SHA → `manifest unknown`. (This is not a Trusted Publishing problem; the OIDC step was never reached.)

## Fix

Pin both occurrences to the **commit SHA** `cef221092ed1bacb1cc03d23a2d87d1d172e277b` (== `release/v1` head / the v1.14.0 commit). Verified the ghcr manifest:

- `:cef22109...` → **HTTP 200** ✅
- `:6733eb7d...` → **HTTP 404** ❌

Still a 40-char SHA pin, so the `actions-security` (zizmor) check stays green (verified locally: no findings).

## After merge

Publish v2.9.0 with `gh workflow run publish-mcp.yml -f target=pypi` (uses the fixed workflow on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publishing workflow to use a newer pinned version of the package upload action for release jobs.
  * Kept the release process behavior the same while refreshing the underlying automation reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->