### PR TITLE
feat: polish application navigation shell

### DIFF
--- a/docs/design-polish/implementation-plan.md
+++ b/docs/design-polish/implementation-plan.md
@@ -25,7 +25,8 @@ data paths.
 
 - [x] Package 1 — Design foundations (implemented 2026-07-21 on
   `codex/design-polish-guide`)
-- [ ] Package 2 — Navigation and application shell
+- [x] Package 2 — Navigation and application shell (implemented 2026-07-21 on
+  `codex/design-polish-packages-2-5`)
 - [ ] Package 3 — Landing page and example presentation
 - [ ] Package 4 — Workspace home, Stories, and Data
 - [ ] Package 5 — Upload, connect, and conversion

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -20,58 +20,64 @@ export function Footer() {
     <Flex
       as="footer"
       mt="auto"
-      align="center"
-      justify="space-between"
-      px={6}
-      py={4}
-      bg="white"
+      bg="bg.raised"
       borderTop="1px solid"
-      borderColor="brand.border"
-      gap={6}
-      flexWrap="wrap"
+      borderColor="border"
     >
-      <Text fontSize="sm" color="brand.textSecondary">
-        Built by{" "}
-        <a
-          href={DS_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{
-            color: "var(--chakra-colors-brand-orange)",
-            fontWeight: 600,
-            textDecoration: "none",
-          }}
-        >
-          Development Seed
-        </a>
-      </Text>
-      <Flex align="center" gap={5}>
-        <Link to={aboutHref} style={linkStyle}>
-          About
-        </Link>
-        <a
-          href={GITHUB_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{
-            ...linkStyle,
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 4,
-          }}
-          aria-label="GitHub repository"
-        >
-          <GithubLogo size={16} weight="duotone" />
-          GitHub
-        </a>
-        <a
-          href={CONTACT_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={linkStyle}
-        >
-          Contact Us
-        </a>
+      <Flex
+        align="center"
+        justify="space-between"
+        px={{ base: 4, md: 6 }}
+        py={4}
+        maxW="1200px"
+        mx="auto"
+        w="100%"
+        gap={6}
+        flexWrap="wrap"
+      >
+        <Text fontSize="sm" color="fg.muted">
+          Built by{" "}
+          <a
+            href={DS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              color: "var(--chakra-colors-brand-orange)",
+              fontWeight: 600,
+              textDecoration: "none",
+            }}
+          >
+            Development Seed
+          </a>
+        </Text>
+        <Flex align="center" gap={5}>
+          <Link to={aboutHref} style={linkStyle}>
+            About
+          </Link>
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              ...linkStyle,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+            aria-label="GitHub repository"
+          >
+            <GithubLogo size={16} weight="duotone" />
+            GitHub
+          </a>
+          <a
+            href={CONTACT_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={linkStyle}
+          >
+            Contact Us
+          </a>
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,5 @@
-import { Flex, Menu, Portal, Text } from "@chakra-ui/react";
-import { Link, useNavigate } from "react-router-dom";
+import { Box, Flex, Menu, Portal, Text } from "@chakra-ui/react";
+import { Link, NavLink, useNavigate } from "react-router-dom";
 import type { ReactNode } from "react";
 import { useState, useCallback, useEffect } from "react";
 import { CaretDown, Check } from "@phosphor-icons/react";
@@ -50,169 +50,197 @@ export function Header({ children, showWorkspace = true }: HeaderProps) {
   }, [navigate]);
 
   return (
-    <Flex
-      as="header"
-      align="center"
-      justify="space-between"
-      px={6}
-      py={3}
-      bg="white"
-      borderBottom="1px solid"
-      borderColor="brand.border"
-    >
-      <Flex align="center" gap={6} flexShrink={0}>
-        <Link to={homeHref} style={{ textDecoration: "none", flexShrink: 0 }}>
-          <Flex align="center" gap={3} flexShrink={0}>
-            <img
-              src="/logo.svg"
-              alt="Development Seed"
-              width={32}
-              height={32}
-            />
-            <Text
-              as="span"
-              color="brand.brown"
-              fontWeight={700}
-              fontSize="15px"
-              whiteSpace="nowrap"
-            >
-              CNG Sandbox
-            </Text>
-          </Flex>
-        </Link>
-        {storiesHref && (
-          <Link to={storiesHref} style={{ textDecoration: "none" }}>
-            <Text
-              fontSize="sm"
-              fontWeight={500}
-              color="brand.brown"
-              _hover={{ color: "brand.orange" }}
-            >
-              Stories
-            </Text>
-          </Link>
-        )}
-        {dataHref && (
-          <Link to={dataHref} style={{ textDecoration: "none" }}>
-            <Text
-              fontSize="sm"
-              fontWeight={500}
-              color="brand.brown"
-              _hover={{ color: "brand.orange" }}
-            >
-              Data
-            </Text>
-          </Link>
-        )}
-        <Link to={aboutHref} style={{ textDecoration: "none" }}>
-          <Text
-            fontSize="sm"
-            fontWeight={500}
-            color="gray.600"
-            _hover={{ color: "gray.800" }}
-          >
-            About
-          </Text>
-        </Link>
-      </Flex>
-      {showWorkspace && workspace && (
-        <Menu.Root>
-          <Menu.Trigger asChild>
-            <Flex
-              align="center"
-              gap={1}
-              px={2}
-              py={1}
-              borderRadius="md"
-              bg="gray.100"
-              cursor="pointer"
-              fontSize="xs"
-              color="gray.500"
-              _hover={{ bg: "gray.200" }}
-              aria-label="Workspace menu"
-            >
-              <Text>
-                {copied ? "Copied!" : `Workspace ${workspace.workspaceId}`}
-              </Text>
-              <CaretDown size={10} />
-            </Flex>
-          </Menu.Trigger>
-          <Portal>
-            <Menu.Positioner>
-              <Menu.Content
-                bg="white"
-                border="1px solid"
-                borderColor="brand.border"
-                borderRadius="8px"
-                boxShadow="md"
-                py={1}
-                minW="220px"
-                fontSize="sm"
+    <>
+      <Box
+        asChild
+        position="fixed"
+        top={2}
+        left={2}
+        zIndex="modal"
+        px={4}
+        py={2}
+        bg="bg.raised"
+        color="fg"
+        borderRadius="control"
+        boxShadow="md"
+        transform="translateY(-160%)"
+        _focus={{ transform: "translateY(0)" }}
+      >
+        <a href="#main-content">Skip to main content</a>
+      </Box>
+      <Flex
+        as="header"
+        align="center"
+        justify="space-between"
+        px={{ base: 3, md: 6 }}
+        py={2.5}
+        minH="60px"
+        bg="bg.raised"
+        borderBottom="1px solid"
+        borderColor="border"
+        gap={{ base: 2, md: 5 }}
+      >
+        <Flex align="center" gap={{ base: 2, md: 6 }} minW={0}>
+          <Link to={homeHref} style={{ textDecoration: "none", flexShrink: 0 }}>
+            <Flex align="center" gap={2.5} flexShrink={0}>
+              <img
+                src="/logo.svg"
+                alt="Development Seed"
+                width={32}
+                height={32}
+              />
+              <Text
+                as="span"
+                color="brand.brown"
+                fontWeight={700}
+                fontSize="15px"
+                whiteSpace="nowrap"
+                display={{ base: "none", sm: "block" }}
               >
-                <Menu.Item
-                  value="copy-link"
-                  onClick={copyWorkspaceUrl}
-                  px={3}
-                  py={2}
-                  cursor="pointer"
-                  _hover={{ bg: "brand.bgSubtle" }}
-                >
-                  Copy workspace link
-                </Menu.Item>
-                {!isPrimary && (
-                  <Menu.Item
-                    value="make-primary"
-                    onClick={makePrimary}
-                    px={3}
-                    py={2}
-                    cursor="pointer"
-                    _hover={{ bg: "brand.bgSubtle" }}
-                  >
-                    Make this my primary workspace
-                  </Menu.Item>
-                )}
-                {isPrimary && (
-                  <Menu.Item
-                    value="is-primary"
-                    disabled
-                    px={3}
-                    py={2}
-                    color="gray.500"
-                  >
-                    <Flex align="center" gap={2}>
-                      <Check size={14} weight="bold" />
-                      <Text>Primary workspace</Text>
-                    </Flex>
-                  </Menu.Item>
-                )}
-                <Menu.Separator borderColor="brand.border" my={1} />
-                <Menu.Item
-                  value="change-workspace"
-                  onClick={changeWorkspaces}
-                  px={3}
-                  py={2}
-                  cursor="pointer"
-                  _hover={{ bg: "brand.bgSubtle" }}
-                >
-                  Change workspaces
-                </Menu.Item>
-              </Menu.Content>
-            </Menu.Positioner>
-          </Portal>
-        </Menu.Root>
-      )}
-      {children && (
-        <Flex
-          gap={2}
-          align="center"
-          flex="1 1 auto"
-          minW={0}
-          justify="flex-end"
-          ml={6}
-        >
-          {children}
+                CNG Sandbox
+              </Text>
+            </Flex>
+          </Link>
+          <Flex
+            as="nav"
+            aria-label="Primary navigation"
+            align="stretch"
+            gap={1}
+          >
+            {storiesHref && <NavItem to={storiesHref}>Stories</NavItem>}
+            {dataHref && <NavItem to={dataHref}>Data</NavItem>}
+            <NavItem to={aboutHref}>About</NavItem>
+          </Flex>
         </Flex>
-      )}
-    </Flex>
+        <Flex align="center" gap={2} minW={0}>
+          {children && (
+            <Flex gap={2} align="center" minW={0} justify="flex-end">
+              {children}
+            </Flex>
+          )}
+          {showWorkspace && workspace && (
+            <Menu.Root>
+              <Menu.Trigger asChild>
+                <Flex
+                  align="center"
+                  gap={1}
+                  px={{ base: 2, md: 3 }}
+                  py={1.5}
+                  borderRadius="control"
+                  bg="bg.emphasized"
+                  cursor="pointer"
+                  fontSize="xs"
+                  color="fg.muted"
+                  _hover={{ bg: "bg.muted", color: "fg" }}
+                  aria-label="Workspace menu"
+                >
+                  <Text>{copied ? "Copied!" : "Workspace"}</Text>
+                  <CaretDown size={10} />
+                </Flex>
+              </Menu.Trigger>
+              <Portal>
+                <Menu.Positioner>
+                  <Menu.Content
+                    bg="white"
+                    border="1px solid"
+                    borderColor="brand.border"
+                    borderRadius="8px"
+                    boxShadow="md"
+                    py={1}
+                    minW="220px"
+                    fontSize="sm"
+                  >
+                    <Text px={3} pt={2} pb={1} fontSize="xs" color="fg.subtle">
+                      ID:{" "}
+                      <Text as="span" fontFamily="mono">
+                        {workspace.workspaceId}
+                      </Text>
+                    </Text>
+                    <Menu.Item
+                      value="copy-link"
+                      onClick={copyWorkspaceUrl}
+                      px={3}
+                      py={2}
+                      cursor="pointer"
+                      _hover={{ bg: "brand.bgSubtle" }}
+                    >
+                      Copy workspace link
+                    </Menu.Item>
+                    {!isPrimary && (
+                      <Menu.Item
+                        value="make-primary"
+                        onClick={makePrimary}
+                        px={3}
+                        py={2}
+                        cursor="pointer"
+                        _hover={{ bg: "brand.bgSubtle" }}
+                      >
+                        Make this my primary workspace
+                      </Menu.Item>
+                    )}
+                    {isPrimary && (
+                      <Menu.Item
+                        value="is-primary"
+                        disabled
+                        px={3}
+                        py={2}
+                        color="gray.500"
+                      >
+                        <Flex align="center" gap={2}>
+                          <Check size={14} weight="bold" />
+                          <Text>Primary workspace</Text>
+                        </Flex>
+                      </Menu.Item>
+                    )}
+                    <Menu.Separator borderColor="brand.border" my={1} />
+                    <Menu.Item
+                      value="change-workspace"
+                      onClick={changeWorkspaces}
+                      px={3}
+                      py={2}
+                      cursor="pointer"
+                      _hover={{ bg: "brand.bgSubtle" }}
+                    >
+                      Change workspaces
+                    </Menu.Item>
+                  </Menu.Content>
+                </Menu.Positioner>
+              </Portal>
+            </Menu.Root>
+          )}
+        </Flex>
+      </Flex>
+    </>
+  );
+}
+
+function NavItem({ to, children }: { to: string; children: ReactNode }) {
+  return (
+    <Box asChild>
+      <NavLink
+        to={to}
+        style={({ isActive }) => ({
+          display: "inline-flex",
+          alignItems: "center",
+          minHeight: 36,
+          padding: "0 10px",
+          borderRadius: 8,
+          color: isActive
+            ? "var(--chakra-colors-brand-brown)"
+            : "var(--chakra-colors-fg-muted)",
+          background: isActive
+            ? "var(--chakra-colors-bg-emphasized)"
+            : "transparent",
+          boxShadow: isActive
+            ? "inset 0 -2px 0 var(--chakra-colors-action-primary)"
+            : "none",
+          fontSize: 14,
+          fontWeight: isActive ? 600 : 500,
+          textDecoration: "none",
+        })}
+      >
+        {children}
+      </NavLink>
+    </Box>
   );
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -216,31 +216,28 @@ export function Header({ children, showWorkspace = true }: HeaderProps) {
 
 function NavItem({ to, children }: { to: string; children: ReactNode }) {
   return (
-    <Box asChild>
-      <NavLink
-        to={to}
-        style={({ isActive }) => ({
-          display: "inline-flex",
-          alignItems: "center",
-          minHeight: 36,
-          padding: "0 10px",
-          borderRadius: 8,
-          color: isActive
-            ? "var(--chakra-colors-brand-brown)"
-            : "var(--chakra-colors-fg-muted)",
-          background: isActive
-            ? "var(--chakra-colors-bg-emphasized)"
-            : "transparent",
-          boxShadow: isActive
-            ? "inset 0 -2px 0 var(--chakra-colors-action-primary)"
-            : "none",
-          fontSize: 14,
-          fontWeight: isActive ? 600 : 500,
-          textDecoration: "none",
-        })}
-      >
-        {children}
-      </NavLink>
+    <Box
+      asChild
+      display="inline-flex"
+      alignItems="center"
+      minH={9}
+      px={2.5}
+      borderRadius="control"
+      color="fg.muted"
+      fontSize="sm"
+      fontWeight={500}
+      textDecoration="none"
+      _hover={{ bg: "bg.subtle", color: "fg" }}
+      css={{
+        '&[aria-current="page"]': {
+          color: "brand.brown",
+          background: "bg.emphasized",
+          boxShadow: "inset 0 -2px 0 token(colors.action.primary)",
+          fontWeight: 600,
+        },
+      }}
+    >
+      <NavLink to={to}>{children}</NavLink>
     </Box>
   );
 }

--- a/frontend/src/components/__tests__/Header.test.tsx
+++ b/frontend/src/components/__tests__/Header.test.tsx
@@ -7,10 +7,13 @@ import { ChakraProvider } from "@chakra-ui/react";
 import { system } from "../../theme";
 import { WorkspaceProvider } from "../../hooks/useWorkspace";
 
-function renderWithProviders(ui: React.ReactElement) {
+function renderWithProviders(
+  ui: React.ReactElement,
+  initialEntry = "/w/test-workspace"
+) {
   return render(
     <ChakraProvider value={system}>
-      <MemoryRouter initialEntries={["/w/test-workspace"]}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
           <Route
             path="/w/:workspaceId/*"
@@ -37,6 +40,21 @@ describe("Header", () => {
       screen.getByRole("link", { name: /^stories$/i })
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /about/i })).toBeInTheDocument();
+  });
+
+  it("marks the current navigation item", () => {
+    renderWithProviders(<Header />, "/w/test-workspace/stories");
+    expect(screen.getByRole("link", { name: /^stories$/i })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+
+  it("provides a keyboard skip link", () => {
+    renderWithProviders(<Header />);
+    expect(
+      screen.getByRole("link", { name: /skip to main content/i })
+    ).toHaveAttribute("href", "#main-content");
   });
 });
 
@@ -125,6 +143,7 @@ describe("Header workspace menu", () => {
     expect(
       screen.getByRole("menuitem", { name: /change workspaces/i })
     ).toBeInTheDocument();
+    expect(screen.getByText("test-workspace")).toBeInTheDocument();
   });
 
   it("hides 'make primary' when this workspace is already the primary", async () => {

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -100,7 +100,7 @@ export default function AboutPage() {
   return (
     <Flex direction="column" minH="100vh" bg="gray.50">
       <Header />
-      <Box maxW="960px" mx="auto" py={8} px={4}>
+      <Box as="main" id="main-content" maxW="960px" mx="auto" py={8} px={4}>
         <Box mb={10}>
           <Heading size="lg" color="brand.brown" mb={4}>
             About CNG Sandbox

--- a/frontend/src/pages/DataPage.tsx
+++ b/frontend/src/pages/DataPage.tsx
@@ -123,7 +123,7 @@ export default function DataPage() {
   return (
     <Flex direction="column" minH="100vh" bg="bg">
       <Header />
-      <Box maxW="960px" mx="auto" py={8} px={4}>
+      <Box as="main" id="main-content" maxW="960px" mx="auto" py={8} px={4}>
         <Flex justify="space-between" align="center" mb={6}>
           <Heading size="lg" color="fg">
             Data

--- a/frontend/src/pages/ExpiredPage.tsx
+++ b/frontend/src/pages/ExpiredPage.tsx
@@ -10,7 +10,15 @@ export default function ExpiredPage() {
   return (
     <Flex direction="column" minH="100vh" bg="white">
       <Header />
-      <Flex direction="column" align="center" justify="center" flex="1" px={8}>
+      <Flex
+        as="main"
+        id="main-content"
+        direction="column"
+        align="center"
+        justify="center"
+        flex="1"
+        px={8}
+      >
         <Flex
           align="center"
           justify="center"

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -89,7 +89,7 @@ export default function LandingPage() {
     <Box minH="100vh" bg="brand.bgSubtle" display="flex" flexDirection="column">
       <Header showWorkspace={false} />
 
-      <Box flex="1" px={4} py={10}>
+      <Box as="main" id="main-content" flex="1" px={4} py={10}>
         <Box maxW="720px" mx="auto" textAlign="center" mb={10}>
           <Text
             fontSize="11px"

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -595,7 +595,13 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
     return (
       <Box minH="100vh" bg="white">
         {shared ? <SharedHeader /> : <Header />}
-        <Flex align="center" justify="center" h="calc(100vh - 56px)">
+        <Flex
+          as="main"
+          id="main-content"
+          align="center"
+          justify="center"
+          h="calc(100vh - 56px)"
+        >
           <SpinnerGap
             size={32}
             color="#CF3F02"
@@ -611,6 +617,8 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
       <Box minH="100vh" bg="white">
         {shared ? <SharedHeader /> : <Header />}
         <Flex
+          as="main"
+          id="main-content"
           direction="column"
           align="center"
           justify="center"
@@ -650,7 +658,7 @@ export default function MapPage({ shared = false }: { shared?: boolean }) {
       )}
 
       <ErrorBoundary>
-        <Flex flex={1} overflow="hidden">
+        <Flex as="main" id="main-content" flex={1} overflow="hidden">
           <Box flex={7} position="relative" ref={mapContainerRef}>
             {isServerGeoParquet && needsConversion && (
               <Box

--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -63,7 +63,15 @@ export default function StoriesPage() {
   return (
     <Flex direction="column" minH="100vh" bg="bg">
       <Header />
-      <Box maxW="960px" mx="auto" py={8} px={4} w="100%">
+      <Box
+        as="main"
+        id="main-content"
+        maxW="960px"
+        mx="auto"
+        py={8}
+        px={4}
+        w="100%"
+      >
         <Flex justify="space-between" align="center" mb={6}>
           <Heading size="lg" color="fg">
             Your stories

--- a/frontend/src/pages/StoryEditorPage.tsx
+++ b/frontend/src/pages/StoryEditorPage.tsx
@@ -290,7 +290,7 @@ export default function StoryEditorPage() {
       )}
 
       {/* Three-panel layout: Chapters | Map | Editor */}
-      <Flex flex={1} overflow="hidden">
+      <Flex as="main" id="main-content" flex={1} overflow="hidden">
         {/* Left: chapter list */}
         <Box
           w="200px"

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -332,69 +332,71 @@ export default function UploadPage() {
   return (
     <Flex direction="column" minH="100vh" bg="white">
       <Header />
-      <HomepageHero />
+      <Box as="main" id="main-content">
+        <HomepageHero />
 
-      <Flex
-        gap={5}
-        px={8}
-        pb={4}
-        pt={3}
-        maxW="560px"
-        mx="auto"
-        w="100%"
-        direction="column"
-      >
-        <PathCard
-          icon={<FolderOpen size={36} />}
-          title="Visualize data"
-          description="Upload a file or connect to a cloud source"
-          ctaLabel="Explore data"
-          onClick={handleVisualizeCardClick}
-          expanded={visualizeCardExpanded}
-          faded={false}
-          onCollapse={mode === "upload-idle" ? handleCollapse : undefined}
+        <Flex
+          gap={5}
+          px={8}
+          pb={4}
+          pt={3}
+          maxW="560px"
+          mx="auto"
+          w="100%"
+          direction="column"
         >
-          <Box
-            as="ul"
-            mb={4}
-            pl={4}
-            fontSize="13px"
-            color="brand.textSecondary"
-            lineHeight={1.8}
-            listStyleType="disc"
+          <PathCard
+            icon={<FolderOpen size={36} />}
+            title="Visualize data"
+            description="Upload a file or connect to a cloud source"
+            ctaLabel="Explore data"
+            onClick={handleVisualizeCardClick}
+            expanded={visualizeCardExpanded}
+            faded={false}
+            onCollapse={mode === "upload-idle" ? handleCollapse : undefined}
           >
-            <li>Upload GeoTIFF, GeoJSON, Shapefile, NetCDF, or HDF5</li>
-            <li>Connect a COG, PMTiles, or XYZ tile source</li>
-            <li>Data is private to your workspace</li>
-            <li>Files hosted for 30 days</li>
-          </Box>
-          {visualizeCardExpanded && (
-            <>
-              <Box display={mode === "xyz-picker" ? "none" : "block"}>
-                <VisualizeDataCardContent
-                  onFileSelected={handleFile}
-                  onFilesSelected={handleTemporalUpload}
-                  onExampleClicked={(id) =>
-                    navigate(workspacePath(`/map/${id}`))
-                  }
-                  onUrlSubmitted={handleUrlSubmitted}
-                  inlineContent={inlineContent}
-                />
-              </Box>
-              {mode === "xyz-picker" && xyzPickerUrl && (
-                <InlineConnectionForm
-                  prefilledUrl={xyzPickerUrl}
-                  onCancel={() => {
-                    setXyzPickerUrl(null);
-                    setMode("upload-idle");
-                  }}
-                  onCreated={handleConnectionCreated}
-                />
-              )}
-            </>
-          )}
-        </PathCard>
-      </Flex>
+            <Box
+              as="ul"
+              mb={4}
+              pl={4}
+              fontSize="13px"
+              color="brand.textSecondary"
+              lineHeight={1.8}
+              listStyleType="disc"
+            >
+              <li>Upload GeoTIFF, GeoJSON, Shapefile, NetCDF, or HDF5</li>
+              <li>Connect a COG, PMTiles, or XYZ tile source</li>
+              <li>Data is private to your workspace</li>
+              <li>Files hosted for 30 days</li>
+            </Box>
+            {visualizeCardExpanded && (
+              <>
+                <Box display={mode === "xyz-picker" ? "none" : "block"}>
+                  <VisualizeDataCardContent
+                    onFileSelected={handleFile}
+                    onFilesSelected={handleTemporalUpload}
+                    onExampleClicked={(id) =>
+                      navigate(workspacePath(`/map/${id}`))
+                    }
+                    onUrlSubmitted={handleUrlSubmitted}
+                    inlineContent={inlineContent}
+                  />
+                </Box>
+                {mode === "xyz-picker" && xyzPickerUrl && (
+                  <InlineConnectionForm
+                    prefilledUrl={xyzPickerUrl}
+                    onCancel={() => {
+                      setXyzPickerUrl(null);
+                      setMode("upload-idle");
+                    }}
+                    onCreated={handleConnectionCreated}
+                  />
+                )}
+              </>
+            )}
+          </PathCard>
+        </Flex>
+      </Box>
 
       <BugReportModal
         open={reportOpen}

--- a/frontend/src/pages/WorkspaceHomePage.tsx
+++ b/frontend/src/pages/WorkspaceHomePage.tsx
@@ -97,7 +97,16 @@ export default function WorkspaceHomePage() {
   return (
     <Flex direction="column" minH="100vh" bg="gray.50">
       <Header />
-      <Box maxW="960px" mx="auto" py={8} px={4} w="100%" flex="1">
+      <Box
+        as="main"
+        id="main-content"
+        maxW="960px"
+        mx="auto"
+        py={8}
+        px={4}
+        w="100%"
+        flex="1"
+      >
         <Flex justify="space-between" align="center" mb={2}>
           <Heading size="lg" color="gray.800">
             Workspace home


### PR DESCRIPTION
## What changed

- adds active and programmatically indicated primary navigation states
- adds a keyboard skip link and consistent main-content targets
- simplifies the workspace trigger while keeping the raw ID available in its menu
- improves compact navigation behavior and aligns the footer to the page content grid
- records package 2 completion in the design-polish implementation guide

## Why

The application shell did not consistently communicate the current location, exposed a long workspace identifier in the header, and lacked a direct keyboard path to page content. This package makes navigation clearer and more resilient before the page-specific polish work begins.

## Validation

- `npx vitest run src/components/__tests__/Header.test.tsx src/pages/__tests__/LandingPage.test.tsx src/pages/__tests__/WorkspaceHomePage.test.tsx src/pages/__tests__/StoriesPage.test.tsx src/pages/__tests__/DataPage.test.tsx` — 47 tests passed
- `npx tsc --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated navigation and application shell styling for a more consistent interface.
  * Added active-state indicators to navigation links.
  * Added a keyboard-accessible “Skip to main content” link.
  * Improved responsive spacing and workspace menu presentation.
  * Applied refreshed styling to the footer.

* **Accessibility**
  * Added semantic main content landmarks across key pages.

* **Tests**
  * Added coverage for active navigation, skip links, and workspace menu content.

* **Documentation**
  * Marked the navigation and application shell work as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->