### PR TITLE
feat: seed "Earth's high places" 3D example story

### DIFF
--- a/ingestion/src/services/example_stories.py
+++ b/ingestion/src/services/example_stories.py
@@ -698,12 +698,140 @@ ANTAKYA_STORY = StorySeed(
 )
 
 
+HIGH_PLACES_STORY = StorySeed(
+    title="Earth's high places",
+    description=(
+        "A 3D tour of the planet's great mountains — spin the globe, tilt into "
+        "exaggerated terrain over the Himalaya and the Andes, rise through a city "
+        "built into the peaks, then explore global relief. Try the **Ask this "
+        "map** button to fly between the stops. Built on open elevation data."
+    ),
+    chapters=[
+        ChapterSeed(
+            type="prose",
+            title="The high places",
+            narrative=(
+                "Mountains are the hardest part of the planet to picture from a "
+                "flat map. Height is the whole story, and a top-down view throws "
+                "it away.\n\n"
+                "This story leans on the map's **3D scene** instead — a globe, "
+                "exaggerated terrain, and extruded buildings — to put the "
+                "vertical back in. Scroll through five stops from orbit down to "
+                "street level, then open the free-explore map at the end.\n\n"
+                "There's also an **Ask this map** button. Ask it to fly to the "
+                "Andes, jump to a chapter, or explain what a stop is showing — "
+                "it drives the map for you."
+            ),
+        ),
+        ChapterSeed(
+            type="scrollytelling",
+            title="One planet, seen whole",
+            narrative=(
+                "Start from orbit. On the globe the great mountain belts read as "
+                "seams across the continents — the Himalaya arcing along southern "
+                "Asia, the Andes running the length of South America.\n\n"
+                "These are the collision zones, where plates push into each other "
+                "and the crust has nowhere to go but up. We'll drop into two of "
+                "them."
+            ),
+            center=(80.0, 20.0),
+            zoom=1.7,
+            globe=True,
+        ),
+        ChapterSeed(
+            type="scrollytelling",
+            title="The Himalaya",
+            narrative=(
+                "Where the Indian plate drives into Asia, the ground has buckled "
+                "into the highest range on Earth — fourteen peaks above 8,000 m, "
+                "**Everest** the tallest of them.\n\n"
+                "Tilt into the terrain and the relief is exaggerated so the "
+                "ridges and valleys read clearly. This is a scene-setting stop: "
+                "no data overlay, just the shape of the land."
+            ),
+            center=(86.925, 27.988),
+            zoom=9.0,
+            pitch=68.0,
+            bearing=20.0,
+            terrain={"enabled": True, "exaggeration": 1.5},
+        ),
+        ChapterSeed(
+            type="scrollytelling",
+            title="The Andes",
+            narrative=(
+                "On the other side of the planet, the Andes run more than "
+                "7,000 km down the western edge of South America — the longest "
+                "continental mountain range there is, thrown up where the Nazca "
+                "plate dives under the continent.\n\n"
+                "Near the Argentina-Chile border sits **Aconcagua**, at 6,961 m "
+                "the highest peak outside Asia. Tilt across the spine and watch "
+                "the terrain climb straight out of the lowlands."
+            ),
+            center=(-70.011, -32.653),
+            zoom=8.5,
+            pitch=66.0,
+            bearing=-25.0,
+            terrain={"enabled": True, "exaggeration": 1.5},
+        ),
+        ChapterSeed(
+            type="scrollytelling",
+            title="A city in the mountains",
+            narrative=(
+                "People live in these ranges too. **Kathmandu** sits in a "
+                "bowl-shaped valley at about 1,400 m, ringed by Himalayan "
+                "foothills.\n\n"
+                "Drop to street level and the buildings rise in 3D — extruded "
+                "from open building-footprint data. It's a different kind of "
+                "terrain: the built one."
+            ),
+            center=(85.324, 27.7172),
+            zoom=15.5,
+            pitch=55.0,
+            bearing=20.0,
+            buildings=True,
+        ),
+        ChapterSeed(
+            type="map",
+            title="Explore the world's relief",
+            narrative=(
+                "Now the whole planet's elevation, from the **GEBCO 2024** global "
+                "model. Pan and zoom anywhere: trace the Rockies, the Alps, the "
+                "East African Rift, or the deep ocean trenches on the other end "
+                "of the scale.\n\n"
+                "Ask the map to take you somewhere, or toggle the relief layer "
+                "on and off to compare it with the basemap."
+            ),
+            dataset_source_url=GEBCO_URL,
+            center=(30.0, 25.0),
+            zoom=2.0,
+            colormap="terrain",
+            opacity=0.9,
+        ),
+        ChapterSeed(
+            type="prose",
+            title="Built from open data",
+            narrative=(
+                "Every layer here is open. Terrain relief comes from the "
+                "**Mapterhorn** global DEM, the 3D buildings from **OpenFreeMap** "
+                "vector tiles, and the elevation model from **GEBCO 2024**, "
+                "distributed as cloud-optimized GeoTIFFs via [source.coop]"
+                "(https://source.coop/alexgleith/gebco-2024).\n\n"
+                "Fork this story to reuse its 3D map states, or start from "
+                "scratch and add your own data on top. And keep using **Ask this "
+                "map** — it can navigate any published story like this one."
+            ),
+        ),
+    ],
+)
+
+
 ALL_STORIES: list[StorySeed] = [
     OCEAN_FLOOR_STORY,
     CITIES_STORY,
     OCEAN_FOREST_STORY,
     LAHAINA_STORY,
     ANTAKYA_STORY,
+    HIGH_PLACES_STORY,
 ]
 
 

