### PR TITLE
feat: aerial example story (OpenAerialMap Hatay earthquake)

### DIFF
--- a/ingestion/src/services/enumerators/single_cog.py
+++ b/ingestion/src/services/enumerators/single_cog.py
@@ -1,0 +1,15 @@
+"""single_cog enumerator: register one directly-addressed public COG URL.
+
+Used for sources (e.g. OpenAerialMap) that expose a single COG at a stable
+HTTPS URL rather than a listable prefix or STAC catalog. Bounds are left None
+so register_remote_collection probes them from the COG.
+"""
+
+from __future__ import annotations
+
+from src.services.enumerators import RemoteItem
+
+
+async def enumerate_single_cog(cog_url: str) -> list[RemoteItem]:
+    """Return a single RemoteItem for a direct COG URL."""
+    return [RemoteItem(href=cog_url, datetime=None, bbox=None)]

--- a/ingestion/src/services/example_datasets.py
+++ b/ingestion/src/services/example_datasets.py
@@ -25,6 +25,7 @@ from src.models.dataset import DatasetRow
 from src.services.enumerators import RemoteItem
 from src.services.enumerators.maxar import enumerate_maxar_event
 from src.services.enumerators.path_listing import enumerate_path_listing
+from src.services.enumerators.single_cog import enumerate_single_cog
 from src.services.enumerators.stac_sidecars import enumerate_stac_sidecars
 from src.services.pmtiles_register import (
     PMTilesRegistrationError,
@@ -75,6 +76,8 @@ async def run_enumerator(product: SourceCoopProduct) -> list[RemoteItem]:
             min_date=product.enumerator_args.get("min_date"),
             max_date=product.enumerator_args.get("max_date"),
         )
+    if product.enumerator == "single_cog":
+        return await enumerate_single_cog(product.listing_url)
     raise ValueError(f"Unknown enumerator: {product.enumerator}")
 
 

--- a/ingestion/src/services/example_stories.py
+++ b/ingestion/src/services/example_stories.py
@@ -32,6 +32,9 @@ GHRSST_URL = "https://data.source.coop/ausantarctic/ghrsst-mur-v2/"
 CARBON_URL = "https://data.source.coop/vizzuality/lg-land-carbon-data/"
 BUILDINGS_URL = "https://data.source.coop/vida/google-microsoft-osm-open-buildings/"
 LAHAINA_URL = "https://maxar-opendata.s3.amazonaws.com/events/Maui-Hawaii-fires-Aug-23/collection.json"
+HATAY_FLIGHT1_URL = "https://oin-hotosm-temp.s3.amazonaws.com/63f21def525f0700077ed4e2/0/63f21def525f0700077ed4e3.tif"
+HATAY_DEFNE_URL = "https://oin-hotosm-temp.s3.amazonaws.com/63eb7815ca43600005f4d91e/0/63eb7815ca43600005f4d91f.tif"
+HATAY_TURINCLU_URL = "https://oin-hotosm-temp.s3.amazonaws.com/63eb8222ca43600005f4d925/0/63eb8222ca43600005f4d926.tif"
 
 
 @dataclass(frozen=True)
@@ -565,11 +568,110 @@ LAHAINA_STORY = StorySeed(
 )
 
 
