### PR TITLE
refactor: split heavy frontend routes and editor workflows

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,25 +1,42 @@
+import { lazy, Suspense } from "react";
+import { Flex } from "@chakra-ui/react";
 import { Routes, Route, Navigate, useParams } from "react-router-dom";
 import {
   WorkspaceProvider,
   WorkspaceRedirect,
   useWorkspace,
 } from "./hooks/useWorkspace";
-import UploadPage from "./pages/UploadPage";
-import MapPage from "./pages/MapPage";
-import ExpiredPage from "./pages/ExpiredPage";
-import DataPage from "./pages/DataPage";
-import StoriesPage from "./pages/StoriesPage";
-import WorkspaceHomePage from "./pages/WorkspaceHomePage";
-import StoryReaderPage from "./pages/StoryReaderPage";
-import StoryEditorPage from "./pages/StoryEditorPage";
-import StoryEmbedPage from "./pages/StoryEmbedPage";
-import AboutPage from "./pages/AboutPage";
-import DiscoverPage from "./pages/DiscoverPage";
-import DiscoverDatasetPage from "./pages/DiscoverDatasetPage";
-import LandingPage from "./pages/LandingPage";
 import { Toaster } from "./components/ui/toaster";
 import { toaster } from "./lib/toaster";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { BrandSpinner } from "./components/ui/BrandSpinner";