--- a/ingestion/tests/services/test_example_stories.py
+++ b/ingestion/tests/services/test_example_stories.py
@@ -151,7 +151,7 @@ def test_seed_is_idempotent_on_repeat_call():
 
 
 def test_seed_skips_story_when_dataset_missing():
-    """With only GEBCO registered, only the GEBCO-only story seeds."""
+    """With only GEBCO registered, only stories whose datasets are all GEBCO seed."""
     _, factory = _make_db()
     session = factory()
     try:
@@ -173,7 +173,14 @@ def test_seed_skips_story_when_dataset_missing():
     finally:
         session.close()
 
-    assert titles == {OCEAN_FLOOR_STORY.title}
+    gebco_only = {
+        s.title
+        for s in ALL_STORIES
+        if {ch.dataset_source_url for ch in s.chapters if ch.dataset_source_url}
+        <= {GEBCO_URL}
+    }
+    assert OCEAN_FLOOR_STORY.title in gebco_only
+    assert titles == gebco_only
 
 
 def test_seed_populates_chapter_layer_config_with_resolved_dataset_id():

--- a/ingestion/tests/test_high_places_story_seed.py
+++ b/ingestion/tests/test_high_places_story_seed.py
@@ -1,0 +1,55 @@
+from src.services.example_stories import (
+    ALL_STORIES,
+    GEBCO_URL,
+    _build_chapter_dict,
+)
+
+
+def _story():
+    return next(s for s in ALL_STORIES if s.title == "Earth's high places")
+
+
+def test_high_places_story_meets_chapter_invariants():
+    chapters = _story().chapters
+    assert 6 <= len(chapters) <= 10
+    assert {"scrollytelling", "prose", "map"} <= {c.type for c in chapters}
+
+
+def test_high_places_exercises_all_three_3d_features():
+    chapters = _story().chapters
+    assert any(c.globe for c in chapters)
+    assert any(c.terrain for c in chapters)
+    assert any(c.buildings for c in chapters)
+
+
+def test_terrain_chapters_carry_no_data_layer():
+    # A chapter with a data overlay force-disables terrain (allowTerrain policy),
+    # so terrain stops must be scene-setting only.
+    for ch in _story().chapters:
+        if ch.terrain:
+            assert ch.dataset_source_url is None
+
+
+def test_only_referenced_dataset_is_gebco():
+    urls = {ch.dataset_source_url for ch in _story().chapters if ch.dataset_source_url}
+    assert urls == {GEBCO_URL}
+
+
+def test_3d_fields_flow_into_map_state():
+    globe_ch = next(c for c in _story().chapters if c.globe)
+    terrain_ch = next(c for c in _story().chapters if c.terrain)
+    buildings_ch = next(c for c in _story().chapters if c.buildings)
+
+    assert _build_chapter_dict(globe_ch, order=0, dataset_id=None)["map_state"]["globe"]
+    assert _build_chapter_dict(terrain_ch, order=0, dataset_id=None)["map_state"][
+        "terrain"
+    ] == {"enabled": True, "exaggeration": 1.5}
+    assert _build_chapter_dict(buildings_ch, order=0, dataset_id=None)["map_state"][
+        "buildings"
+    ]
+
+
+def test_gebco_map_chapter_builds_layer_config():
+    ch = next(c for c in _story().chapters if c.dataset_source_url == GEBCO_URL)
+    built = _build_chapter_dict(ch, order=0, dataset_id="ds-gebco")
+    assert built["layer_config"]["dataset_id"] == "ds-gebco"