+ANTAKYA_STORY = StorySeed(
+    title="Antakya from above: a city after the earthquake",
+    description=(
+        "Drone aerial imagery of Antakya (Hatay), Turkey, captured days after "
+        "the February 2023 earthquake — detail no satellite can resolve. "
+        "Imagery © OpenAerialMap contributors (CC-BY 4.0)."
+    ),
+    chapters=[
+        ChapterSeed(
+            type="prose",
+            title="When the ground moved",
+            narrative=(
+                "On **February 6, 2023**, a magnitude 7.8 earthquake struck "
+                "southern Turkey and northern Syria. In the days that "
+                "followed, drones flew over Antakya and mapped the damage at "
+                "**centimeter resolution** — far sharper than any satellite.\n\n"
+                "Scroll to fly across the city, then open the map at the end "
+                "to explore it yourself."
+            ),
+        ),
+        ChapterSeed(
+            type="scrollytelling",
+            title="A district in ruins",
+            narrative=(
+                "A wide view over one Antakya district. Even at this zoom, "
+                "the pattern of collapse is unmistakable — standing blocks "
+                "beside heaps of rubble."
+            ),
+            dataset_source_url=HATAY_FLIGHT1_URL,
+            center=(36.199, 36.229),
+            zoom=16.0,
+            basemap="streets",
+            opacity=1.0,
+            transition="fly-to",
+            overlay_position="left",
+        ),
+        ChapterSeed(
+            type="scrollytelling",
+            title="Elektrik Mahallesi, building by building",
+            narrative=(
+                "At ~3 cm resolution in Defne's Elektrik neighborhood, the "
+                "imagery resolves individual structures — pancaked floors, "
+                "debris fields, and the narrow lanes rescue crews had to "
+                "clear."
+            ),
+            dataset_source_url=HATAY_DEFNE_URL,
+            center=(36.149, 36.198),
+            zoom=18.0,
+            basemap="streets",
+            opacity=1.0,
+            transition="fly-to",
+            overlay_position="right",
+        ),
+        ChapterSeed(
+            type="scrollytelling",
+            title="Akdeniz and Armutlu",
+            narrative=(
+                "A second neighborhood at the same fidelity. Cleared lots and "
+                "staging areas mark where response was already underway when "
+                "the drone flew."
+            ),
+            dataset_source_url=HATAY_TURINCLU_URL,
+            center=(36.147, 36.194),
+            zoom=18.0,
+            basemap="streets",
+            opacity=1.0,
+            transition="fly-to",
+            overlay_position="left",
+        ),
+        ChapterSeed(
+            type="prose",
+            title="What aerial sees that satellites can't",
+            narrative=(
+                "At a few centimeters per pixel, low-altitude aerial imagery "
+                "shows what satellites smear together: which floor failed, "
+                "where a façade fell, whether a lane is passable. That detail "
+                "drives search-and-rescue routing and damage assessment in "
+                "the first hours after a disaster.\n\n"
+                "Imagery © OpenAerialMap contributors, released under CC-BY 4.0."
+            ),
+        ),
+        ChapterSeed(
+            type="map",
+            title="Explore the imagery",
+            narrative=(
+                "Pan and zoom across the district. Zoom all the way in — the "
+                "imagery holds detail well past where satellite would blur."
+            ),
+            dataset_source_url=HATAY_FLIGHT1_URL,
+            center=(36.199, 36.229),
+            zoom=15.0,
+            basemap="streets",
+            opacity=1.0,
+        ),
+    ],
+)
+
+
 ALL_STORIES: list[StorySeed] = [
     OCEAN_FLOOR_STORY,
     CITIES_STORY,
     OCEAN_FOREST_STORY,
     LAHAINA_STORY,
+    ANTAKYA_STORY,
 ]
 
 

--- a/ingestion/src/services/source_coop_config.py
+++ b/ingestion/src/services/source_coop_config.py
@@ -47,6 +47,10 @@ class SourceCoopProduct:
 
 MAXAR_LAHAINA_COLLECTION = "https://maxar-opendata.s3.amazonaws.com/events/Maui-Hawaii-fires-Aug-23/collection.json"
 
+HATAY_FLIGHT1_COG = "https://oin-hotosm-temp.s3.amazonaws.com/63f21def525f0700077ed4e2/0/63f21def525f0700077ed4e3.tif"
+HATAY_DEFNE_COG = "https://oin-hotosm-temp.s3.amazonaws.com/63eb7815ca43600005f4d91e/0/63eb7815ca43600005f4d91f.tif"
+HATAY_TURINCLU_COG = "https://oin-hotosm-temp.s3.amazonaws.com/63eb8222ca43600005f4d925/0/63eb8222ca43600005f4d926.tif"
+
 
 _PRODUCTS: dict[str, SourceCoopProduct] = {
     "ausantarctic/ghrsst-mur-v2": SourceCoopProduct(
@@ -117,6 +121,42 @@ _PRODUCTS: dict[str, SourceCoopProduct] = {
             "max_items": 80,
         },
         is_temporal=False,
+    ),
+    "openaerialmap/hatay-flight1": SourceCoopProduct(
+        slug="openaerialmap/hatay-flight1",
+        name="Antakya district after the 2023 earthquake (aerial)",
+        description=(
+            "Drone aerial imagery (~6 cm) of an Antakya district captured days "
+            "after the February 2023 earthquake. Imagery © OpenAerialMap "
+            "contributors (CC-BY 4.0)."
+        ),
+        listing_url=HATAY_FLIGHT1_COG,
+        kind="mosaic",
+        enumerator="single_cog",
+    ),
+    "openaerialmap/hatay-defne": SourceCoopProduct(
+        slug="openaerialmap/hatay-defne",
+        name="Defne, Elektrik Mah. after the 2023 earthquake (aerial)",
+        description=(
+            "Ultra-high-resolution drone aerial imagery (~3 cm) of the Elektrik "
+            "Mahallesi neighborhood in Defne, Hatay, after the February 2023 "
+            "earthquake. Imagery © OpenAerialMap contributors (CC-BY 4.0)."
+        ),
+        listing_url=HATAY_DEFNE_COG,
+        kind="mosaic",
+        enumerator="single_cog",
+    ),
+    "openaerialmap/hatay-turinclu": SourceCoopProduct(
+        slug="openaerialmap/hatay-turinclu",
+        name="Turinclu (Akdeniz/Armutlu Mah.) after the 2023 earthquake (aerial)",
+        description=(
+            "Ultra-high-resolution drone aerial imagery (~4 cm) of the "
+            "Akdeniz and Armutlu neighborhoods in Hatay after the February "
+            "2023 earthquake. Imagery © OpenAerialMap contributors (CC-BY 4.0)."
+        ),
+        listing_url=HATAY_TURINCLU_COG,
+        kind="mosaic",
+        enumerator="single_cog",
     ),
 }
 

