### PR TITLE
feat: add Esri World Imagery satellite basemap

### DIFF
--- a/frontend/src/components/MapShell.test.tsx
+++ b/frontend/src/components/MapShell.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { BASEMAPS, BASEMAP_OPTIONS } from "./MapShell";
+
+describe("BASEMAPS", () => {
+  it("keeps the existing CARTO vector basemaps as style-URL strings", () => {
+    expect(typeof BASEMAPS.streets).toBe("string");
+    expect(typeof BASEMAPS.satellite).toBe("string");
+    expect(typeof BASEMAPS.dark).toBe("string");
+  });
+
+  it("exposes imagery as an Esri World Imagery raster style with attribution", () => {
+    const style = BASEMAPS.imagery;
+    expect(typeof style).toBe("object");
+    if (typeof style === "string") throw new Error("expected a style object");
+
+    expect(style.version).toBe(8);
+
+    const source = style.sources["esri-imagery"];
+    expect(source.type).toBe("raster");
+    if (source.type !== "raster") throw new Error("expected a raster source");
+
+    expect(source.tiles?.[0]).toContain("server.arcgisonline.com");
+    expect(source.tiles?.[0]).toContain("World_Imagery");
+    expect(source.attribution).toBeTruthy();
+
+    expect(style.layers.some((l) => l.type === "raster")).toBe(true);
+  });
+});
+
+describe("BASEMAP_OPTIONS", () => {
+  it("offers a Satellite option keyed to imagery alongside the original three", () => {
+    const keys = BASEMAP_OPTIONS.map((o) => o.key);
+    expect(keys).toEqual(
+      expect.arrayContaining(["streets", "satellite", "dark", "imagery"])
+    );
+
+    const imagery = BASEMAP_OPTIONS.find((o) => o.key === "imagery");
+    expect(imagery?.label).toBe("Satellite");
+  });
+});

--- a/frontend/src/components/MapShell.test.tsx
+++ b/frontend/src/components/MapShell.test.tsx
@@ -4,9 +4,15 @@ import { BASEMAPS, BASEMAP_OPTIONS } from "./MapShell";
 
 describe("BASEMAPS", () => {
   it("keeps the existing CARTO vector basemaps as style-URL strings", () => {
-    expect(typeof BASEMAPS.streets).toBe("string");
-    expect(typeof BASEMAPS.satellite).toBe("string");
-    expect(typeof BASEMAPS.dark).toBe("string");
+    expect(BASEMAPS.streets).toBe(
+      "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
+    );
+    expect(BASEMAPS.satellite).toBe(
+      "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json"
+    );
+    expect(BASEMAPS.dark).toBe(
+      "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
+    );
   });
 
   it("exposes imagery as an Esri World Imagery raster style with attribution", () => {
@@ -24,7 +30,15 @@ describe("BASEMAPS", () => {
     expect(source.tiles?.[0]).toContain("World_Imagery");
     expect(source.attribution).toBeTruthy();
 
-    expect(style.layers.some((l) => l.type === "raster")).toBe(true);
+    expect(style.layers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "esri-imagery",
+          type: "raster",
+          source: "esri-imagery",
+        }),
+      ])
+    );
   });
 });
 

--- a/frontend/src/components/MapShell.tsx
+++ b/frontend/src/components/MapShell.tsx
@@ -1,10 +1,29 @@
 import { Box, Flex } from "@chakra-ui/react";
+import type { StyleSpecification } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 
-export const BASEMAPS: Record<string, string> = {
+const ESRI_WORLD_IMAGERY: StyleSpecification = {
+  version: 8,
+  sources: {
+    "esri-imagery": {
+      type: "raster",
+      tiles: [
+        "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+      ],
+      tileSize: 256,
+      maxzoom: 19,
+      attribution:
+        "Tiles &copy; Esri &mdash; Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community",
+    },
+  },
+  layers: [{ id: "esri-imagery", type: "raster", source: "esri-imagery" }],
+};
+
+export const BASEMAPS: Record<string, string | StyleSpecification> = {
   streets: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
   satellite: "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json",
   dark: "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
+  imagery: ESRI_WORLD_IMAGERY,
 };
 
 // Mapterhorn hosted terrain-RGB (terrarium encoding). Single constant so
@@ -23,10 +42,11 @@ interface BasemapPickerProps {
   onChange: (value: string) => void;
 }
 
-const BASEMAP_OPTIONS = [
+export const BASEMAP_OPTIONS = [
   { key: "streets", label: "Light", bg: "#e8e8e8" },
   { key: "satellite", label: "Color", bg: "#a8c8e8" },
   { key: "dark", label: "Dark", bg: "#2d2d2d" },
+  { key: "imagery", label: "Satellite", bg: "#3d5a45" },
 ];
 
 export function BasemapPicker({ value, onChange }: BasemapPickerProps) {


### PR DESCRIPTION
## What

Adds a real **satellite-imagery basemap** (Esri World Imagery) to the map basemap picker.

Until now the picker's `satellite` key actually pointed at CARTO's *Voyager* vector street map (labeled "Color"), so there was no true imagery option. This adds a new `imagery` basemap, surfaced as a **"Satellite"** swatch.

## How

- New `imagery` entry in `BASEMAPS` — an inline MapLibre style object with a single Esri World Imagery raster source (`server.arcgisonline.com/.../World_Imagery`), including the required Esri attribution.
- Widened the `BASEMAPS` value type from `Record<string, string>` to `Record<string, string | StyleSpecification>`, since a raster basemap is a style object rather than a style-URL string.
- Added the `{ key: "imagery", label: "Satellite" }` picker option.

The three existing CARTO basemap keys (`streets`, `satellite`, `dark`) are **untouched**, so any story persisted with an existing `basemap` value renders exactly as before — no migration.

## Notes

- No CSP/Caddy change needed — the CSP already permits HTTPS tile/image sources.
- Switching to a raster basemap triggers MapLibre `setStyle`, which the app already handles (deck.gl layers/3D re-apply on style reload).

## Testing

- New `MapShell.test.tsx`: asserts `BASEMAPS.imagery` is a valid Esri raster style with attribution, the original three keys stay string URLs, and the picker offers a "Satellite" option.
- Full frontend suite green (1072 tests), `tsc --noEmit` clean, prettier + eslint clean.
- **Visual/WebGL smoke not run on CI** (headless VM has no GPU) — verified interactively; see PR checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Satellite” basemap option to the basemap picker, backed by ESRI World Imagery.
  * Satellite imagery now includes attribution and raster styling details for the map view.

* **Tests**
  * Added a new test suite validating the available basemaps and confirming the presence and configuration of the “Satellite” imagery option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->