### PR TITLE
fix: carry story overlays into portable export, accept GPX/LAS uploads, validate overlay refs

### DIFF
--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -12,6 +12,9 @@ const ALLOWED_EXTENSIONS = [
   ".nc",
   ".h5",
   ".hdf5",
+  ".las",
+  ".laz",
+  ".gpx",
 ];
 const RASTER_EXTENSIONS = [".tif", ".tiff", ".nc", ".h5", ".hdf5"];
 

--- a/frontend/src/components/__tests__/FileUploader.test.tsx
+++ b/frontend/src/components/__tests__/FileUploader.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { system } from "../../theme";
+import { FileUploader } from "../FileUploader";
+
+function renderUploader() {
+  const onFileSelected = vi.fn();
+  const { container } = render(
+    <ChakraProvider value={system}>
+      <FileUploader
+        onFileSelected={onFileSelected}
+        onFilesSelected={vi.fn()}
+        onUrlSubmitted={vi.fn()}
+      />
+    </ChakraProvider>
+  );
+  const input = container.querySelector(
+    'input[type="file"]'
+  ) as HTMLInputElement;
+  return { onFileSelected, input };
+}
+
+describe("FileUploader accepted formats", () => {
+  it("accepts a .gpx trajectory file", () => {
+    const { onFileSelected, input } = renderUploader();
+    const file = new File(["<gpx/>"], "track.gpx", { type: "application/gpx+xml" });
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(onFileSelected).toHaveBeenCalledWith(file);
+  });
+
+  it("accepts a .laz point-cloud file", () => {
+    const { onFileSelected, input } = renderUploader();
+    const file = new File(["x"], "scan.laz", { type: "application/octet-stream" });
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(onFileSelected).toHaveBeenCalledWith(file);
+  });
+
+  it("rejects an unsupported extension", () => {
+    const { onFileSelected, input } = renderUploader();
+    const file = new File(["x"], "notes.txt", { type: "text/plain" });
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(onFileSelected).not.toHaveBeenCalled();
+    expect(screen.getByText(/unsupported format/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/FileUploader.test.tsx
+++ b/frontend/src/components/__tests__/FileUploader.test.tsx
@@ -24,14 +24,18 @@ function renderUploader() {
 describe("FileUploader accepted formats", () => {
   it("accepts a .gpx trajectory file", () => {
     const { onFileSelected, input } = renderUploader();
-    const file = new File(["<gpx/>"], "track.gpx", { type: "application/gpx+xml" });
+    const file = new File(["<gpx/>"], "track.gpx", {
+      type: "application/gpx+xml",
+    });
     fireEvent.change(input, { target: { files: [file] } });
     expect(onFileSelected).toHaveBeenCalledWith(file);
   });
 
   it("accepts a .laz point-cloud file", () => {
     const { onFileSelected, input } = renderUploader();
-    const file = new File(["x"], "scan.laz", { type: "application/octet-stream" });
+    const file = new File(["x"], "scan.laz", {
+      type: "application/octet-stream",
+    });
     fireEvent.change(input, { target: { files: [file] } });
     expect(onFileSelected).toHaveBeenCalledWith(file);
   });

--- a/frontend/src/lib/story/__tests__/cngRcAdapter.test.ts
+++ b/frontend/src/lib/story/__tests__/cngRcAdapter.test.ts
@@ -145,6 +145,51 @@ describe("cngRcToStory", () => {
     expect(chapter.layer_config.dataset_id).toBe("");
   });
 
+  it("carries a chapter's extra layers into overlays", () => {
+    const config = makeConfig({
+      chapters: [
+        {
+          id: "ch-1",
+          type: "map",
+          title: "Chapter 1",
+          body: "",
+          map: { center: [0, 0], zoom: 3 },
+          layers: ["primary", "boundary", "watershed"],
+        },
+      ],
+      layers: {
+        primary: makeLayer({
+          type: "raster-cog",
+          source_url: "https://example.com/data.tif",
+        }),
+        boundary: makeLayer({
+          type: "pmtiles",
+          source_url: "https://example.com/admin.pmtiles",
+          render: {
+            colormap: null,
+            rescale: null,
+            opacity: 0.5,
+            band: null,
+            timestep: null,
+          },
+        }),
+        watershed: makeLayer({
+          type: "vector-geoparquet",
+          source_url: "https://example.com/basins.parquet",
+        }),
+      },
+    });
+
+    const { story } = cngRcToStory(config);
+    const chapter = story.chapters[0];
+    if (chapter.type !== "map") throw new Error("expected map");
+    expect(chapter.layer_config.connection_id).toBe("portable-primary");
+    expect(chapter.overlays).toEqual([
+      { connection_id: "portable-boundary", opacity: 0.5, visible: true },
+      { connection_id: "portable-watershed", opacity: 1, visible: true },
+    ]);
+  });
+
   it("synthesizes a Connection for each layer with a usable URL", () => {
     const config = makeConfig({
       layers: {

--- a/frontend/src/lib/story/cngRcAdapter.ts
+++ b/frontend/src/lib/story/cngRcAdapter.ts
@@ -13,7 +13,13 @@ import {
   createProseChapter,
   createScrollytellingChapter,
 } from "./types";
-import type { Chapter, LayerConfig, MapState, Story } from "./types";
+import type {
+  Chapter,
+  LayerConfig,
+  MapState,
+  OverlayConfig,
+  Story,
+} from "./types";
 
 export interface PortableStoryBundle {
   story: Story;
@@ -133,6 +139,24 @@ function buildLayerConfig(
   return config;
 }
 
+function buildOverlays(
+  layerKeys: string[],
+  layers: Record<string, CngRcLayer>,
+  synthesizedKeys: Set<string>
+): OverlayConfig[] {
+  const overlays: OverlayConfig[] = [];
+  for (const key of layerKeys) {
+    if (!synthesizedKeys.has(key)) continue;
+    const layer = layers[key];
+    overlays.push({
+      connection_id: `portable-${key}`,
+      opacity: layer?.render.opacity ?? 1,
+      visible: true,
+    });
+  }
+  return overlays;
+}
+
 function convertChapter(
   ch: CngRcChapter,
   index: number,
@@ -156,6 +180,7 @@ function convertChapter(
     firstLayer,
     hasConnection
   );
+  const overlays = buildOverlays(ch.layers.slice(1), layers, synthesizedKeys);
   const mapState = buildMapState(ch.map);
 
   // image/video/chart chapters fall back to prose: portable asset hosting is deferred.
@@ -165,12 +190,14 @@ function convertChapter(
         ...baseOverrides,
         map_state: mapState,
         layer_config: layerConfig,
+        overlays,
       });
     case "map":
       return createMapChapter({
         ...baseOverrides,
         map_state: mapState,
         layer_config: layerConfig,
+        overlays,
       });
     case "prose":
     case "image":

--- a/frontend/src/lib/story/rendering.ts
+++ b/frontend/src/lib/story/rendering.ts
@@ -79,7 +79,10 @@ function buildOverlayLayer(
     const conn = connectionMap.get(overlay.connection_id);
     if (!conn) return null;
     if (!(
-      (conn.connection_type === "pmtiles" && conn.tile_type === "vector") ||
+      // Overlays are vector by construction; a portable-exported pmtiles
+      // overlay carries a null tile_type, so accept pmtiles unless it is
+      // explicitly raster.
+      (conn.connection_type === "pmtiles" && conn.tile_type !== "raster") ||
       conn.connection_type === "xyz_vector"
     )) {
       return null;

--- a/ingestion/src/routes/validation.py
+++ b/ingestion/src/routes/validation.py
@@ -59,7 +59,9 @@ def validate_layer_config(body: ValidateLayerConfigBody, request: Request):
         session.close()
 
 
-def _validate_overlay_ref(session, overlay: OverlayRef, workspace_id: str) -> str | None:
+def _validate_overlay_ref(
+    session, overlay: OverlayRef, workspace_id: str
+) -> str | None:
     """Return an error string if an overlay's referenced layer does not resolve."""
     if overlay.dataset_id:
         ds = (

--- a/ingestion/src/routes/validation.py
+++ b/ingestion/src/routes/validation.py
@@ -5,9 +5,15 @@ from pydantic import BaseModel
 from sqlalchemy import or_
 
 from src.dependencies import get_session
+from src.models.connection import ConnectionRow
 from src.models.dataset import DatasetRow
 
 router = APIRouter(prefix="/api")
+
+
+class OverlayRef(BaseModel):
+    dataset_id: str | None = None
+    connection_id: str | None = None
 
 
 class ValidateLayerConfigBody(BaseModel):
@@ -16,6 +22,7 @@ class ValidateLayerConfigBody(BaseModel):
     rescale_min: float | None = None
     rescale_max: float | None = None
     color_mode: str | None = None
+    overlays: list[OverlayRef] = []
 
 
 @router.post("/validate-layer-config")
@@ -43,6 +50,43 @@ def validate_layer_config(body: ValidateLayerConfigBody, request: Request):
         )
         if ds is None:
             return {"valid": False, "error": f"Dataset '{body.dataset_id}' not found"}
+        for overlay in body.overlays:
+            error = _validate_overlay_ref(session, overlay, workspace_id)
+            if error:
+                return {"valid": False, "error": error}
         return {"valid": True}
     finally:
         session.close()
+
+
+def _validate_overlay_ref(session, overlay: OverlayRef, workspace_id: str) -> str | None:
+    """Return an error string if an overlay's referenced layer does not resolve."""
+    if overlay.dataset_id:
+        ds = (
+            session.query(DatasetRow)
+            .filter(
+                DatasetRow.id == overlay.dataset_id,
+                or_(
+                    DatasetRow.workspace_id == workspace_id,
+                    DatasetRow.is_example.is_(True),
+                ),
+            )
+            .first()
+        )
+        if ds is None:
+            return f"Overlay dataset '{overlay.dataset_id}' not found"
+    if overlay.connection_id:
+        conn = (
+            session.query(ConnectionRow)
+            .filter(
+                ConnectionRow.id == overlay.connection_id,
+                or_(
+                    ConnectionRow.workspace_id == workspace_id,
+                    ConnectionRow.is_example.is_(True),
+                ),
+            )
+            .first()
+        )
+        if conn is None:
+            return f"Overlay connection '{overlay.connection_id}' not found"
+    return None

--- a/ingestion/tests/test_validate_layer_config.py
+++ b/ingestion/tests/test_validate_layer_config.py
@@ -71,3 +71,65 @@ def test_validate_layer_config_valid_dataset(client, db_session):
     assert resp.status_code == 200
     body = resp.json()
     assert body["valid"] is True
+
+
+def test_validate_layer_config_rejects_dangling_overlay(client, db_session):
+    from src.models.dataset import DatasetRow
+
+    ds = DatasetRow(
+        id="ds-primary",
+        filename="test.tif",
+        dataset_type="raster",
+        format_pair="geotiff-cog",
+        tile_url="/cog/tiles/{z}/{x}/{y}.png",
+        workspace_id="testABCD",
+    )
+    db_session.add(ds)
+    db_session.commit()
+
+    resp = client.post(
+        "/api/validate-layer-config",
+        json={
+            "dataset_id": "ds-primary",
+            "colormap": "viridis",
+            "overlays": [{"connection_id": "missing-conn"}],
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False
+    assert "error" in body
+
+
+def test_validate_layer_config_accepts_resolvable_overlay(client, db_session):
+    from src.models.dataset import DatasetRow
+
+    primary = DatasetRow(
+        id="ds-primary2",
+        filename="test.tif",
+        dataset_type="raster",
+        format_pair="geotiff-cog",
+        tile_url="/cog/tiles/{z}/{x}/{y}.png",
+        workspace_id="testABCD",
+    )
+    overlay_ds = DatasetRow(
+        id="ds-overlay",
+        filename="boundary.geojson",
+        dataset_type="vector",
+        format_pair="geojson-to-geoparquet",
+        tile_url="/vector/tiles/{z}/{x}/{y}",
+        workspace_id="testABCD",
+    )
+    db_session.add_all([primary, overlay_ds])
+    db_session.commit()
+
+    resp = client.post(
+        "/api/validate-layer-config",
+        json={
+            "dataset_id": "ds-primary2",
+            "colormap": "viridis",
+            "overlays": [{"dataset_id": "ds-overlay"}],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["valid"] is True


### PR DESCRIPTION
## Summary

Three gaps found while auditing the recently shipped **overlay layers** (#566) and **movement tracks** (#567) features. Each is independent.

### 1. Story overlays were dropped from the portable / embedded export
The backend export already writes overlay layers into a chapter's `cng-rc` layer list ([`story_export.py`](../blob/main/ingestion/src/services/story_export.py)), but the frontend importer `cngRcToStory` only mapped `ch.layers[0]` to `layer_config` and **ignored the rest** — so an exported or iframe-embedded story silently lost its context overlays.

- `cngRcAdapter.ts`: carry a chapter's extra layers into `chapter.overlays`.
- `rendering.ts`: broaden `buildOverlayLayer` to accept a portable-exported pmtiles overlay (which carries a `null` `tile_type`); real raster pmtiles (`tile_type: "raster"`) are still excluded.

⚠️ **Caveat (needs a browser smoke on a real export):** this makes the common case — pmtiles admin-boundary context layers — carry through and render. Two portable-specific limits remain, matching the COG limitation already documented in the adapter header: (a) `vector-geoparquet` overlays need the geoparquet loader (not `buildVectorLayer`) and are **not** yet rendered in portable mode; (b) external pmtiles may depend on the viewer subdomain proxying the source. Both are follow-ups.

### 2. GPX / LAS / LAZ uploads were rejected
`FileUploader`'s `ALLOWED_EXTENSIONS` gates both the file picker **and** `handleFile` validation, and it listed neither `.gpx` nor `.las`/`.laz` — so the shipped movement-tracks and point-cloud features had **no working upload path in this component** (files were rejected with "Unsupported format", even via drag-and-drop). Added `.las`, `.laz`, `.gpx` (all already supported by the backend detector).

### 3. `validate-layer-config` ignored overlays
Added an optional `overlays` list to the request body and reject dangling overlay dataset/connection references. Additive and backward-compatible.

## Testing
- Frontend: full suite green (**1069 tests**), `tsc --noEmit` clean, prettier clean. New tests: overlay carry-through in `cngRcAdapter.test.ts`, accepted-format cases in a new `FileUploader.test.tsx`.
- Backend: overlay/story/validation tests green (50), incl. two new dangling/valid overlay-ref cases. (Unrelated `test_scanner`/`test_temporal` errors in my local worktree venv are a missing `xarray` dep — they pass on `main` and in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for uploading `.las`, `.laz`, and `.gpx` files.
  * Added overlay references to layer configuration validation via an optional `overlays` input.
  * Enhanced story/map chapter overlay generation to include additional layers.
* **Bug Fixes**
  * Improved handling of `pmtiles` overlays by treating more non-raster tile types as vector-compatible.
  * Validation now returns `valid: false` for unresolved overlay dataset/connection references.
* **Tests**
  * Added/expanded test coverage for file uploads, overlay conversion, and the validation endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->