--- a/ingestion/tests/services/test_example_stories.py
+++ b/ingestion/tests/services/test_example_stories.py
@@ -18,6 +18,9 @@ from src.services.example_stories import (
     CARBON_URL,
     GEBCO_URL,
     GHRSST_URL,
+    HATAY_DEFNE_URL,
+    HATAY_FLIGHT1_URL,
+    HATAY_TURINCLU_URL,
     LAHAINA_URL,
     OCEAN_FLOOR_STORY,
     relink_dead_chapter_dataset_ids,
@@ -86,6 +89,24 @@ def _seed_all_example_datasets(factory):
             ds_id="lahaina-id",
             source_url=LAHAINA_URL,
             filename="Lahaina",
+        )
+        _seed_example_dataset(
+            session,
+            ds_id="hatay-f1-id",
+            source_url=HATAY_FLIGHT1_URL,
+            filename="Hatay F1",
+        )
+        _seed_example_dataset(
+            session,
+            ds_id="hatay-defne-id",
+            source_url=HATAY_DEFNE_URL,
+            filename="Hatay Defne",
+        )
+        _seed_example_dataset(
+            session,
+            ds_id="hatay-tur-id",
+            source_url=HATAY_TURINCLU_URL,
+            filename="Hatay Tur",
         )
         session.commit()
     finally:
@@ -284,6 +305,9 @@ def _reseed_example_datasets_with_new_ids(factory, suffix: str):
             (CARBON_URL, "Carbon"),
             (BUILDINGS_URL, "Buildings"),
             (LAHAINA_URL, "Lahaina"),
+            (HATAY_FLIGHT1_URL, "HatayF1"),
+            (HATAY_DEFNE_URL, "HatayDefne"),
+            (HATAY_TURINCLU_URL, "HatayTur"),
         ]:
             _seed_example_dataset(
                 session,

--- a/ingestion/tests/services/test_source_coop_config.py
+++ b/ingestion/tests/services/test_source_coop_config.py
@@ -16,6 +16,9 @@ def test_list_products_returns_expected_entries():
         "vizzuality/lg-land-carbon-data",
         "vida/google-microsoft-osm-open-buildings",
         "maxar/lahaina",
+        "openaerialmap/hatay-flight1",
+        "openaerialmap/hatay-defne",
+        "openaerialmap/hatay-turinclu",
     }
 
 

--- a/ingestion/tests/test_antakya_story_seed.py
+++ b/ingestion/tests/test_antakya_story_seed.py
@@ -1,0 +1,28 @@
+from src.services.example_stories import (
+    ALL_STORIES,
+    HATAY_DEFNE_URL,
+    HATAY_FLIGHT1_URL,
+    HATAY_TURINCLU_URL,
+    _build_chapter_dict,
+)
+
+
+def _story():
+    return next(s for s in ALL_STORIES if "Antakya" in s.title)
+
+
+def test_antakya_story_references_all_three_datasets():
+    urls = {ch.dataset_source_url for ch in _story().chapters if ch.dataset_source_url}
+    assert urls == {HATAY_FLIGHT1_URL, HATAY_DEFNE_URL, HATAY_TURINCLU_URL}
+
+
+def test_antakya_story_meets_chapter_invariants():
+    chapters = _story().chapters
+    assert 6 <= len(chapters) <= 10
+    assert {"scrollytelling", "prose", "map"} <= {c.type for c in chapters}
+
+
+def test_antakya_map_chapter_builds_layer_config():
+    ch = next(c for c in _story().chapters if c.dataset_source_url)
+    built = _build_chapter_dict(ch, order=0, dataset_id="ds-1")
+    assert built["layer_config"]["dataset_id"] == "ds-1"