+
+const AboutPage = lazy(() => import("./pages/AboutPage"));
+const DataPage = lazy(() => import("./pages/DataPage"));
+const DiscoverDatasetPage = lazy(() => import("./pages/DiscoverDatasetPage"));
+const DiscoverPage = lazy(() => import("./pages/DiscoverPage"));
+const ExpiredPage = lazy(() => import("./pages/ExpiredPage"));
+const LandingPage = lazy(() => import("./pages/LandingPage"));
+const MapPage = lazy(() => import("./pages/MapPage"));
+const StoriesPage = lazy(() => import("./pages/StoriesPage"));
+const StoryEditorPage = lazy(() => import("./pages/StoryEditorPage"));
+const StoryEmbedPage = lazy(() => import("./pages/StoryEmbedPage"));
+const StoryReaderPage = lazy(() => import("./pages/StoryReaderPage"));
+const UploadPage = lazy(() => import("./pages/UploadPage"));
+const WorkspaceHomePage = lazy(() => import("./pages/WorkspaceHomePage"));
+
+function RouteLoadingFallback() {
+  return (
+    <Flex
+      minH="100vh"
+      align="center"
+      justify="center"
+      aria-label="Loading page"
+    >
+      <BrandSpinner size={32} />
+    </Flex>
+  );
+}
 
 function StoryReaderRedirect() {
   const { id } = useParams<{ id: string }>();
@@ -64,16 +81,18 @@ export default function App() {
   return (
     <>
       <ErrorBoundary>
-        <Routes>
-          <Route path="/" element={<LandingPage />} />
-          <Route path="/about" element={<AboutPage />} />
-          <Route path="/story/:id/embed" element={<StoryEmbedPage />} />
-          <Route path="/map/connection/:id" element={<MapPage shared />} />
-          <Route path="/map/:id" element={<MapPage shared />} />
-          <Route path="/story/:id" element={<StoryReaderPage />} />
-          <Route path="/w/:workspaceId/*" element={<WorkspaceRoutes />} />
-          <Route path="*" element={<WorkspaceRedirect />} />
-        </Routes>
+        <Suspense fallback={<RouteLoadingFallback />}>
+          <Routes>
+            <Route path="/" element={<LandingPage />} />
+            <Route path="/about" element={<AboutPage />} />
+            <Route path="/story/:id/embed" element={<StoryEmbedPage />} />
+            <Route path="/map/connection/:id" element={<MapPage shared />} />
+            <Route path="/map/:id" element={<MapPage shared />} />
+            <Route path="/story/:id" element={<StoryReaderPage />} />
+            <Route path="/w/:workspaceId/*" element={<WorkspaceRoutes />} />
+            <Route path="*" element={<WorkspaceRedirect />} />
+          </Routes>
+        </Suspense>
       </ErrorBoundary>
       <Toaster toaster={toaster} />
     </>

--- a/frontend/src/__tests__/App.routing.test.tsx
+++ b/frontend/src/__tests__/App.routing.test.tsx
@@ -53,21 +53,21 @@ function renderApp(route: string) {
   );
 }
 
-test("/map/:id renders MapPage with shared=true", () => {
+test("/map/:id renders MapPage with shared=true", async () => {
   renderApp("/map/test-dataset-id");
-  const el = screen.getByTestId("map-page");
+  const el = await screen.findByTestId("map-page");
   expect(el).toHaveAttribute("data-shared", "true");
 });
 
-test("/map/connection/:id renders MapPage with shared=true", () => {
+test("/map/connection/:id renders MapPage with shared=true", async () => {
   renderApp("/map/connection/test-conn-id");
-  const el = screen.getByTestId("map-page");
+  const el = await screen.findByTestId("map-page");
   expect(el).toHaveAttribute("data-shared", "true");
 });
 
-test("/story/:id renders StoryReaderPage", () => {
+test("/story/:id renders StoryReaderPage", async () => {
   renderApp("/story/test-story-id");
-  expect(screen.getByTestId("story-reader")).toBeInTheDocument();
+  expect(await screen.findByTestId("story-reader")).toBeInTheDocument();
 });
 
 vi.mock("../pages/LandingPage", () => ({
@@ -86,29 +86,29 @@ vi.mock("../hooks/useWorkspace", async (importOriginal) => {
   };
 });
 
-test("/ renders LandingPage (no auto-redirect to a workspace)", () => {
+test("/ renders LandingPage (no auto-redirect to a workspace)", async () => {
   renderApp("/");
-  expect(screen.getByTestId("landing-page")).toBeInTheDocument();
+  expect(await screen.findByTestId("landing-page")).toBeInTheDocument();
 });
 
-test("/about renders the public AboutPage without a workspace", () => {
+test("/about renders the public AboutPage without a workspace", async () => {
   renderApp("/about");
-  expect(screen.getByTestId("about-page")).toBeInTheDocument();
+  expect(await screen.findByTestId("about-page")).toBeInTheDocument();
 });
 
-test("/w/:workspaceId/ renders the WorkspaceHomePage", () => {
+test("/w/:workspaceId/ renders the WorkspaceHomePage", async () => {
   renderApp("/w/abc12345/");
-  expect(screen.getByTestId("workspace-home-page")).toBeInTheDocument();
+  expect(await screen.findByTestId("workspace-home-page")).toBeInTheDocument();
 });
 
-test("/w/:workspaceId/quick-map renders the workspace UploadPage", () => {
+test("/w/:workspaceId/quick-map renders the workspace UploadPage", async () => {
   renderApp("/w/abc12345/quick-map");
-  expect(screen.getByTestId("upload-page")).toBeInTheDocument();
+  expect(await screen.findByTestId("upload-page")).toBeInTheDocument();
 });
 
-test("/w/:workspaceId/stories renders the StoriesPage", () => {
+test("/w/:workspaceId/stories renders the StoriesPage", async () => {
   renderApp("/w/abc12345/stories");
-  expect(screen.getByTestId("stories-page")).toBeInTheDocument();
+  expect(await screen.findByTestId("stories-page")).toBeInTheDocument();
 });
 
 test("unknown public path falls through to WorkspaceRedirect", () => {

--- a/frontend/src/pages/StoryEditorPage.tsx
+++ b/frontend/src/pages/StoryEditorPage.tsx
@@ -8,7 +8,7 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
-import { useMemo, useState } from "react";
+import { lazy, Suspense, useMemo, useState } from "react";
 import {
   X as XIcon,
   ArrowCounterClockwise,
@@ -25,13 +25,6 @@ import { UnifiedMap } from "../components/UnifiedMap";
 import { ChapterList } from "../components/ChapterList";
 import { NarrativeEditor } from "../components/NarrativeEditor";
 import { OverlayLayersEditor } from "../components/OverlayLayersEditor";
-import { OverlayPicker } from "../components/OverlayPicker";
-import { FlyoverKeyframePanel } from "../components/flyover/FlyoverKeyframePanel";
-import { VideoChapterEditor } from "../components/editor/VideoChapterEditor";
-import { UploadModal } from "../components/UploadModal";
-import { ConnectionModal } from "../components/ConnectionModal";
-import { PublishDialog } from "../components/PublishDialog";
-import { ExportDialog } from "../components/ExportDialog";
 import { Header } from "../components/Header";
 import { SaveStatus } from "../components/SaveStatus";
 import { RenderModeIndicator } from "../components/RenderModeIndicator";
@@ -41,11 +34,67 @@ import {
   DEFAULT_MAP_STATE,
 } from "../lib/story";
 import { chapterAllowsTerrain } from "../lib/story/terrainPolicy";
-import { ChapterPreview } from "../components/editor/ChapterPreview";
-import { ImageChapterEditor } from "../components/editor/ImageChapterEditor";
-import { ChartChapterEditor } from "../components/editor/ChartChapterEditor";
 import { StatePanel } from "../components/ui/StatePanel";
 import { BrandSpinner } from "../components/ui/BrandSpinner";
+
+const ChapterPreview = lazy(() =>
+  import("../components/editor/ChapterPreview").then((module) => ({
+    default: module.ChapterPreview,
+  }))
+);
+const ChartChapterEditor = lazy(() =>
+  import("../components/editor/ChartChapterEditor").then((module) => ({
+    default: module.ChartChapterEditor,
+  }))
+);
+const ConnectionModal = lazy(() =>
+  import("../components/ConnectionModal").then((module) => ({
+    default: module.ConnectionModal,
+  }))
+);
+const ExportDialog = lazy(() =>
+  import("../components/ExportDialog").then((module) => ({
+    default: module.ExportDialog,
+  }))
+);
+const FlyoverKeyframePanel = lazy(() =>
+  import("../components/flyover/FlyoverKeyframePanel").then((module) => ({
+    default: module.FlyoverKeyframePanel,
+  }))
+);
+const ImageChapterEditor = lazy(() =>
+  import("../components/editor/ImageChapterEditor").then((module) => ({
+    default: module.ImageChapterEditor,
+  }))
+);
+const OverlayPicker = lazy(() =>
+  import("../components/OverlayPicker").then((module) => ({
+    default: module.OverlayPicker,
+  }))
+);
+const PublishDialog = lazy(() =>
+  import("../components/PublishDialog").then((module) => ({
+    default: module.PublishDialog,
+  }))
+);
+const UploadModal = lazy(() =>
+  import("../components/UploadModal").then((module) => ({
+    default: module.UploadModal,
+  }))
+);
+const VideoChapterEditor = lazy(() =>
+  import("../components/editor/VideoChapterEditor").then((module) => ({
+    default: module.VideoChapterEditor,
+  }))
+);
+
+function EditorPanelFallback() {
+  return (
+    <Flex minH="160px" align="center" justify="center" color="fg.muted">
+      <BrandSpinner size={20} />
+    </Flex>
+  );
+}
 
 function TooltipCard({
   text,
@@ -556,10 +605,12 @@ export default function StoryEditorPage() {
             }}
           >
             {activeChapter && (
-              <ChapterPreview
-                chapter={activeChapter}
-                onChange={updateChapter}
-              />
+              <Suspense fallback={<EditorPanelFallback />}>
+                <ChapterPreview
+                  chapter={activeChapter}
+                  onChange={updateChapter}
+                />
+              </Suspense>
             )}
           </Box>
         )}
@@ -587,129 +638,144 @@ export default function StoryEditorPage() {
               onDismiss={() => dismiss("narrative")}
             />
           )}
-          {activeChapter && activeChapter.type === "chart" ? (
-            <ChartChapterEditor
-              chapter={activeChapter}
-              onChange={updateChapter}
-              onChapterTypeChange={updateChapterType}
-            />
-          ) : activeChapter && activeChapter.type === "image" ? (
-            <ImageChapterEditor
-              chapter={activeChapter}
-              onChange={updateChapter}
-              onChapterTypeChange={updateChapterType}
-            />
-          ) : activeChapter && activeChapter.type === "video" ? (
-            <VideoChapterEditor
-              chapter={activeChapter}
-              onChange={(next) => updateChapter(next)}
-              onChapterTypeChange={updateChapterType}
-            />
-          ) : activeChapter ? (
-            <>
-              <NarrativeEditor
-                chapterType={activeChapter.type}
+          <Suspense fallback={<EditorPanelFallback />}>
+            {activeChapter && activeChapter.type === "chart" ? (
+              <ChartChapterEditor
+                chapter={activeChapter}
+                onChange={updateChapter}
                 onChapterTypeChange={updateChapterType}
-                title={activeChapter.title}
-                narrative={activeChapter.narrative}
-                onTitleChange={updateChapterTitle}
-                onNarrativeChange={updateChapterNarrative}
-                layerConfig={
-                  "layer_config" in activeChapter && activeChapter.layer_config
-                    ? activeChapter.layer_config
-                    : DEFAULT_LAYER_CONFIG
-                }
-                onLayerConfigChange={updateChapterLayerConfig}
-                datasetType={activeDataset?.dataset_type ?? "raster"}
-                datasets={allDatasets}
-                connections={allConnections}
-                onUploadClick={() => setUploadModalOpen(true)}
-                onAddConnectionClick={() => setConnectionModalOpen(true)}
-                overlayPosition={
-                  activeChapter.type === "scrollytelling"
-                    ? (activeChapter.overlay_position ?? "left")
-                    : "left"
-                }
-                onOverlayPositionChange={updateChapterOverlayPosition}
-                temporalTimesteps={activeDatasetTimesteps}
-                mapState={
-                  "map_state" in activeChapter
-                    ? activeChapter.map_state
-                    : DEFAULT_MAP_STATE
-                }
-                onMapStateChange={updateChapterMapState}
               />
-              {isMapBoundChapter(activeChapter) && (
-                <>
-                  <OverlayLayersEditor
-                    overlays={activeChapter.overlays ?? []}
-                    datasets={allDatasets}
-                    connections={allConnections}
-                    onChange={updateChapterOverlays}
-                    onAddClick={() => setOverlayPickerOpen(true)}
-                  />
-                  <OverlayPicker
-                    open={overlayPickerOpen}
-                    datasets={allDatasets.filter(
-                      (d) => d.dataset_type === "vector"
+            ) : activeChapter && activeChapter.type === "image" ? (
+              <ImageChapterEditor
+                chapter={activeChapter}
+                onChange={updateChapter}
+                onChapterTypeChange={updateChapterType}
+              />
+            ) : activeChapter && activeChapter.type === "video" ? (
+              <VideoChapterEditor
+                chapter={activeChapter}
+                onChange={(next) => updateChapter(next)}
+                onChapterTypeChange={updateChapterType}
+              />
+            ) : activeChapter ? (
+              <>
+                <NarrativeEditor
+                  chapterType={activeChapter.type}
+                  onChapterTypeChange={updateChapterType}
+                  title={activeChapter.title}
+                  narrative={activeChapter.narrative}
+                  onTitleChange={updateChapterTitle}
+                  onNarrativeChange={updateChapterNarrative}
+                  layerConfig={
+                    "layer_config" in activeChapter &&
+                    activeChapter.layer_config
+                      ? activeChapter.layer_config
+                      : DEFAULT_LAYER_CONFIG
+                  }
+                  onLayerConfigChange={updateChapterLayerConfig}
+                  datasetType={activeDataset?.dataset_type ?? "raster"}
+                  datasets={allDatasets}
+                  connections={allConnections}
+                  onUploadClick={() => setUploadModalOpen(true)}
+                  onAddConnectionClick={() => setConnectionModalOpen(true)}
+                  overlayPosition={
+                    activeChapter.type === "scrollytelling"
+                      ? (activeChapter.overlay_position ?? "left")
+                      : "left"
+                  }
+                  onOverlayPositionChange={updateChapterOverlayPosition}
+                  temporalTimesteps={activeDatasetTimesteps}
+                  mapState={
+                    "map_state" in activeChapter
+                      ? activeChapter.map_state
+                      : DEFAULT_MAP_STATE
+                  }
+                  onMapStateChange={updateChapterMapState}
+                />
+                {isMapBoundChapter(activeChapter) && (
+                  <>
+                    <OverlayLayersEditor
+                      overlays={activeChapter.overlays ?? []}
+                      datasets={allDatasets}
+                      connections={allConnections}
+                      onChange={updateChapterOverlays}
+                      onAddClick={() => setOverlayPickerOpen(true)}
+                    />
+                    {overlayPickerOpen && (
+                      <OverlayPicker
+                        open
+                        datasets={allDatasets.filter(
+                          (d) => d.dataset_type === "vector"
+                        )}
+                        connections={allConnections.filter(
+                          (c) =>
+                            (c.connection_type === "pmtiles" &&
+                              c.tile_type === "vector") ||
+                            c.connection_type === "xyz_vector"
+                        )}
+                        onClose={() => setOverlayPickerOpen(false)}
+                        onSelect={(overlay) => {
+                          updateChapterOverlays([
+                            ...(activeChapter.overlays ?? []),
+                            overlay,
+                          ]);
+                          setOverlayPickerOpen(false);
+                        }}
+                      />
                     )}
-                    connections={allConnections.filter(
-                      (c) =>
-                        (c.connection_type === "pmtiles" &&
-                          c.tile_type === "vector") ||
-                        c.connection_type === "xyz_vector"
-                    )}
-                    onClose={() => setOverlayPickerOpen(false)}
-                    onSelect={(overlay) => {
-                      updateChapterOverlays([
-                        ...(activeChapter.overlays ?? []),
-                        overlay,
-                      ]);
-                      setOverlayPickerOpen(false);
-                    }}
-                  />
-                </>
-              )}
-              {activeChapter.type === "flyover" && (
-                <Box px={4} pb={6}>
-                  <FlyoverKeyframePanel
-                    chapter={activeChapter}
-                    onChange={updateChapter}
-                    currentCamera={camera}
-                    onPreviewPose={previewFlyoverPose}
-                  />
-                </Box>
-              )}
-            </>
-          ) : (
-            <Flex h="100%" align="center" justify="center">
-              <Text color="gray.400">Select a chapter to edit</Text>
-            </Flex>
-          )}
+                  </>
+                )}
+                {activeChapter.type === "flyover" && (
+                  <Box px={4} pb={6}>
+                    <FlyoverKeyframePanel
+                      chapter={activeChapter}
+                      onChange={updateChapter}
+                      currentCamera={camera}
+                      onPreviewPose={previewFlyoverPose}
+                    />
+                  </Box>
+                )}
+              </>
+            ) : (
+              <Flex h="100%" align="center" justify="center">
+                <Text color="gray.400">Select a chapter to edit</Text>
+              </Flex>
+            )}
+          </Suspense>
         </Box>
       </Flex>
-      <UploadModal
-        open={uploadModalOpen}
-        onClose={() => setUploadModalOpen(false)}
-        onDatasetReady={handleDatasetReady}
-      />
-      <ConnectionModal
-        isOpen={connectionModalOpen}
-        onClose={() => setConnectionModalOpen(false)}
-        onCreated={handleConnectionCreated}
-      />
-      <PublishDialog
-        open={publishDialogOpen}
-        story={story}
-        shareUrl={`${window.location.origin}/story/${story.id}`}
-        onPublish={handlePublish}
-        onClose={() => setPublishDialogOpen(false)}
-      />
-      <ExportDialog
-        open={exportDialogOpen}
-        story={story}
-        onClose={() => setExportDialogOpen(false)}
-      />
+      <Suspense fallback={null}>
+        {uploadModalOpen && (
+          <UploadModal
+            open
+            onClose={() => setUploadModalOpen(false)}
+            onDatasetReady={handleDatasetReady}
+          />
+        )}
+        {connectionModalOpen && (
+          <ConnectionModal
+            isOpen
+            onClose={() => setConnectionModalOpen(false)}
+            onCreated={handleConnectionCreated}
+          />
+        )}
+        {publishDialogOpen && (
+          <PublishDialog
+            open
+            story={story}
+            shareUrl={`${window.location.origin}/story/${story.id}`}
+            onPublish={handlePublish}
+            onClose={() => setPublishDialogOpen(false)}
+          />
+        )}
+        {exportDialogOpen && (
+          <ExportDialog
+            open
+            story={story}
+            onClose={() => setExportDialogOpen(false)}
+          />
+        )}
+      </Suspense>
     </Box>
   );
 }

--- a/frontend/src/pages/WorkspaceHomePage.tsx
+++ b/frontend/src/pages/WorkspaceHomePage.tsx
@@ -164,8 +164,6 @@ export default function WorkspaceHomePage() {
               title="Recent stories"
               viewAllLabel="View all stories"
               viewAllHref={workspacePath("/stories")}
-              actionLabel="New story"
-              actionHref={workspacePath("/story/new")}
               emptyText="No stories yet."
             >
               {recentStories.map((s) => (
@@ -184,8 +182,6 @@ export default function WorkspaceHomePage() {
               title="Recent data"
               viewAllLabel="View all data"
               viewAllHref={workspacePath("/data")}
-              actionLabel="Quick map"
-              actionHref={workspacePath("/quick-map")}
               emptyText="No datasets yet."
             >
               {recentDatasets.map((d) => (
@@ -244,8 +240,6 @@ interface SectionProps {
   title: string;
   viewAllLabel: string;
   viewAllHref: string;
-  actionLabel: string;
-  actionHref: string;
   emptyText: string;
   children: React.ReactNode;
 }
@@ -254,8 +248,6 @@ function Section({
   title,
   viewAllLabel,
   viewAllHref,
-  actionLabel,
-  actionHref,
   emptyText,
   children,
 }: SectionProps) {
@@ -268,16 +260,6 @@ function Section({
         <Heading size="md" color="gray.700">
           {title}
         </Heading>
-        <Link to={actionHref}>
-          <Button
-            size="sm"
-            bg="brand.orange"
-            color="white"
-            _hover={{ bg: "brand.orangeHover" }}
-          >
-            {actionLabel}
-          </Button>
-        </Link>
       </Flex>
       {hasChildren ? (
         <Box>{children}</Box>

--- a/frontend/src/pages/__tests__/WorkspaceHomePage.test.tsx
+++ b/frontend/src/pages/__tests__/WorkspaceHomePage.test.tsx
@@ -189,6 +189,30 @@ describe("WorkspaceHomePage", () => {
     ).toHaveAttribute("href", "/w/test-workspace/data");
   });
 
+  it("shows each primary creation action once", async () => {
+    mockListStories.mockResolvedValue([
+      {
+        id: "s-seed",
+        title: "Seed story",
+        chapters: [],
+        is_example: false,
+      },
+    ]);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+    renderHome();
+
+    expect(
+      await screen.findAllByRole("link", { name: "New story" })
+    ).toHaveLength(1);
+    expect(screen.getAllByRole("link", { name: "Add data" })).toHaveLength(1);
+    expect(
+      screen.queryByRole("link", { name: "Quick map" })
+    ).not.toBeInTheDocument();
+  });
+
   it("shows example story clone cards when the workspace is empty", async () => {
     mockListStories.mockResolvedValue([
       {


### PR DESCRIPTION
## What changed

- lazy-load every top-level application route behind a shared accessible loading boundary
- defer upload, connection, publish, export, flyover, overlay, and media-specific editor modules until their workflows are opened
- keep local loading boundaries inside the editor so optional modules do not blank the full page
- remove duplicate workspace creation actions and add regression coverage

## Why

The frontend router eagerly imported the map and story editor stacks for every page. The editor also mounted optional workflow modules even while their dialogs were closed. This made the lightweight workspace pay the cost of geospatial rendering code and delayed editor interactivity.

## Impact

The workspace now builds as a roughly 5 KB route chunk. The story editor entry chunk dropped from approximately 458 KB (134.5 KB gzip) to 77 KB (22.3 KB gzip); optional features are emitted as separate on-demand chunks.

## Validation

- `corepack yarn tsc --noEmit`
- ESLint on all changed files
- production Vite build
- route and workspace tests: 16 passed
- story editor overlay tests: 2 passed
- broader editor/dialog run: 25 passed; four tests exceeded the shared 15-second timeout on this constrained runner, with the changed editor overlay suite passing when rerun independently


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Pages and editor tools now load on demand, improving initial load performance.
  - Added branded loading screens and spinners while content is loading.

- **Workspace**
  - Simplified workspace section navigation with clearer view-all links.
  - New story and add data actions remain available from their primary links.

- **Editor**
  - Editor previews, dialogs, and tools now load as needed without changing existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->