### PR DESCRIPTION
## Example story: "Earth's high places"

Seeds a new `is_example=True` story (visible in every workspace, forkable) that showcases the **3D basemap features** from #555/#556 and serves as a demo target for the **"Ask this map"** reader agent from #557.

### Chapters

1. **prose** — intro; points readers at the 3D scene and the Ask-this-map button.
2. **globe** — spin the planet; mountain belts as continental seams.
3. **terrain** — the Himalaya (Everest), exaggerated relief, pitched view, no data overlay.
4. **terrain** — the Andes (Aconcagua), same treatment.
5. **buildings** — Kathmandu in 3D extruded footprints.
6. **map** — free-explore over GEBCO 2024 global relief.
7. **prose** — open-data credits (Mapterhorn DEM, OpenFreeMap buildings, GEBCO) + fork/ask hints.

### How it exercises "Ask this map"

The chat feature is globally gated (`CHAT_ENABLED` + key), so it lights up on any published story automatically — no per-story config. On this story the agent demonstrates the **navigation tools** (fly between the peaks, jump to chapters, toggle the relief layer, highlight) and **answering from story context** (what a chapter shows, how many chapters, where a range is).

**Deliberately not wired:** the agent's raster/vector *data-value* tools (`query_point`, `get_area_statistics`, `query_features`). Every example dataset is a remote pgSTAC mosaic / PMTiles with no `cog_url` or tipg collection (only the upload-conversion pipeline sets `cog_url`), so those tools can't return values on example data. The narrative therefore invites navigation/context questions, not "what's the value here?" — nothing misleading ships. A point-queryable example dataset would be a separate follow-up.

### Notes

- Terrain chapters carry **no data overlay** — a data layer force-disables terrain via the `chapterAllowsTerrain` policy, so terrain stops are scene-setting only. Covered by a test.
- Reuses the existing `ChapterSeed` `terrain`/`globe`/`buildings` fields and the already-registered GEBCO example dataset — no new dataset registration, no schema change.
- On re-seed, `seed_example_stories` refreshes existing example rows in place by title, so this appears on the next startup poll without a wipe.

### Tests

`ingestion/tests/test_high_places_story_seed.py` — chapter invariants, all three 3D features present, terrain-chapters-have-no-data policy, GEBCO-only dataset ref, and 3D fields flowing into `map_state`. Full: `uv run pytest` green for the story suite; ruff check + format clean.

### Verification still owed (user's Mac — VM has no GPU)

The 3D rendering (globe projection, terrain relief, extruded buildings) and the chat navigation can only be smoke-tested on a machine with a GPU. Suggested: with the stack running + `CHAT_ENABLED=true`, open "Earth's high places", scroll through, and ask the agent to "fly to the Andes" / "go to the buildings chapter".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new example story featuring a 3D tour of the world’s major mountains, with a mix of prose, scrollytelling, and map-based chapters.
  * Included the story in the existing example story set so it appears with the other seeded content.

* **Tests**
  * Added coverage for the new story to verify chapter structure, 3D feature variations, and map-state behavior.
  * Updated story seeding tests to be data-driven when only the GEBCO dataset is available, ensuring only GEBCO-backed stories are seeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->