--- a/ingestion/tests/test_oam_products.py
+++ b/ingestion/tests/test_oam_products.py
@@ -1,0 +1,14 @@
+from src.services.source_coop_config import get_product
+
+
+def test_oam_hatay_products_registered():
+    for slug in (
+        "openaerialmap/hatay-flight1",
+        "openaerialmap/hatay-defne",
+        "openaerialmap/hatay-turinclu",
+    ):
+        p = get_product(slug)
+        assert p.enumerator == "single_cog"
+        assert p.kind == "mosaic"
+        assert p.listing_url.startswith("https://oin-hotosm-temp.s3.amazonaws.com/")
+        assert p.listing_url.endswith(".tif")

--- a/ingestion/tests/test_single_cog_enumerator.py
+++ b/ingestion/tests/test_single_cog_enumerator.py
@@ -1,0 +1,32 @@
+from src.services import example_datasets
+from src.services.enumerators.single_cog import enumerate_single_cog
+from src.services.source_coop_config import SourceCoopProduct
+
+
+async def test_single_cog_returns_one_bboxless_item():
+    items = await enumerate_single_cog("https://x/scene.tif")
+    assert len(items) == 1
+    assert items[0].href == "https://x/scene.tif"
+    assert items[0].bbox is None
+
+
+async def test_run_enumerator_dispatches_single_cog(monkeypatch):
+    called = {}
+
+    async def fake(cog_url):
+        called["url"] = cog_url
+        return ["sentinel"]
+
+    monkeypatch.setattr(example_datasets, "enumerate_single_cog", fake)
+
+    product = SourceCoopProduct(
+        slug="openaerialmap/x",
+        name="X",
+        description="",
+        listing_url="https://x/scene.tif",
+        enumerator="single_cog",
+    )
+    result = await example_datasets.run_enumerator(product)
+
+    assert result == ["sentinel"]
+    assert called == {"url": "https://x/scene.tif"}


### PR DESCRIPTION
## What

Adds a genuinely **aerial** example story to complement the Maxar *satellite* example: **"Antakya from above: a city after the earthquake"** — drone imagery of post-earthquake Hatay, Turkey (Feb 2023) at 3–6 cm resolution, from OpenAerialMap.

### Backend
- **`single_cog` enumerator** (~5 lines) — registers one directly-addressed public COG URL as a 1-item example mosaic dataset (bounds/band metadata probed by `register_remote_collection`). Dispatched from `run_enumerator`.
- **Three OAM `SourceCoopProduct` entries** (Antakya district + two ~3 cm neighborhoods), `enumerator="single_cog"`.
- **New example story** (6 chapters) referencing the three datasets by `source_url`.

### No frontend changes
The imagery is 3-band RGB, so it renders through the `band_count === 3` path + true-color legend already shipped in #541.

## Why OpenAerialMap
OAM serves public, **no-auth, CC-BY-4.0** COGs that read directly through our `/cog` tiler — no signing or requester-pays (unlike NAIP). All three COGs verified live: `3 uint8 ['red','green','blue']`.

## Notes
- **Genuinely aerial** (drone/aircraft), ~10× sharper than satellite — the point of the addition.
- URLs are on OAM's `oin-hotosm-temp` staging bucket — stable for years but a re-seed risk if one ever moves; the deterministic-ID + heal-on-reseed machinery makes recovery a one-line swap.
- Not yet done: post-deploy seed check + in-browser visual render (needs a GPU).

## Testing
33 tests pass (enumerator, dispatch, products, story invariants, seed helpers); ruff clean.

Spec/plan: `~/Obsidian/Project Docs/CNG Sandbox/{specs,plans}/2026-06-24-aerial-oam-hatay-story*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for directly registering single COG datasets by URL.
  * Introduced new Hatay/Antakya example datasets and story content for seeding.
  * Expanded curated product listings with additional Hatay imagery entries.

* **Bug Fixes**
  * Ensured new example stories and product entries are included in seeding and listing flows.
  * Improved coverage so map chapters continue to link to the correct dataset content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->