### PR TITLE
feat: improve workspace authoring UX

### DIFF
--- a/docs/frontend-gotchas.md
+++ b/docs/frontend-gotchas.md
@@ -7,6 +7,13 @@ Implementation details and non-obvious behaviors in the frontend. Read this when
 - **Top-level actions describe outcomes, not ingestion methods**: use `CREATE_MAP_INTENT` and `CREATE_STORY_INTENT` from `src/lib/creationIntents.ts` for workspace, data-library, and stories-page calls to action. The canonical labels are “Create map” and “Create story.” The map intent deliberately keeps `/quick-map` as its implementation route; route names are not user-facing vocabulary.
 - **Uploading and connecting remain contextual actions**: use `DATA_ENTRY_ACTIONS.upload` (“Upload data”) and `DATA_ENTRY_ACTIONS.connect` (“Connect data”) inside an authoring flow. Both are available from the story editor `DataSelector`, so starting with narrative never forces the user back through map creation.
 - **Do not duplicate primary creation actions within one page**: `WorkspaceHomePage` owns one header-level link for each creation intent. Recent-content sections only navigate to their full collections.
+- **Creation routes delay persistence until the first real action**: `/quick-map` opens with its upload/connect surface already expanded. `/story/new` renders `StorySetupPage`; it creates the server-side story only after the author chooses Map-led, Media, or Blank. Preserve `?dataset=<id>` when linking into story setup so Map-led can inherit the dataset colormap and initial bounds.
+
+## Workspace resource states
+
+- **Workspace collections share explicit request state**: `useWorkspaceDatasets`, `useWorkspaceConnections`, and `useWorkspaceStories` expose `loading | ready | empty | error`, retain previously loaded data during refresh, and provide `retry`. Consumers must not infer loading from a missing ID or convert request failures into empty arrays.
+- **Partial success remains usable**: datasets and connections load independently. `DataSelector`, Data, Workspace Home, and the story editor keep successful results visible while showing a retryable error for the failed resource.
+- **A missing active reference is not loading**: once requests settle, `DataSelector` labels an unresolved active ID as “Dataset unavailable” and asks the author to choose a replacement.
 
 ## Map compositing and camera
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ const StoriesPage = lazy(() => import("./pages/StoriesPage"));
 const StoryEditorPage = lazy(() => import("./pages/StoryEditorPage"));
 const StoryEmbedPage = lazy(() => import("./pages/StoryEmbedPage"));
 const StoryReaderPage = lazy(() => import("./pages/StoryReaderPage"));
+const StorySetupPage = lazy(() => import("./pages/StorySetupPage"));
 const UploadPage = lazy(() => import("./pages/UploadPage"));
 const WorkspaceHomePage = lazy(() => import("./pages/WorkspaceHomePage"));
 
@@ -66,7 +67,7 @@ function WorkspaceRoutes() {
         <Route path="/data" element={<DataPage />} />
         <Route path="/library" element={<LibraryRedirect />} />
         <Route path="/datasets" element={<DatasetsRedirect />} />
-        <Route path="/story/new" element={<StoryEditorPage />} />
+        <Route path="/story/new" element={<StorySetupPage />} />
         <Route path="/story/:id" element={<StoryReaderRedirect />} />
         <Route path="/story/:id/edit" element={<StoryEditorPage />} />
         <Route path="/about" element={<AboutPage />} />

--- a/frontend/src/components/AdvancedSettingsDisclosure.tsx
+++ b/frontend/src/components/AdvancedSettingsDisclosure.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { CaretDown } from "@phosphor-icons/react";
+
+interface AdvancedSettingsDisclosureProps {
+  title: string;
+  children: ReactNode;
+}
+
+export function AdvancedSettingsDisclosure({
+  title,
+  children,
+}: AdvancedSettingsDisclosureProps) {
+  return (
+    <Box
+      as="details"
+      border="1px solid"
+      borderColor="brand.border"
+      borderRadius="md"
+      bg="white"
+      css={{ "&[open] > summary svg": { transform: "rotate(180deg)" } }}
+    >
+      <Flex
+        as="summary"
+        align="center"
+        justify="space-between"
+        px={3}
+        py={2}
+        cursor="pointer"
+        listStyle="none"
+        css={{ "&::-webkit-details-marker": { display: "none" } }}
+      >
+        <Text fontSize="sm" fontWeight={600} color="brand.brown">
+          {title}
+        </Text>
+        <CaretDown size={14} style={{ transition: "transform 0.15s" }} />
+      </Flex>
+      <Box px={3} pb={3}>
+        {children}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/ChapterTypePicker.tsx
+++ b/frontend/src/components/ChapterTypePicker.tsx
@@ -1,34 +1,7 @@
 import { Flex, Text } from "@chakra-ui/react";
-import {
-  Path,
-  Article,
-  MapTrifold,
-  Image,
-  VideoCamera,
-  ChartLine,
-  PaperPlaneTilt,
-} from "@phosphor-icons/react";
-import type { ReactNode } from "react";
+import { useState } from "react";
 import type { ChapterType } from "../lib/story";
-import {
-  CHAPTER_TYPE_LABELS,
-  CHAPTER_TYPE_DESCRIPTIONS,
-} from "../lib/story/labels";
-
-interface ChapterTypeOption {
-  type: ChapterType;
-  icon: ReactNode;
-}
-
-const CHAPTER_TYPE_OPTIONS: ChapterTypeOption[] = [
-  { type: "scrollytelling", icon: <Path size={16} /> },
-  { type: "map", icon: <MapTrifold size={16} /> },
-  { type: "prose", icon: <Article size={16} /> },
-  { type: "image", icon: <Image size={16} /> },
-  { type: "video", icon: <VideoCamera size={16} /> },
-  { type: "chart", icon: <ChartLine size={16} /> },
-  { type: "flyover", icon: <PaperPlaneTilt size={16} /> },
-];
+import { CHAPTER_TYPE_REGISTRY } from "../lib/story/chapterRegistry";
 
 interface ChapterTypePickerProps {
   value: ChapterType;
@@ -36,9 +9,15 @@ interface ChapterTypePickerProps {
 }
 
 export function ChapterTypePicker({ value, onChange }: ChapterTypePickerProps) {
+  const current = CHAPTER_TYPE_REGISTRY.find((item) => item.type === value);
+  const [showMore, setShowMore] = useState(current?.prominence === "secondary");
+  const options = CHAPTER_TYPE_REGISTRY.filter(
+    (item) => showMore || item.prominence === "primary"
+  );
+
   return (
     <Flex gap={1} flexWrap="wrap" role="group" aria-label="Chapter type">
-      {CHAPTER_TYPE_OPTIONS.map(({ type, icon }) => (
+      {options.map(({ type, icon: Icon, label, description }) => (
         <Flex
           key={type}
           as="button"
@@ -53,24 +32,36 @@ export function ChapterTypePicker({ value, onChange }: ChapterTypePickerProps) {
           fontWeight={value === type ? 600 : 500}
           onClick={() => onChange(type)}
           aria-pressed={value === type}
-          aria-label={`${CHAPTER_TYPE_LABELS[type]}: ${CHAPTER_TYPE_DESCRIPTIONS[type]}`}
+          aria-label={`${label}: ${description}`}
           _hover={{
             bg: value === type ? "brand.bgSubtle" : "brand.bgSubtle",
             color: value === type ? "brand.orange" : "brand.brown",
           }}
           _active={{ transform: "scale(0.98)" }}
-          title={CHAPTER_TYPE_DESCRIPTIONS[type]}
+          title={description}
           transition="all 0.15s"
         >
-          {icon}
+          <Icon size={16} />
           <Text fontSize="12px" lineHeight={1}>
-            {CHAPTER_TYPE_LABELS[type]}
+            {label}
           </Text>
         </Flex>
       ))}
+      <Flex
+        as="button"
+        align="center"
+        px={3}
+        py={1.5}
+        borderRadius="6px"
+        color="gray.600"
+        fontWeight={500}
+        onClick={() => setShowMore((visible) => !visible)}
+        _hover={{ bg: "brand.bgSubtle", color: "brand.brown" }}
+      >
+        <Text fontSize="12px" lineHeight={1}>
+          {showMore ? "Fewer chapter types" : "More chapter types"}
+        </Text>
+      </Flex>
     </Flex>
   );
 }
-
-export type { ChapterTypeOption };
-export { CHAPTER_TYPE_OPTIONS };

--- a/frontend/src/components/ChapterTypePicker.tsx
+++ b/frontend/src/components/ChapterTypePicker.tsx
@@ -9,10 +9,9 @@ interface ChapterTypePickerProps {
 }
 
 export function ChapterTypePicker({ value, onChange }: ChapterTypePickerProps) {
-  const current = CHAPTER_TYPE_REGISTRY.find((item) => item.type === value);
-  const [showMore, setShowMore] = useState(current?.prominence === "secondary");
+  const [showMore, setShowMore] = useState(false);
   const options = CHAPTER_TYPE_REGISTRY.filter(
-    (item) => showMore || item.prominence === "primary"
+    (item) => showMore || item.prominence === "primary" || item.type === value
   );
 
   return (

--- a/frontend/src/components/DataSelector.tsx
+++ b/frontend/src/components/DataSelector.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { Box, Flex, Text } from "@chakra-ui/react";
-import { CaretDown, Upload, Plus } from "@phosphor-icons/react";
+import { CaretDown, Upload, Plus, WarningCircle } from "@phosphor-icons/react";
 import { transition } from "../lib/interactionStyles";
 import { DATA_ENTRY_ACTIONS } from "../lib/creationIntents";
 import type { MapItemSource } from "../types";
@@ -47,6 +47,9 @@ interface DataSelectorProps {
   items: DataSelectorItem[];
   activeId: string;
   activeSource: MapItemSource;
+  status?: "loading" | "ready" | "error";
+  error?: string | null;
+  onRetry?: () => void;
   onSelect: (id: string, source: MapItemSource) => void;
   onUploadClick: () => void;
   onAddConnectionClick: () => void;
@@ -56,6 +59,9 @@ export function DataSelector({
   items,
   activeId,
   activeSource,
+  status = "ready",
+  error,
+  onRetry,
   onSelect,
   onUploadClick,
   onAddConnectionClick,
@@ -112,7 +118,9 @@ export function DataSelector({
   const activeItem = items.find(
     (i) => i.id === activeId && i.source === activeSource
   );
-  const activeName = activeItem?.name ?? "Loading...";
+  const activeName =
+    activeItem?.name ??
+    (status === "loading" ? "Loading data…" : "Dataset unavailable");
 
   return (
     <Box ref={containerRef}>
@@ -136,7 +144,13 @@ export function DataSelector({
           w="8px"
           h="8px"
           borderRadius="sm"
-          bg={activeItem ? dotColor(activeItem) : "gray.500"}
+          bg={
+            activeItem
+              ? dotColor(activeItem)
+              : status === "error"
+                ? "red.500"
+                : "gray.500"
+          }
           flexShrink={0}
         />
         <Text fontSize="sm" fontWeight={500} flex={1} textAlign="left" truncate>
@@ -165,6 +179,45 @@ export function DataSelector({
             py={1}
             boxShadow="lg"
           >
+            {status === "error" && (
+              <Box
+                px={3}
+                py={2}
+                borderBottom="1px solid"
+                borderColor="brand.border"
+              >
+                <Flex align="start" gap={2} color="red.700">
+                  <WarningCircle
+                    size={16}
+                    style={{ marginTop: 2, flexShrink: 0 }}
+                  />
+                  <Box>
+                    <Text fontSize="sm" fontWeight={600}>
+                      Some data couldn’t load
+                    </Text>
+                    {error && <Text fontSize="xs">{error}</Text>}
+                    {onRetry && (
+                      <Box
+                        as="button"
+                        mt={1}
+                        fontSize="xs"
+                        fontWeight={600}
+                        color="brand.orange"
+                        onClick={onRetry}
+                      >
+                        Try again
+                      </Box>
+                    )}
+                  </Box>
+                </Flex>
+              </Box>
+            )}
+            {!activeItem && status !== "loading" && (
+              <Text px={3} py={2} fontSize="sm" color="gray.600">
+                The data referenced by this view is unavailable. Choose a
+                replacement below.
+              </Text>
+            )}
             <Text
               px={3}
               py={1}

--- a/frontend/src/components/DataSwitcher.tsx
+++ b/frontend/src/components/DataSwitcher.tsx
@@ -1,8 +1,10 @@
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useWorkspace } from "../hooks/useWorkspace";
-import { connectionsApi, workspaceFetch } from "../lib/api";
-import type { Dataset } from "../types";
+import {
+  useWorkspaceConnections,
+  useWorkspaceDatasets,
+} from "../hooks/useWorkspaceLibrary";
 import { displayName } from "../utils/dataset";
 import { DataSelector } from "./DataSelector";
 import type { DataSelectorItem } from "./DataSelector";
@@ -22,56 +24,51 @@ export function DataSwitcher({
   onAddConnectionClick,
   refreshKey,
 }: DataSwitcherProps) {
-  const [items, setItems] = useState<DataSelectorItem[]>([]);
   const navigate = useNavigate();
   const { workspacePath } = useWorkspace();
+  const datasets = useWorkspaceDatasets();
+  const connections = useWorkspaceConnections();
 
   useEffect(() => {
-    const fetchData = async () => {
-      const datasetItems: DataSelectorItem[] = [];
-      const connectionItems: DataSelectorItem[] = [];
-
-      try {
-        const res = await workspaceFetch("/api/datasets");
-        const list: Dataset[] = await res.json();
-        datasetItems.push(
-          ...list.map((d) => ({
-            id: d.id,
-            name: displayName(d),
-            source: "dataset" as const,
-            dataType: d.dataset_type,
-            isZeroCopy: d.is_zero_copy,
-            isMosaic: d.is_mosaic,
-            expiresAt: d.expires_at,
-          }))
-        );
-      } catch {
-        // ignore fetch errors
-      }
-
-      try {
-        const list = await connectionsApi.list();
-        connectionItems.push(
-          ...list.map((c) => ({
-            id: c.id,
-            name: c.name,
-            source: "connection" as const,
-            dataType:
-              c.connection_type === "xyz_vector" ||
-              (c.connection_type === "pmtiles" && c.tile_type === "vector")
-                ? ("vector" as const)
-                : ("raster" as const),
-          }))
-        );
-      } catch {
-        // ignore fetch errors
-      }
-
-      setItems([...datasetItems, ...connectionItems]);
-    };
-
-    fetchData();
+    if (refreshKey === 0) return;
+    datasets.retry();
+    connections.retry();
+    // refreshKey deliberately invalidates both independent resources.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refreshKey]);
+
+  const items = useMemo<DataSelectorItem[]>(
+    () => [
+      ...datasets.data.map((dataset) => ({
+        id: dataset.id,
+        name: displayName(dataset),
+        source: "dataset" as const,
+        dataType: dataset.dataset_type,
+        isZeroCopy: dataset.is_zero_copy,
+        isMosaic: dataset.is_mosaic,
+        expiresAt: dataset.expires_at,
+      })),
+      ...connections.data.map((connection) => ({
+        id: connection.id,
+        name: connection.name,
+        source: "connection" as const,
+        dataType:
+          connection.connection_type === "xyz_vector" ||
+          (connection.connection_type === "pmtiles" &&
+            connection.tile_type === "vector")
+            ? ("vector" as const)
+            : ("raster" as const),
+      })),
+    ],
+    [datasets.data, connections.data]
+  );
+
+  const isInitialLoading =
+    items.length === 0 &&
+    (datasets.status === "loading" || connections.status === "loading");
+  const failures = [datasets.error, connections.error]
+    .filter(Boolean)
+    .join("; ");
 
   const handleSelect = useCallback(
     (id: string, source: "dataset" | "connection") => {
@@ -89,6 +86,12 @@ export function DataSwitcher({
       items={items}
       activeId={activeId}
       activeSource={activeSource}
+      status={isInitialLoading ? "loading" : failures ? "error" : "ready"}
+      error={failures || null}
+      onRetry={() => {
+        datasets.retry();
+        connections.retry();
+      }}
       onSelect={handleSelect}
       onUploadClick={onUploadClick}
       onAddConnectionClick={onAddConnectionClick}

--- a/frontend/src/components/DataSwitcher.tsx
+++ b/frontend/src/components/DataSwitcher.tsx
@@ -28,14 +28,14 @@ export function DataSwitcher({
   const { workspacePath } = useWorkspace();
   const datasets = useWorkspaceDatasets();
   const connections = useWorkspaceConnections();
+  const retryDatasets = datasets.retry;
+  const retryConnections = connections.retry;
 
   useEffect(() => {
     if (refreshKey === 0) return;
-    datasets.retry();
-    connections.retry();
-    // refreshKey deliberately invalidates both independent resources.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshKey]);
+    retryDatasets();
+    retryConnections();
+  }, [refreshKey, retryDatasets, retryConnections]);
 
   const items = useMemo<DataSelectorItem[]>(
     () => [
@@ -89,8 +89,8 @@ export function DataSwitcher({
       status={isInitialLoading ? "loading" : failures ? "error" : "ready"}
       error={failures || null}
       onRetry={() => {
-        datasets.retry();
-        connections.retry();
+        retryDatasets();
+        retryConnections();
       }}
       onSelect={handleSelect}
       onUploadClick={onUploadClick}

--- a/frontend/src/components/NarrativeEditor.tsx
+++ b/frontend/src/components/NarrativeEditor.tsx
@@ -14,6 +14,7 @@ import type { CopcColorMode } from "../lib/layers/copcLayer";
 import { DataSelector } from "./DataSelector";
 import type { DataSelectorItem } from "./DataSelector";
 import { MarkdownToolbar } from "./MarkdownToolbar";
+import { AdvancedSettingsDisclosure } from "./AdvancedSettingsDisclosure";
 
 interface NarrativeEditorProps {
   chapterType: ChapterType;
@@ -27,6 +28,9 @@ interface NarrativeEditorProps {
   datasetType: "raster" | "vector" | "pointcloud" | "trajectory";
   datasets: Dataset[];
   connections?: Connection[];
+  dataStatus?: "loading" | "ready" | "error";
+  dataError?: string | null;
+  onDataRetry?: () => void;
   onUploadClick?: () => void;
   onAddConnectionClick?: () => void;
   overlayPosition: "left" | "right";
@@ -48,6 +52,9 @@ export function NarrativeEditor({
   datasetType,
   datasets,
   connections,
+  dataStatus,
+  dataError,
+  onDataRetry,
   onUploadClick,
   onAddConnectionClick,
   overlayPosition,
@@ -164,7 +171,7 @@ export function NarrativeEditor({
       )}
 
       {showMapControls && (
-        <Box mt={4}>
+        <AdvancedSettingsDisclosure title="Map environment">
           <Text
             fontSize="xs"
             fontWeight={600}
@@ -270,7 +277,7 @@ export function NarrativeEditor({
               style={{ accentColor: "#CF3F02", cursor: "pointer" }}
             />
           </Flex>
-        </Box>
+        </AdvancedSettingsDisclosure>
       )}
 
       {/* 3. Dataset selector */}
@@ -290,6 +297,9 @@ export function NarrativeEditor({
             items={dataSelectorItems}
             activeId={activeDataId}
             activeSource={activeSource}
+            status={dataStatus}
+            error={dataError}
+            onRetry={onDataRetry}
             onSelect={handleDataSelect}
             onUploadClick={onUploadClick ?? (() => {})}
             onAddConnectionClick={onAddConnectionClick ?? (() => {})}
@@ -374,7 +384,7 @@ export function NarrativeEditor({
 
       {/* 7. Style section */}
       {showMapControls && (
-        <Box>
+        <AdvancedSettingsDisclosure title="Map appearance">
           <Text
             fontSize="12px"
             color="gray.500"
@@ -554,7 +564,7 @@ export function NarrativeEditor({
               />
             </Box>
           </Flex>
-        </Box>
+        </AdvancedSettingsDisclosure>
       )}
     </Flex>
   );

--- a/frontend/src/components/StoryProgress.tsx
+++ b/frontend/src/components/StoryProgress.tsx
@@ -1,0 +1,24 @@
+import { Box } from "@chakra-ui/react";
+
+export function StoryProgress({ progress }: { progress: number }) {
+  const normalized = Math.max(0, Math.min(1, progress));
+  return (
+    <Box
+      role="progressbar"
+      aria-label="Reading progress"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(normalized * 100)}
+      h="3px"
+      bg="brand.border"
+      flexShrink={0}
+    >
+      <Box
+        h="100%"
+        w={`${normalized * 100}%`}
+        bg="brand.orange"
+        transition="width 120ms linear"
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/__tests__/ChapterTypePicker.test.tsx
+++ b/frontend/src/components/__tests__/ChapterTypePicker.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { describe, expect, it, vi } from "vitest";
+import { system } from "../../theme";
+import { ChapterTypePicker } from "../ChapterTypePicker";
+
+describe("ChapterTypePicker", () => {
+  it("reveals specialized types on request", () => {
+    render(
+      <ChakraProvider value={system}>
+        <ChapterTypePicker value="map" onChange={vi.fn()} />
+      </ChakraProvider>
+    );
+
+    expect(screen.queryByRole("button", { name: /3D flyover/i })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "More chapter types" }));
+    expect(screen.getByRole("button", { name: /3D flyover/i })).toBeTruthy();
+  });
+
+  it("keeps a selected specialized type visible", () => {
+    render(
+      <ChakraProvider value={system}>
+        <ChapterTypePicker value="flyover" onChange={vi.fn()} />
+      </ChakraProvider>
+    );
+    expect(screen.getByRole("button", { name: /3D flyover/i })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+});

--- a/frontend/src/components/__tests__/ChapterTypePicker.test.tsx
+++ b/frontend/src/components/__tests__/ChapterTypePicker.test.tsx
@@ -28,4 +28,26 @@ describe("ChapterTypePicker", () => {
       "true"
     );
   });
+
+  it("keeps a specialized type visible after the value changes", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <ChakraProvider value={system}>
+        <ChapterTypePicker value="map" onChange={onChange} />
+      </ChakraProvider>
+    );
+
+    expect(screen.queryByRole("button", { name: /3D flyover/i })).toBeNull();
+
+    rerender(
+      <ChakraProvider value={system}>
+        <ChapterTypePicker value="flyover" onChange={onChange} />
+      </ChakraProvider>
+    );
+
+    expect(screen.getByRole("button", { name: /3D flyover/i })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
 });

--- a/frontend/src/components/__tests__/DataSelector.test.tsx
+++ b/frontend/src/components/__tests__/DataSelector.test.tsx
@@ -122,7 +122,7 @@ describe("DataSelector", () => {
     expect(screen.getByText("Point cloud")).toBeTruthy();
   });
 
-  it("shows Loading... when activeId is not in items", () => {
+  it("shows an unavailable state when the active reference is missing", () => {
     renderWithChakra(
       <DataSelector
         items={DATASETS}
@@ -133,6 +133,43 @@ describe("DataSelector", () => {
         onAddConnectionClick={vi.fn()}
       />
     );
-    expect(screen.getByText("Loading...")).toBeTruthy();
+    expect(screen.getByText("Dataset unavailable")).toBeTruthy();
+  });
+
+  it("only shows loading while resources are actually loading", () => {
+    renderWithChakra(
+      <DataSelector
+        items={[]}
+        activeId="d1"
+        activeSource="dataset"
+        status="loading"
+        onSelect={vi.fn()}
+        onUploadClick={vi.fn()}
+        onAddConnectionClick={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Loading data…")).toBeTruthy();
+  });
+
+  it("surfaces partial load errors while preserving available items", () => {
+    const onRetry = vi.fn();
+    renderWithChakra(
+      <DataSelector
+        items={DATASETS}
+        activeId="d1"
+        activeSource="dataset"
+        status="error"
+        error="Connections failed"
+        onRetry={onRetry}
+        onSelect={vi.fn()}
+        onUploadClick={vi.fn()}
+        onAddConnectionClick={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("Some data couldn’t load")).toBeTruthy();
+    expect(screen.getAllByText("temperature.tif").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByText("Try again"));
+    expect(onRetry).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/__tests__/StoryProgress.test.tsx
+++ b/frontend/src/components/__tests__/StoryProgress.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { describe, expect, it } from "vitest";
+import { system } from "../../theme";
+import { StoryProgress } from "../StoryProgress";
+
+describe("StoryProgress", () => {
+  it("announces normalized reading progress", () => {
+    render(
+      <ChakraProvider value={system}>
+        <StoryProgress progress={0.42} />
+      </ChakraProvider>
+    );
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "42"
+    );
+  });
+
+  it("clamps progress to the valid range", () => {
+    render(
+      <ChakraProvider value={system}>
+        <StoryProgress progress={2} />
+      </ChakraProvider>
+    );
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "100"
+    );
+  });
+});

--- a/frontend/src/components/ui/ResourceCollection.tsx
+++ b/frontend/src/components/ui/ResourceCollection.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode } from "react";
+import { Box, Grid, Text } from "@chakra-ui/react";
+
+interface ResourceCollectionProps {
+  columns: string;
+  headers: ReactNode[];
+  children: ReactNode;
+}
+
+export function ResourceCollection({
+  columns,
+  headers,
+  children,
+}: ResourceCollectionProps) {
+  return (
+    <Box as="section" aria-label="Resource collection">
+      <Grid
+        display={{ base: "none", md: "grid" }}
+        gridTemplateColumns={columns}
+        gap={3}
+        px={3}
+        py={2}
+        borderBottom="1px solid"
+        borderColor="brand.border"
+      >
+        {headers.map((header, index) => (
+          <Text key={index} fontSize="xs" fontWeight={600} color="gray.600">
+            {header}
+          </Text>
+        ))}
+      </Grid>
+      <Box display="grid" gap={{ base: 3, md: 0 }}>
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+interface ResourceCollectionRowProps {
+  columns: string;
+  children: ReactNode;
+}
+
+export function ResourceCollectionRow({
+  columns,
+  children,
+}: ResourceCollectionRowProps) {
+  return (
+    <Grid
+      as="article"
+      gridTemplateColumns={{ base: "1fr", md: columns }}
+      gap={{ base: 3, md: 3 }}
+      alignItems={{ md: "center" }}
+      p={{ base: 4, md: 3 }}
+      bg="white"
+      border="1px solid"
+      borderColor="brand.border"
+      borderRadius={{ base: "lg", md: 0 }}
+      borderTopWidth={{ md: 0 }}
+    >
+      {children}
+    </Grid>
+  );
+}
+
+interface ResourceCollectionCellProps {
+  label: string;
+  primary?: boolean;
+  children: ReactNode;
+}
+
+export function ResourceCollectionCell({
+  label,
+  primary = false,
+  children,
+}: ResourceCollectionCellProps) {
+  return (
+    <Box
+      minW={0}
+      display={{ base: primary ? "block" : "flex", md: "block" }}
+      alignItems="center"
+      justifyContent="space-between"
+      gap={3}
+    >
+      {!primary && (
+        <Text
+          display={{ base: "block", md: "none" }}
+          fontSize="xs"
+          fontWeight={600}
+          color="gray.500"
+        >
+          {label}
+        </Text>
+      )}
+      {children}
+    </Box>
+  );
+}

--- a/frontend/src/components/ui/ResourceThumbnail.tsx
+++ b/frontend/src/components/ui/ResourceThumbnail.tsx
@@ -1,0 +1,52 @@
+import { Flex, Image } from "@chakra-ui/react";
+import { Article, Database, MapTrifold, Path } from "@phosphor-icons/react";
+
+interface ResourceThumbnailProps {
+  src?: string | null;
+  alt: string;
+  kind?: "story" | "raster" | "vector" | "pointcloud" | "trajectory";
+}
+
+export function ResourceThumbnail({
+  src,
+  alt,
+  kind = "story",
+}: ResourceThumbnailProps) {
+  if (src) {
+    return (
+      <Image
+        src={src}
+        alt={alt}
+        w="44px"
+        h="44px"
+        objectFit="cover"
+        borderRadius="md"
+        flexShrink={0}
+      />
+    );
+  }
+
+  const Icon =
+    kind === "trajectory"
+      ? Path
+      : kind === "story"
+        ? Article
+        : kind === "raster" || kind === "vector"
+          ? MapTrifold
+          : Database;
+  return (
+    <Flex
+      aria-label={`${alt} preview unavailable`}
+      w="44px"
+      h="44px"
+      align="center"
+      justify="center"
+      bg="brand.bgSubtle"
+      color="brand.orange"
+      borderRadius="md"
+      flexShrink={0}
+    >
+      <Icon size={20} />
+    </Flex>
+  );
+}

--- a/frontend/src/hooks/__tests__/useWorkspaceLibrary.test.ts
+++ b/frontend/src/hooks/__tests__/useWorkspaceLibrary.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { connectionsApi, workspaceFetch } from "../../lib/api";
+import {
+  useWorkspaceConnections,
+  useWorkspaceDatasets,
+} from "../useWorkspaceLibrary";
+
+vi.mock("../../lib/api", () => ({
+  workspaceFetch: vi.fn(),
+  connectionsApi: { list: vi.fn() },
+}));
+
+const dataset = {
+  id: "dataset-1",
+  name: "rain.tif",
+  original_filename: "rain.tif",
+  dataset_type: "raster" as const,
+};
+
+describe("workspace resource hooks", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("does not turn a failed dataset response into an empty collection", async () => {
+    vi.mocked(workspaceFetch).mockResolvedValue(
+      new Response("failed", { status: 503 })
+    );
+
+    const { result } = renderHook(() => useWorkspaceDatasets());
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.data).toEqual([]);
+    expect(result.current.error).toBe("HTTP 503");
+  });
+
+  it("preserves dataset data when a retry fails", async () => {
+    vi.mocked(workspaceFetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([dataset]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+      .mockResolvedValueOnce(new Response("failed", { status: 500 }));
+
+    const { result } = renderHook(() => useWorkspaceDatasets());
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    act(() => result.current.retry());
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.data).toEqual([dataset]);
+  });
+
+  it("reports connection failures independently", async () => {
+    vi.mocked(connectionsApi.list).mockRejectedValue(
+      new Error("Connections unavailable")
+    );
+
+    const { result } = renderHook(() => useWorkspaceConnections());
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe("Connections unavailable");
+  });
+});

--- a/frontend/src/hooks/useStoryEditor.ts
+++ b/frontend/src/hooks/useStoryEditor.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useWorkspace } from "./useWorkspace";
 import { useSaveStatus } from "./useSaveStatus";
+import {
+  useWorkspaceConnections,
+  useWorkspaceDatasets,
+} from "./useWorkspaceLibrary";
 import {
   type CameraState,
   DEFAULT_CAMERA,
@@ -16,7 +20,6 @@ import {
   type MapState,
   type ChapterRenderMetadata,
   DEFAULT_LAYER_CONFIG,
-  createStory,
   createChapter,
   createScrollytellingChapter,
   createMapChapter,
@@ -27,7 +30,6 @@ import {
   createFlyoverChapter,
   isMapBoundChapter,
   flyoverEntryMapState,
-  createStoryOnServer,
   getStoryFromServer,
   saveStoryToServer,
   migrateStory,
@@ -38,15 +40,12 @@ import { captureKeyframe } from "../lib/story/flyover/keyframes";
 import { captureCameraToChapter } from "../lib/story/cameraCapture";
 import type { Connection, Dataset } from "../types";
 import { config } from "../config";
-import { workspaceFetch, connectionsApi } from "../lib/api";
+import { workspaceFetch } from "../lib/api";
 import { toaster } from "../lib/toaster";
 
 export function useStoryEditor() {
   const { id } = useParams<{ id: string }>();
-  const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
   const { workspacePath } = useWorkspace();
-  const datasetIdParam = searchParams.get("dataset");
 
   const [story, setStory] = useState<Story | null>(null);
   const [dataset, setDataset] = useState<Dataset | null>(null);
@@ -63,29 +62,13 @@ export function useStoryEditor() {
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const autoCaptureRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mapContainerRef = useRef<HTMLDivElement>(null);
-  const [allDatasets, setAllDatasets] = useState<Dataset[]>([]);
-  const [allConnections, setAllConnections] = useState<Connection[]>([]);
+  const datasetsResource = useWorkspaceDatasets();
+  const connectionsResource = useWorkspaceConnections();
   const [uploadModalOpen, setUploadModalOpen] = useState(false);
   const { saveState, markSaving, markSaved, markError } = useSaveStatus();
 
-  useEffect(() => {
-    async function fetchAllDatasets() {
-      try {
-        const resp = await workspaceFetch(`${config.apiBase}/api/datasets`);
-        if (resp.ok) setAllDatasets(await resp.json());
-      } catch {
-        // ignore fetch errors
-      }
-    }
-    fetchAllDatasets();
-  }, []);
-
-  useEffect(() => {
-    connectionsApi
-      .list()
-      .then(setAllConnections)
-      .catch(() => {});
-  }, []);
+  const allDatasets = datasetsResource.data;
+  const allConnections = connectionsResource.data;
 
   // Load existing story
   useEffect(() => {
@@ -113,53 +96,6 @@ export function useStoryEditor() {
     }
     loadStory();
   }, [id]);
-
-  // Create new story if this is /story/new
-  useEffect(() => {
-    if (id || story) return;
-    async function createNew() {
-      try {
-        let fetchedDataset: Dataset | null = null;
-        if (datasetIdParam) {
-          const resp = await workspaceFetch(
-            `${config.apiBase}/api/datasets/${datasetIdParam}`
-          );
-          if (resp.ok) {
-            fetchedDataset = await resp.json();
-            setDataset(fetchedDataset);
-          }
-        }
-        const draft = createStory(datasetIdParam, {
-          preferredColormap: fetchedDataset?.preferred_colormap ?? null,
-          preferredColormapReversed:
-            fetchedDataset?.preferred_colormap_reversed ?? null,
-        });
-        if (fetchedDataset?.bounds) {
-          const cam = cameraFromBounds(fetchedDataset.bounds);
-          const firstChapter = draft.chapters[0];
-          if (firstChapter && isMapBoundChapter(firstChapter)) {
-            firstChapter.map_state = {
-              center: [cam.longitude, cam.latitude],
-              zoom: cam.zoom,
-              bearing: 0,
-              pitch: 0,
-              basemap: "streets",
-            };
-          }
-          setCamera(cam);
-        }
-        const saved = await createStoryOnServer(draft);
-        setStory(saved);
-        setActiveChapterId(saved.chapters[0]?.id ?? "");
-        navigate(workspacePath(`/story/${saved.id}/edit`), { replace: true });
-      } catch (e) {
-        setError(e instanceof Error ? e.message : "Failed to create story");
-      } finally {
-        setLoading(false);
-      }
-    }
-    createNew();
-  }, [id, story, datasetIdParam, navigate, workspacePath]);
 
   // Fetch primary dataset for existing stories
   useEffect(() => {
@@ -569,9 +505,7 @@ export function useStoryEditor() {
       );
       if (!resp.ok) return;
       const ds: Dataset = await resp.json();
-      setAllDatasets((prev) =>
-        prev.some((d) => d.id === ds.id) ? prev : [...prev, ds]
-      );
+      datasetsResource.retry();
       if (activeChapterId) {
         const baseConfig =
           activeChapter && isMapBoundChapter(activeChapter)
@@ -652,6 +586,8 @@ export function useStoryEditor() {
     mapContainerRef,
     allDatasets,
     allConnections,
+    datasetsResource,
+    connectionsResource,
     uploadModalOpen,
     saveState,
     layers,
@@ -679,7 +615,6 @@ export function useStoryEditor() {
     setBasemap,
     setPublishDialogOpen,
     setUploadModalOpen,
-    handleConnectionCreated: (conn: Connection) =>
-      setAllConnections((prev) => [conn, ...prev]),
+    handleConnectionCreated: (_conn: Connection) => connectionsResource.retry(),
   };
 }

--- a/frontend/src/hooks/useWorkspaceLibrary.ts
+++ b/frontend/src/hooks/useWorkspaceLibrary.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { config } from "../config";
+import { connectionsApi, workspaceFetch } from "../lib/api";
+import type { Connection, Dataset } from "../types";
+import { listStoriesFromServer } from "../lib/story/api";
+import type { Story } from "../lib/story/types";
+
+export type ResourceStatus = "loading" | "ready" | "empty" | "error";
+
+export interface ResourceState<T> {
+  status: ResourceStatus;
+  data: T[];
+  error: string | null;
+  retry: () => void;
+}
+
+function message(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+export function useWorkspaceDatasets(): ResourceState<Dataset> {
+  const [data, setData] = useState<Dataset[]>([]);
+  const [status, setStatus] = useState<ResourceStatus>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [request, setRequest] = useState(0);
+  const requestRef = useRef(0);
+
+  const retry = useCallback(() => setRequest((value) => value + 1), []);
+
+  useEffect(() => {
+    const requestId = ++requestRef.current;
+    const controller = new AbortController();
+    setStatus("loading");
+    setError(null);
+
+    workspaceFetch(`${config.apiBase}/api/datasets`, {
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return (await response.json()) as Dataset[];
+      })
+      .then((next) => {
+        if (requestId !== requestRef.current) return;
+        setData(next);
+        setStatus(next.length === 0 ? "empty" : "ready");
+      })
+      .catch((cause) => {
+        if (controller.signal.aborted || requestId !== requestRef.current)
+          return;
+        setStatus("error");
+        setError(message(cause, "Couldn’t load datasets"));
+      });
+
+    return () => controller.abort();
+  }, [request]);
+
+  return { data, status, error, retry };
+}
+
+export function useWorkspaceConnections(): ResourceState<Connection> {
+  const [data, setData] = useState<Connection[]>([]);
+  const [status, setStatus] = useState<ResourceStatus>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [request, setRequest] = useState(0);
+  const requestRef = useRef(0);
+
+  const retry = useCallback(() => setRequest((value) => value + 1), []);
+
+  useEffect(() => {
+    const requestId = ++requestRef.current;
+    setStatus("loading");
+    setError(null);
+
+    connectionsApi
+      .list()
+      .then((next) => {
+        if (requestId !== requestRef.current) return;
+        setData(next);
+        setStatus(next.length === 0 ? "empty" : "ready");
+      })
+      .catch((cause) => {
+        if (requestId !== requestRef.current) return;
+        setStatus("error");
+        setError(message(cause, "Couldn’t load connections"));
+      });
+
+    return () => {
+      requestRef.current += 1;
+    };
+  }, [request]);
+
+  return { data, status, error, retry };
+}
+
+export function useWorkspaceStories(): ResourceState<Story> {
+  const [data, setData] = useState<Story[]>([]);
+  const [status, setStatus] = useState<ResourceStatus>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [request, setRequest] = useState(0);
+  const requestRef = useRef(0);
+
+  const retry = useCallback(() => setRequest((value) => value + 1), []);
+
+  useEffect(() => {
+    const requestId = ++requestRef.current;
+    setStatus("loading");
+    setError(null);
+
+    listStoriesFromServer()
+      .then((next) => {
+        if (requestId !== requestRef.current) return;
+        setData(next);
+        setStatus(next.length === 0 ? "empty" : "ready");
+      })
+      .catch((cause) => {
+        if (requestId !== requestRef.current) return;
+        setStatus("error");
+        setError(message(cause, "Couldn’t load stories"));
+      });
+
+    return () => {
+      requestRef.current += 1;
+    };
+  }, [request]);
+
+  return { data, status, error, retry };
+}

--- a/frontend/src/lib/story/__tests__/chapterRegistry.test.ts
+++ b/frontend/src/lib/story/__tests__/chapterRegistry.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { CHAPTER_TYPE_REGISTRY } from "../chapterRegistry";
+
+describe("chapter type registry", () => {
+  it("defines every chapter type exactly once", () => {
+    expect(CHAPTER_TYPE_REGISTRY.map((item) => item.type).sort()).toEqual(
+      [
+        "chart",
+        "flyover",
+        "image",
+        "map",
+        "prose",
+        "scrollytelling",
+        "video",
+      ].sort()
+    );
+  });
+
+  it("keeps specialized types secondary", () => {
+    const secondary = CHAPTER_TYPE_REGISTRY.filter(
+      (item) => item.prominence === "secondary"
+    ).map((item) => item.type);
+    expect(secondary).toEqual(["video", "chart", "flyover"]);
+  });
+});

--- a/frontend/src/lib/story/chapterRegistry.ts
+++ b/frontend/src/lib/story/chapterRegistry.ts
@@ -1,0 +1,83 @@
+import type { ComponentType } from "react";
+import {
+  Article,
+  ChartLine,
+  Image,
+  MapTrifold,
+  PaperPlaneTilt,
+  Path,
+  VideoCamera,
+} from "@phosphor-icons/react";
+import type { ChapterType } from "./types";
+import { CHAPTER_TYPE_DESCRIPTIONS, CHAPTER_TYPE_LABELS } from "./labels";
+
+export interface ChapterTypeDefinition {
+  type: ChapterType;
+  group: "map" | "media" | "writing";
+  label: string;
+  description: string;
+  icon: ComponentType<{ size?: number }>;
+  prominence: "primary" | "secondary";
+  requiresData: boolean;
+}
+
+function definition(
+  type: ChapterType,
+  values: Omit<ChapterTypeDefinition, "type" | "label" | "description">
+): ChapterTypeDefinition {
+  return {
+    type,
+    label: CHAPTER_TYPE_LABELS[type],
+    description: CHAPTER_TYPE_DESCRIPTIONS[type],
+    ...values,
+  };
+}
+
+export const CHAPTER_TYPE_REGISTRY: ChapterTypeDefinition[] = [
+  definition("scrollytelling", {
+    group: "map",
+    icon: Path,
+    prominence: "primary",
+    requiresData: true,
+  }),
+  definition("map", {
+    group: "map",
+    icon: MapTrifold,
+    prominence: "primary",
+    requiresData: true,
+  }),
+  definition("image", {
+    group: "media",
+    icon: Image,
+    prominence: "primary",
+    requiresData: false,
+  }),
+  definition("prose", {
+    group: "writing",
+    icon: Article,
+    prominence: "primary",
+    requiresData: false,
+  }),
+  definition("video", {
+    group: "media",
+    icon: VideoCamera,
+    prominence: "secondary",
+    requiresData: false,
+  }),
+  definition("chart", {
+    group: "media",
+    icon: ChartLine,
+    prominence: "secondary",
+    requiresData: false,
+  }),
+  definition("flyover", {
+    group: "map",
+    icon: PaperPlaneTilt,
+    prominence: "secondary",
+    requiresData: false,
+  }),
+];
+
+export function chapterTypeDefinition(type: ChapterType) {
+  return CHAPTER_TYPE_REGISTRY.find((item) => item.type === type)!;
+}

--- a/frontend/src/pages/DataPage.tsx
+++ b/frontend/src/pages/DataPage.tsx
@@ -1,14 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { Link } from "react-router-dom";
-import {
-  Badge,
-  Box,
-  Button,
-  Flex,
-  Heading,
-  Table,
-  Text,
-} from "@chakra-ui/react";
+import { Badge, Box, Button, Flex, Heading, Text } from "@chakra-ui/react";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
 import { ExpiryBadge } from "../components/ExpiryBadge";
@@ -16,7 +8,7 @@ import { ExampleDataToggle } from "../components/ExampleDataToggle";
 import { useWorkspace } from "../hooks/useWorkspace";
 import { config } from "../config";
 import { workspaceFetch, connectionsApi } from "../lib/api";
-import type { Dataset, Connection } from "../types";
+import type { Dataset } from "../types";
 import { timeAgo } from "../utils/format";
 import {
   datasetToLibraryItem,
@@ -28,6 +20,18 @@ import { CollectionSkeleton } from "../components/ui/CollectionSkeleton";
 import { PageHeader } from "../components/PageHeader";
 import { ConfirmDialog } from "../components/ui/ConfirmDialog";
 import { CREATE_MAP_INTENT } from "../lib/creationIntents";
+import {
+  useWorkspaceConnections,
+  useWorkspaceDatasets,
+} from "../hooks/useWorkspaceLibrary";
+import {
+  ResourceCollection,
+  ResourceCollectionCell,
+  ResourceCollectionRow,
+} from "../components/ui/ResourceCollection";
+import { ResourceThumbnail } from "../components/ui/ResourceThumbnail";
+
+const DATA_COLUMNS = "minmax(0, 1fr) 90px 200px 100px 140px 80px";
 
 interface DatasetWithStoryCount extends Dataset {
   story_count?: number;
@@ -35,95 +39,69 @@ interface DatasetWithStoryCount extends Dataset {
 
 export default function DataPage() {
   const { workspacePath } = useWorkspace();
-  const [datasets, setDatasets] = useState<DatasetWithStoryCount[]>([]);
-  const [connections, setConnections] = useState<Connection[]>([]);
-  const [datasetsLoading, setDatasetsLoading] = useState(true);
-  const [connectionsLoading, setConnectionsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const datasetsResource = useWorkspaceDatasets();
+  const connectionsResource = useWorkspaceConnections();
+  const datasets = datasetsResource.data as DatasetWithStoryCount[];
+  const connections = connectionsResource.data;
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<LibraryItem | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const loadRequestIdRef = useRef(0);
-
   const reload = useCallback(() => {
-    const requestId = ++loadRequestIdRef.current;
-    const isCurrent = () => requestId === loadRequestIdRef.current;
+    datasetsResource.retry();
+    connectionsResource.retry();
+  }, [datasetsResource.retry, connectionsResource.retry]);
 
-    setError(null);
-    setDatasetsLoading(true);
-    setConnectionsLoading(true);
-
-    workspaceFetch(`${config.apiBase}/api/datasets`)
-      .then((r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.json();
-      })
-      .then((data) => {
-        if (isCurrent()) setDatasets(data);
-      })
-      .catch((err) => {
-        if (isCurrent()) setError((err as Error).message);
-      })
-      .finally(() => {
-        if (isCurrent()) setDatasetsLoading(false);
-      });
-
-    connectionsApi
-      .list()
-      .then((data) => {
-        if (isCurrent()) setConnections(data);
-      })
-      .catch((err) => {
-        if (isCurrent()) setError((err as Error).message);
-      })
-      .finally(() => {
-        if (isCurrent()) setConnectionsLoading(false);
-      });
-  }, []);
-
-  useEffect(() => {
-    reload();
-    return () => {
-      loadRequestIdRef.current += 1;
-    };
-  }, [reload]);
-
-  const handleDelete = useCallback(async (item: LibraryItem) => {
-    setDeleteError(null);
-    if (item.raw.kind === "dataset") {
-      const ds = item.raw.dataset as DatasetWithStoryCount;
-      setDeletingId(item.id);
-      try {
-        const resp = await workspaceFetch(
-          `${config.apiBase}/api/datasets/${ds.id}`,
-          { method: "DELETE" }
-        );
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-        setDatasets((prev) => prev.filter((d) => d.id !== ds.id));
-        setPendingDelete(null);
-      } catch {
-        setDeleteError(
-          "Couldn’t delete this data. Check your connection and try again."
-        );
-      } finally {
-        setDeletingId(null);
+  const handleDelete = useCallback(
+    async (item: LibraryItem) => {
+      setDeleteError(null);
+      if (item.raw.kind === "dataset") {
+        const ds = item.raw.dataset as DatasetWithStoryCount;
+        setDeletingId(item.id);
+        try {
+          const resp = await workspaceFetch(
+            `${config.apiBase}/api/datasets/${ds.id}`,
+            { method: "DELETE" }
+          );
+          if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+          datasetsResource.retry();
+          setPendingDelete(null);
+        } catch {
+          setDeleteError(
+            "Couldn’t delete this data. Check your connection and try again."
+          );
+        } finally {
+          setDeletingId(null);
+        }
+      } else {
+        const conn = item.raw.connection;
+        setDeletingId(item.id);
+        try {
+          await connectionsApi.delete(conn.id);
+          connectionsResource.retry();
+          setPendingDelete(null);
+        } catch {
+          setDeleteError(
+            "Couldn’t delete this connection. Check your connection and try again."
+          );
+        } finally {
+          setDeletingId(null);
+        }
       }
-    } else {
-      const conn = item.raw.connection;
-      setDeletingId(item.id);
-      try {
-        await connectionsApi.delete(conn.id);
-        setConnections((prev) => prev.filter((c) => c.id !== conn.id));
-        setPendingDelete(null);
-      } catch {
-        setDeleteError(
-          "Couldn’t delete this connection. Check your connection and try again."
-        );
-      } finally {
-        setDeletingId(null);
-      }
-    }
-  }, []);
+    },
+    [datasetsResource.retry, connectionsResource.retry]
+  );
+
+  const userItems: LibraryItem[] = [
+    ...datasets.filter((d) => !d.is_example).map(datasetToLibraryItem),
+    ...connections.filter((c) => !c.is_example).map(connectionToLibraryItem),
+  ].sort((a, b) => (a.addedAt < b.addedAt ? 1 : -1));
+  const loading =
+    userItems.length === 0 &&
+    (datasetsResource.status === "loading" ||
+      connectionsResource.status === "loading");
+  const resourceError = [datasetsResource.error, connectionsResource.error]
+    .filter(Boolean)
+    .join("; ");
 
   return (
     <Flex direction="column" minH="100vh" bg="bg">
@@ -146,27 +124,26 @@ export default function DataPage() {
           Your data
         </Heading>
 
-        {datasetsLoading || connectionsLoading ? (
-          <CollectionSkeleton rows={4} />
-        ) : error ? (
-          <StatePanel
-            tone="danger"
-            title="Couldn’t load your data library"
-            description={error}
-            actionLabel="Try again"
-            onAction={reload}
-          />
-        ) : (
-          (() => {
-            const userItems: LibraryItem[] = [
-              ...datasets
-                .filter((d) => !d.is_example)
-                .map(datasetToLibraryItem),
-              ...connections
-                .filter((c) => !c.is_example)
-                .map(connectionToLibraryItem),
-            ].sort((a, b) => (a.addedAt < b.addedAt ? 1 : -1));
+        {resourceError && (
+          <Box mb={4}>
+            <StatePanel
+              tone="danger"
+              title={
+                userItems.length === 0
+                  ? "Couldn’t load your data library"
+                  : "Some data couldn’t load"
+              }
+              description={resourceError}
+              actionLabel="Try again"
+              onAction={reload}
+            />
+          </Box>
+        )}
 
+        {loading ? (
+          <CollectionSkeleton rows={4} />
+        ) : resourceError && userItems.length === 0 ? null : (
+          (() => {
             if (userItems.length === 0) {
               return (
                 <StatePanel
@@ -184,118 +161,111 @@ export default function DataPage() {
             }
 
             return (
-              <Box overflowX="auto" pb={2}>
-                <Table.Root size="sm" tableLayout="fixed">
-                  <Table.Header>
-                    <Table.Row>
-                      <Table.ColumnHeader>Name</Table.ColumnHeader>
-                      <Table.ColumnHeader w="90px">Type</Table.ColumnHeader>
-                      <Table.ColumnHeader w="200px">Source</Table.ColumnHeader>
-                      <Table.ColumnHeader w="100px">Added</Table.ColumnHeader>
-                      <Table.ColumnHeader w="140px">Expires</Table.ColumnHeader>
-                      <Table.ColumnHeader w="80px" />
-                    </Table.Row>
-                  </Table.Header>
-                  <Table.Body>
-                    {userItems.map((item) => (
-                      <Table.Row key={`${item.kind}-${item.id}`}>
-                        <Table.Cell>
-                          <Flex align="center" gap={2}>
-                            <Link to={workspacePath(item.detailHref)}>
-                              <Text
-                                color="brand.orange"
-                                _hover={{ textDecoration: "underline" }}
-                                fontWeight={500}
-                                truncate
-                                title={item.name}
-                              >
-                                {item.name}
-                              </Text>
-                            </Link>
-                            {item.isExampleCopy && (
-                              <Badge
-                                size="sm"
-                                bg="brand.bgSubtle"
-                                color="brand.brown"
-                              >
-                                Example
-                              </Badge>
-                            )}
-                          </Flex>
-                        </Table.Cell>
-                        <Table.Cell>
+              <ResourceCollection
+                columns={DATA_COLUMNS}
+                headers={["Name", "Type", "Source", "Added", "Expires", ""]}
+              >
+                {userItems.map((item) => (
+                  <ResourceCollectionRow
+                    key={`${item.kind}-${item.id}`}
+                    columns={DATA_COLUMNS}
+                  >
+                    <ResourceCollectionCell label="Name" primary>
+                      <Flex align="center" gap={2}>
+                        <ResourceThumbnail alt={item.name} kind={item.type} />
+                        <Link to={workspacePath(item.detailHref)}>
                           <Text
-                            fontSize="xs"
-                            fontWeight={600}
-                            textTransform="uppercase"
-                            color={
-                              item.type === "raster" ? "purple.600" : "teal.600"
-                            }
+                            color="brand.orange"
+                            _hover={{ textDecoration: "underline" }}
+                            fontWeight={500}
+                            truncate
+                            title={item.name}
                           >
-                            {item.type}
+                            {item.name}
                           </Text>
-                        </Table.Cell>
-                        <Table.Cell>
-                          {item.source.href ? (
-                            <a
-                              href={item.source.href}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              title={item.source.label}
-                              style={{
-                                color: "var(--chakra-colors-gray-500)",
-                                fontSize: 13,
-                              }}
-                            >
-                              <Text
-                                fontSize="sm"
-                                color="gray.500"
-                                truncate
-                                title={item.source.label}
-                              >
-                                {item.source.label}
-                              </Text>
-                            </a>
-                          ) : (
-                            <Text fontSize="sm" color="gray.500">
-                              {item.source.label}
-                            </Text>
-                          )}
-                        </Table.Cell>
-                        <Table.Cell>
-                          <Text fontSize="sm" color="gray.600">
-                            {item.addedAt ? timeAgo(item.addedAt) : "—"}
-                          </Text>
-                        </Table.Cell>
-                        <Table.Cell>
-                          {item.expiresAt ? (
-                            <ExpiryBadge expiresAt={item.expiresAt} />
-                          ) : (
-                            <Text fontSize="sm" color="gray.500">
-                              —
-                            </Text>
-                          )}
-                        </Table.Cell>
-                        <Table.Cell>
-                          <Button
-                            size="xs"
-                            variant="ghost"
-                            color="status.danger.fg"
-                            _hover={{ bg: "status.danger.subtle" }}
-                            loading={deletingId === item.id}
-                            onClick={() => {
-                              setDeleteError(null);
-                              setPendingDelete(item);
-                            }}
+                        </Link>
+                        {item.isExampleCopy && (
+                          <Badge
+                            size="sm"
+                            bg="brand.bgSubtle"
+                            color="brand.brown"
                           >
-                            Delete
-                          </Button>
-                        </Table.Cell>
-                      </Table.Row>
-                    ))}
-                  </Table.Body>
-                </Table.Root>
-              </Box>
+                            Example
+                          </Badge>
+                        )}
+                      </Flex>
+                    </ResourceCollectionCell>
+                    <ResourceCollectionCell label="Type">
+                      <Text
+                        fontSize="xs"
+                        fontWeight={600}
+                        textTransform="uppercase"
+                        color={
+                          item.type === "raster" ? "purple.600" : "teal.600"
+                        }
+                      >
+                        {item.type}
+                      </Text>
+                    </ResourceCollectionCell>
+                    <ResourceCollectionCell label="Source">
+                      {item.source.href ? (
+                        <a
+                          href={item.source.href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title={item.source.label}
+                          style={{
+                            color: "var(--chakra-colors-gray-500)",
+                            fontSize: 13,
+                          }}
+                        >
+                          <Text
+                            fontSize="sm"
+                            color="gray.500"
+                            truncate
+                            title={item.source.label}
+                          >
+                            {item.source.label}
+                          </Text>
+                        </a>
+                      ) : (
+                        <Text fontSize="sm" color="gray.500">
+                          {item.source.label}
+                        </Text>
+                      )}
+                    </ResourceCollectionCell>
+                    <ResourceCollectionCell label="Added">
+                      <Text fontSize="sm" color="gray.600">
+                        {item.addedAt ? timeAgo(item.addedAt) : "—"}
+                      </Text>
+                    </ResourceCollectionCell>
+                    <ResourceCollectionCell label="Expires">
+                      {item.expiresAt ? (
+                        <ExpiryBadge expiresAt={item.expiresAt} />
+                      ) : (
+                        <Text fontSize="sm" color="gray.500">
+                          —
+                        </Text>
+                      )}
+                    </ResourceCollectionCell>
+                    <ResourceCollectionCell label="Actions">
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        color="status.danger.fg"
+                        _hover={{ bg: "status.danger.subtle" }}
+                        loading={deletingId === item.id}
+                        onClick={() => {
+                          setDeleteError(null);
+                          setPendingDelete(item);
+                        }}
+                      >
+                        Delete
+                      </Button>
+                    </ResourceCollectionCell>
+                  </ResourceCollectionRow>
+                ))}
+              </ResourceCollection>
             );
           })()
         )}

--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { Badge, Box, Button, Flex, Table, Text } from "@chakra-ui/react";
+import { Badge, Box, Button, Flex, Text } from "@chakra-ui/react";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
 import { ExpiryBadge } from "../components/ExpiryBadge";
@@ -13,6 +13,23 @@ import { CollectionSkeleton } from "../components/ui/CollectionSkeleton";
 import { PageHeader } from "../components/PageHeader";
 import { ConfirmDialog } from "../components/ui/ConfirmDialog";
 import { CREATE_MAP_INTENT, CREATE_STORY_INTENT } from "../lib/creationIntents";
+import {
+  ResourceCollection,
+  ResourceCollectionCell,
+  ResourceCollectionRow,
+} from "../components/ui/ResourceCollection";
+import { ResourceThumbnail } from "../components/ui/ResourceThumbnail";
+
+const STORY_COLUMNS = "minmax(0, 1fr) 100px 100px 100px 140px 80px";
+
+function storyThumbnailUrl(story: Story): string | null {
+  const imageChapter = story.chapters.find(
+    (chapter) => chapter.type === "image"
+  );
+  return imageChapter?.type === "image"
+    ? imageChapter.image.thumbnail_url || imageChapter.image.url
+    : null;
+}
 
 export default function StoriesPage() {
   const { workspacePath } = useWorkspace();
@@ -123,94 +140,83 @@ export default function StoriesPage() {
             }
           />
         ) : (
-          <Box overflowX="auto" pb={2}>
-            <Table.Root size="sm" tableLayout="fixed">
-              <Table.Header>
-                <Table.Row>
-                  <Table.ColumnHeader>Name</Table.ColumnHeader>
-                  <Table.ColumnHeader w="100px">Status</Table.ColumnHeader>
-                  <Table.ColumnHeader w="100px">Chapters</Table.ColumnHeader>
-                  <Table.ColumnHeader w="100px">Updated</Table.ColumnHeader>
-                  <Table.ColumnHeader w="140px">Expires</Table.ColumnHeader>
-                  <Table.ColumnHeader w="80px" />
-                </Table.Row>
-              </Table.Header>
-              <Table.Body>
-                {userStories.map((story) => (
-                  <Table.Row key={story.id}>
-                    <Table.Cell>
-                      <Flex align="center" gap={2}>
-                        <Link to={workspacePath(`/story/${story.id}/edit`)}>
-                          <Text
-                            color="brand.orange"
-                            _hover={{ textDecoration: "underline" }}
-                            fontWeight={500}
-                            truncate
-                            title={story.title}
-                          >
-                            {story.title}
-                          </Text>
-                        </Link>
-                        {story.is_example_copy && (
-                          <Badge
-                            size="sm"
-                            bg="brand.bgSubtle"
-                            color="brand.brown"
-                          >
-                            Example
-                          </Badge>
-                        )}
-                      </Flex>
-                    </Table.Cell>
-                    <Table.Cell>
+          <ResourceCollection
+            columns={STORY_COLUMNS}
+            headers={["Name", "Status", "Chapters", "Updated", "Expires", ""]}
+          >
+            {userStories.map((story) => (
+              <ResourceCollectionRow key={story.id} columns={STORY_COLUMNS}>
+                <ResourceCollectionCell label="Name" primary>
+                  <Flex align="center" gap={2}>
+                    <ResourceThumbnail
+                      src={storyThumbnailUrl(story)}
+                      alt={story.title}
+                    />
+                    <Link to={workspacePath(`/story/${story.id}/edit`)}>
                       <Text
-                        fontSize="xs"
-                        fontWeight={600}
-                        textTransform="uppercase"
-                        color={story.published ? "green.600" : "gray.500"}
+                        color="brand.orange"
+                        _hover={{ textDecoration: "underline" }}
+                        fontWeight={500}
+                        truncate
+                        title={story.title}
                       >
-                        {story.published ? "Published" : "Draft"}
+                        {story.title}
                       </Text>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Text fontSize="sm" color="gray.600">
-                        {story.chapters.length}
-                      </Text>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Text fontSize="sm" color="gray.600">
-                        {story.updated_at ? timeAgo(story.updated_at) : "—"}
-                      </Text>
-                    </Table.Cell>
-                    <Table.Cell>
-                      {story.expires_at ? (
-                        <ExpiryBadge expiresAt={story.expires_at} />
-                      ) : (
-                        <Text fontSize="sm" color="gray.500">
-                          —
-                        </Text>
-                      )}
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Button
-                        size="xs"
-                        variant="ghost"
-                        color="status.danger.fg"
-                        _hover={{ bg: "status.danger.subtle" }}
-                        loading={deletingId === story.id}
-                        onClick={() => {
-                          setDeleteError(null);
-                          setPendingDelete(story);
-                        }}
-                      >
-                        Delete
-                      </Button>
-                    </Table.Cell>
-                  </Table.Row>
-                ))}
-              </Table.Body>
-            </Table.Root>
-          </Box>
+                    </Link>
+                    {story.is_example_copy && (
+                      <Badge size="sm" bg="brand.bgSubtle" color="brand.brown">
+                        Example
+                      </Badge>
+                    )}
+                  </Flex>
+                </ResourceCollectionCell>
+                <ResourceCollectionCell label="Status">
+                  <Text
+                    fontSize="xs"
+                    fontWeight={600}
+                    textTransform="uppercase"
+                    color={story.published ? "green.600" : "gray.500"}
+                  >
+                    {story.published ? "Published" : "Draft"}
+                  </Text>
+                </ResourceCollectionCell>
+                <ResourceCollectionCell label="Chapters">
+                  <Text fontSize="sm" color="gray.600">
+                    {story.chapters.length}
+                  </Text>
+                </ResourceCollectionCell>
+                <ResourceCollectionCell label="Updated">
+                  <Text fontSize="sm" color="gray.600">
+                    {story.updated_at ? timeAgo(story.updated_at) : "—"}
+                  </Text>
+                </ResourceCollectionCell>
+                <ResourceCollectionCell label="Expires">
+                  {story.expires_at ? (
+                    <ExpiryBadge expiresAt={story.expires_at} />
+                  ) : (
+                    <Text fontSize="sm" color="gray.500">
+                      —
+                    </Text>
+                  )}
+                </ResourceCollectionCell>
+                <ResourceCollectionCell label="Actions">
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    color="status.danger.fg"
+                    _hover={{ bg: "status.danger.subtle" }}
+                    loading={deletingId === story.id}
+                    onClick={() => {
+                      setDeleteError(null);
+                      setPendingDelete(story);
+                    }}
+                  >
+                    Delete
+                  </Button>
+                </ResourceCollectionCell>
+              </ResourceCollectionRow>
+            ))}
+          </ResourceCollection>
         )}
       </Box>
       <ConfirmDialog

--- a/frontend/src/pages/StoryEditorPage.tsx
+++ b/frontend/src/pages/StoryEditorPage.tsx
@@ -153,6 +153,8 @@ export default function StoryEditorPage() {
     mapContainerRef,
     allDatasets,
     allConnections,
+    datasetsResource,
+    connectionsResource,
     uploadModalOpen,
     saveState,
     layers,
@@ -676,6 +678,24 @@ export default function StoryEditorPage() {
                   datasetType={activeDataset?.dataset_type ?? "raster"}
                   datasets={allDatasets}
                   connections={allConnections}
+                  dataStatus={
+                    datasetsResource.status === "loading" ||
+                    connectionsResource.status === "loading"
+                      ? "loading"
+                      : datasetsResource.status === "error" ||
+                          connectionsResource.status === "error"
+                        ? "error"
+                        : "ready"
+                  }
+                  dataError={
+                    [datasetsResource.error, connectionsResource.error]
+                      .filter(Boolean)
+                      .join("; ") || null
+                  }
+                  onDataRetry={() => {
+                    datasetsResource.retry();
+                    connectionsResource.retry();
+                  }}
                   onUploadClick={() => setUploadModalOpen(true)}
                   onAddConnectionClick={() => setConnectionModalOpen(true)}
                   overlayPosition={

--- a/frontend/src/pages/StoryReaderInner.tsx
+++ b/frontend/src/pages/StoryReaderInner.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { Box, Flex, Heading, Text } from "@chakra-ui/react";
 import { StoryRenderer } from "../components/StoryRenderer";
 import { BugReportLink } from "../components/BugReportLink";
@@ -34,6 +34,30 @@ export function StoryReaderInner({
   const { enabled: chatEnabled } = useChatConfig();
   const showChat = chatEligible && chatEnabled;
 
+  const updateReadingProgress = useCallback(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    const remaining = element.scrollHeight - element.clientHeight;
+    setReadingProgress(remaining <= 0 ? 1 : element.scrollTop / remaining);
+  }, []);
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    updateReadingProgress();
+
+    const observer = new ResizeObserver(updateReadingProgress);
+    observer.observe(element);
+    if (element.firstElementChild) {
+      observer.observe(element.firstElementChild);
+    }
+    window.addEventListener("resize", updateReadingProgress);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateReadingProgress);
+    };
+  }, [story, updateReadingProgress]);
+
   return (
     <Box h="100vh" display="flex" flexDirection="column">
       {!embed && (
@@ -64,14 +88,7 @@ export function StoryReaderInner({
         ref={scrollRef}
         flex={1}
         overflowY="auto"
-        onScroll={() => {
-          const element = scrollRef.current;
-          if (!element) return;
-          const remaining = element.scrollHeight - element.clientHeight;
-          setReadingProgress(
-            remaining <= 0 ? 1 : element.scrollTop / remaining
-          );
-        }}
+        onScroll={updateReadingProgress}
       >
         <StoryRenderer
           story={story}

--- a/frontend/src/pages/StoryReaderInner.tsx
+++ b/frontend/src/pages/StoryReaderInner.tsx
@@ -8,6 +8,7 @@ import { useChatConfig } from "../lib/chat/useChatConfig";
 import type { AgentBridge } from "../lib/chat/types";
 import type { Story } from "../lib/story";
 import type { Connection, Dataset } from "../types";
+import { StoryProgress } from "../components/StoryProgress";
 
 interface StoryReaderInnerProps {
   story: Story;
@@ -27,7 +28,9 @@ export function StoryReaderInner({
   chatEligible = false,
 }: StoryReaderInnerProps) {
   const agentBridgeRef = useRef<AgentBridge | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
   const [chatOpen, setChatOpen] = useState(false);
+  const [readingProgress, setReadingProgress] = useState(0);
   const { enabled: chatEnabled } = useChatConfig();
   const showChat = chatEligible && chatEnabled;
 
@@ -55,7 +58,21 @@ export function StoryReaderInner({
         </Flex>
       )}
 
-      <Box flex={1} overflowY="auto">
+      <StoryProgress progress={readingProgress} />
+
+      <Box
+        ref={scrollRef}
+        flex={1}
+        overflowY="auto"
+        onScroll={() => {
+          const element = scrollRef.current;
+          if (!element) return;
+          const remaining = element.scrollHeight - element.clientHeight;
+          setReadingProgress(
+            remaining <= 0 ? 1 : element.scrollTop / remaining
+          );
+        }}
+      >
         <StoryRenderer
           story={story}
           datasetMap={datasetMap}

--- a/frontend/src/pages/StorySetupPage.tsx
+++ b/frontend/src/pages/StorySetupPage.tsx
@@ -1,0 +1,189 @@
+import { useMemo, useState } from "react";
+import { Box, Button, Flex, Heading, Text } from "@chakra-ui/react";
+import { Article, ImageSquare, MapTrifold } from "@phosphor-icons/react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Footer } from "../components/Footer";
+import { Header } from "../components/Header";
+import { PageHeader } from "../components/PageHeader";
+import { useWorkspace } from "../hooks/useWorkspace";
+import { useWorkspaceDatasets } from "../hooks/useWorkspaceLibrary";
+import { cameraFromBounds } from "../lib/layers";
+import {
+  createImageChapter,
+  createMapChapter,
+  createStory,
+  createStoryOnServer,
+  isMapBoundChapter,
+} from "../lib/story";
+import { displayName } from "../utils/dataset";
+
+type StoryTemplate = "map" | "media" | "blank";
+
+const templates = [
+  {
+    id: "map" as const,
+    title: "Map-led story",
+    description: "Guide readers through a map with narrative chapters.",
+    icon: MapTrifold,
+  },
+  {
+    id: "media" as const,
+    title: "Media story",
+    description: "Begin with an image, then add maps, video, or charts.",
+    icon: ImageSquare,
+  },
+  {
+    id: "blank" as const,
+    title: "Blank story",
+    description: "Start with writing and shape the structure yourself.",
+    icon: Article,
+  },
+];
+
+export default function StorySetupPage() {
+  const [searchParams] = useSearchParams();
+  const datasetId = searchParams.get("dataset");
+  const datasets = useWorkspaceDatasets();
+  const dataset = useMemo(
+    () => datasets.data.find((item) => item.id === datasetId),
+    [datasets.data, datasetId]
+  );
+  const [creating, setCreating] = useState<StoryTemplate | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const { workspacePath } = useWorkspace();
+
+  async function chooseTemplate(template: StoryTemplate) {
+    setCreating(template);
+    setError(null);
+    try {
+      const story =
+        template === "map"
+          ? datasetId
+            ? createStory(datasetId, {
+                preferredColormap: dataset?.preferred_colormap ?? null,
+                preferredColormapReversed:
+                  dataset?.preferred_colormap_reversed ?? null,
+              })
+            : createStory(null, {
+                chapters: [createMapChapter({ order: 0, title: "Chapter 1" })],
+              })
+          : template === "media"
+            ? createStory(null, {
+                chapters: [
+                  createImageChapter({ order: 0, title: "Chapter 1" }),
+                ],
+              })
+            : createStory();
+
+      const firstChapter = story.chapters[0];
+      if (
+        template === "map" &&
+        dataset?.bounds &&
+        firstChapter &&
+        isMapBoundChapter(firstChapter)
+      ) {
+        const camera = cameraFromBounds(dataset.bounds);
+        firstChapter.map_state = {
+          ...firstChapter.map_state,
+          center: [camera.longitude, camera.latitude],
+          zoom: camera.zoom,
+        };
+      }
+
+      const saved = await createStoryOnServer(story);
+      navigate(workspacePath(`/story/${saved.id}/edit`), { replace: true });
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : "Couldn’t create the story"
+      );
+      setCreating(null);
+    }
+  }
+
+  return (
+    <Flex direction="column" minH="100vh" bg="bg">
+      <Header />
+      <Box
+        as="main"
+        id="main-content"
+        maxW="960px"
+        mx="auto"
+        px={4}
+        py={{ base: 6, md: 10 }}
+        w="100%"
+        flex="1"
+      >
+        <PageHeader
+          title="Create a story"
+          description={
+            dataset
+              ? `Choose how to begin with ${displayName(dataset)}.`
+              : "Choose a starting point. You can add any chapter type later."
+          }
+        />
+        <Box
+          display="grid"
+          gridTemplateColumns={{ base: "1fr", md: "repeat(3, 1fr)" }}
+          gap={4}
+        >
+          {templates.map((template) => {
+            const Icon = template.icon;
+            const recommended = datasetId && template.id === "map";
+            return (
+              <Flex
+                key={template.id}
+                as="section"
+                direction="column"
+                align="start"
+                p={5}
+                minH="230px"
+                bg="white"
+                border="1px solid"
+                borderColor={recommended ? "brand.orange" : "brand.border"}
+                borderRadius="lg"
+              >
+                <Flex
+                  w={10}
+                  h={10}
+                  align="center"
+                  justify="center"
+                  bg="brand.bgSubtle"
+                  color="brand.orange"
+                  borderRadius="md"
+                  mb={5}
+                >
+                  <Icon size={22} />
+                </Flex>
+                <Heading size="md" color="fg" mb={2}>
+                  {template.title}
+                </Heading>
+                <Text fontSize="sm" color="fg.muted" lineHeight="1.6" mb={5}>
+                  {template.description}
+                </Text>
+                <Button
+                  mt="auto"
+                  size="sm"
+                  variant={recommended ? "solid" : "outline"}
+                  loading={creating === template.id}
+                  disabled={creating !== null}
+                  onClick={() => void chooseTemplate(template.id)}
+                >
+                  {recommended
+                    ? "Start with this map"
+                    : `Choose ${template.title}`}
+                </Button>
+              </Flex>
+            );
+          })}
+        </Box>
+        {error && (
+          <Text role="alert" mt={4} fontSize="sm" color="status.danger.fg">
+            {error}
+          </Text>
+        )}
+      </Box>
+      <Footer />
+    </Flex>
+  );
+}

--- a/frontend/src/pages/StorySetupPage.tsx
+++ b/frontend/src/pages/StorySetupPage.tsx
@@ -52,8 +52,22 @@ export default function StorySetupPage() {
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
   const { workspacePath } = useWorkspace();
+  const requestedDatasetLoading =
+    Boolean(datasetId) && !dataset && datasets.status === "loading";
+  const requestedDatasetError =
+    Boolean(datasetId) && !dataset && datasets.status === "error";
+  const requestedDatasetMissing =
+    Boolean(datasetId) &&
+    !dataset &&
+    (datasets.status === "ready" || datasets.status === "empty");
+  const requestedDatasetUnavailable =
+    requestedDatasetLoading || requestedDatasetError || requestedDatasetMissing;
 
   async function chooseTemplate(template: StoryTemplate) {
+    if (template === "map" && datasetId && !dataset) {
+      setError("The selected dataset is not available yet.");
+      return;
+    }
     setCreating(template);
     setError(null);
     try {
@@ -119,9 +133,35 @@ export default function StorySetupPage() {
           description={
             dataset
               ? `Choose how to begin with ${displayName(dataset)}.`
-              : "Choose a starting point. You can add any chapter type later."
+              : requestedDatasetLoading
+                ? "Loading the selected dataset before you begin."
+                : requestedDatasetError
+                  ? "We couldn’t load the selected dataset. Retry it or choose a story that doesn’t start with a map."
+                  : requestedDatasetMissing
+                    ? "The selected dataset is unavailable. Choose another starting point."
+                    : "Choose a starting point. You can add any chapter type later."
           }
         />
+        {requestedDatasetError && (
+          <Flex
+            role="alert"
+            align="center"
+            justify="space-between"
+            gap={3}
+            mb={5}
+            p={3}
+            bg="status.danger.subtle"
+            color="status.danger.fg"
+            borderRadius="md"
+          >
+            <Text fontSize="sm">
+              {datasets.error ?? "Couldn’t load the selected dataset"}
+            </Text>
+            <Button size="xs" variant="outline" onClick={datasets.retry}>
+              Try again
+            </Button>
+          </Flex>
+        )}
         <Box
           display="grid"
           gridTemplateColumns={{ base: "1fr", md: "repeat(3, 1fr)" }}
@@ -129,7 +169,9 @@ export default function StorySetupPage() {
         >
           {templates.map((template) => {
             const Icon = template.icon;
-            const recommended = datasetId && template.id === "map";
+            const recommended = Boolean(datasetId && template.id === "map");
+            const mapBlocked =
+              template.id === "map" && requestedDatasetUnavailable;
             return (
               <Flex
                 key={template.id}
@@ -166,12 +208,18 @@ export default function StorySetupPage() {
                   size="sm"
                   variant={recommended ? "solid" : "outline"}
                   loading={creating === template.id}
-                  disabled={creating !== null}
+                  disabled={creating !== null || mapBlocked}
                   onClick={() => void chooseTemplate(template.id)}
                 >
-                  {recommended
-                    ? "Start with this map"
-                    : `Choose ${template.title}`}
+                  {requestedDatasetLoading && template.id === "map"
+                    ? "Loading selected dataset…"
+                    : requestedDatasetError && template.id === "map"
+                      ? "Dataset couldn’t load"
+                      : requestedDatasetMissing && template.id === "map"
+                        ? "Dataset unavailable"
+                        : recommended
+                          ? "Start with this map"
+                          : `Choose ${template.title}`}
                 </Button>
               </Flex>
             );

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -57,7 +57,7 @@ export default function UploadPage() {
     name: "",
     size: "",
   });
-  const [mode, setMode] = useState<PageMode>("initial");
+  const [mode, setMode] = useState<PageMode>("upload-idle");
   const [reportOpen, setReportOpen] = useState(false);
   const [xyzPickerUrl, setXyzPickerUrl] = useState<string | null>(null);
   const [parquetPreviewUrl, setParquetPreviewUrl] = useState<string | null>(
@@ -273,10 +273,6 @@ export default function UploadPage() {
     setMode("upload-idle");
   }, []);
 
-  const handleCollapse = useCallback(() => {
-    setMode("initial");
-  }, []);
-
   const inlineContent = (
     <>
       {(mode === "uploading" || mode === "error") && (
@@ -354,7 +350,6 @@ export default function UploadPage() {
             onClick={handleVisualizeCardClick}
             expanded={visualizeCardExpanded}
             faded={false}
-            onCollapse={mode === "upload-idle" ? handleCollapse : undefined}
           >
             <Text mb={4} fontSize="sm" color="fg.muted" lineHeight="1.6">
               Upload a local file to convert it, or add a URL to connect cloud

--- a/frontend/src/pages/WorkspaceHomePage.tsx
+++ b/frontend/src/pages/WorkspaceHomePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Box, Button, Flex, Heading, Text } from "@chakra-ui/react";
 import { ArrowRight } from "@phosphor-icons/react";
@@ -6,18 +6,20 @@ import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
 import { ExampleStoryCard } from "../components/ExampleStoryCard";
 import { useWorkspace } from "../hooks/useWorkspace";
-import { forkStoryOnServer, listStoriesFromServer } from "../lib/story/api";
-import { workspaceFetch } from "../lib/api";
+import { forkStoryOnServer } from "../lib/story/api";
 import { toaster } from "../lib/toaster";
 import { inferDataType } from "../lib/story/dataType";
-import { config } from "../config";
 import type { Story } from "../lib/story/types";
-import type { Dataset } from "../types";
 import { displayName } from "../utils/dataset";
 import { timeAgo } from "../utils/format";
 import { CollectionSkeleton } from "../components/ui/CollectionSkeleton";
 import { PageHeader } from "../components/PageHeader";
 import { CREATE_MAP_INTENT, CREATE_STORY_INTENT } from "../lib/creationIntents";
+import {
+  useWorkspaceDatasets,
+  useWorkspaceStories,
+} from "../hooks/useWorkspaceLibrary";
+import { StatePanel } from "../components/ui/StatePanel";
 
 function sortByUpdated<T extends { updated_at?: string; created_at?: string }>(
   items: T[]
@@ -31,50 +33,35 @@ function sortByUpdated<T extends { updated_at?: string; created_at?: string }>(
 
 export default function WorkspaceHomePage() {
   const { workspacePath } = useWorkspace();
-  const [stories, setStories] = useState<Story[] | null>(null);
-  const [datasets, setDatasets] = useState<Dataset[] | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    listStoriesFromServer()
-      .then((data) => {
-        if (!cancelled) setStories(data);
-      })
-      .catch(() => {
-        if (!cancelled) setStories([]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    workspaceFetch(`${config.apiBase}/api/datasets`)
-      .then((r) => (r.ok ? r.json() : []))
-      .then((data: Dataset[]) => {
-        if (!cancelled) setDatasets(data);
-      })
-      .catch(() => {
-        if (!cancelled) setDatasets([]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const storiesResource = useWorkspaceStories();
+  const datasetsResource = useWorkspaceDatasets();
+  const stories = storiesResource.data;
+  const datasets = datasetsResource.data;
 
   const navigate = useNavigate();
   const [cloningId, setCloningId] = useState<string | null>(null);
   const cloneInFlightRef = useRef(false);
 
-  const userStories = (stories ?? []).filter((s) => !s.is_example);
-  const exampleStories = (stories ?? []).filter((s) => s.is_example);
-  const userDatasets = (datasets ?? []).filter((d) => !d.is_example);
+  const userStories = stories.filter((s) => !s.is_example);
+  const exampleStories = stories.filter((s) => s.is_example);
+  const userDatasets = datasets.filter((d) => !d.is_example);
   const recentStories = sortByUpdated(userStories).slice(0, 3);
   const recentDatasets = sortByUpdated(userDatasets).slice(0, 3);
-  const loading = stories === null || datasets === null;
+  const loading =
+    stories.length === 0 &&
+    datasets.length === 0 &&
+    (storiesResource.status === "loading" ||
+      datasetsResource.status === "loading");
+  const resourceError = [storiesResource.error, datasetsResource.error]
+    .filter(Boolean)
+    .join("; ");
+  const allUnavailable =
+    storiesResource.status === "error" && datasetsResource.status === "error";
   const isEmpty =
-    !loading && userStories.length === 0 && userDatasets.length === 0;
+    !loading &&
+    !resourceError &&
+    userStories.length === 0 &&
+    userDatasets.length === 0;
 
   const handleCloneExample = useCallback(
     async (story: Story) => {
@@ -129,9 +116,28 @@ export default function WorkspaceHomePage() {
           }
         />
 
+        {resourceError && (
+          <Box mb={6}>
+            <StatePanel
+              tone="danger"
+              title={
+                allUnavailable
+                  ? "Couldn’t load your workspace"
+                  : "Some workspace content couldn’t load"
+              }
+              description={resourceError}
+              actionLabel="Try again"
+              onAction={() => {
+                storiesResource.retry();
+                datasetsResource.retry();
+              }}
+            />
+          </Box>
+        )}
+
         {loading ? (
           <CollectionSkeleton rows={4} />
-        ) : isEmpty ? (
+        ) : allUnavailable ? null : isEmpty ? (
           <Box>
             <Heading textStyle="sectionTitle" color="fg" mb={2}>
               Start your first map or story

--- a/frontend/src/pages/WorkspaceHomePage.tsx
+++ b/frontend/src/pages/WorkspaceHomePage.tsx
@@ -19,7 +19,6 @@ import {
   useWorkspaceDatasets,
   useWorkspaceStories,
 } from "../hooks/useWorkspaceLibrary";
-import { StatePanel } from "../components/ui/StatePanel";
 
 function sortByUpdated<T extends { updated_at?: string; created_at?: string }>(
   items: T[]
@@ -117,22 +116,36 @@ export default function WorkspaceHomePage() {
         />
 
         {resourceError && (
-          <Box mb={6}>
-            <StatePanel
-              tone="danger"
-              title={
-                allUnavailable
+          <Flex
+            role="alert"
+            mb={6}
+            p={4}
+            gap={4}
+            align={{ base: "stretch", sm: "center" }}
+            direction={{ base: "column", sm: "row" }}
+            bg="status.danger.subtle"
+            color="status.danger.fg"
+            borderRadius="md"
+          >
+            <Box flex="1">
+              <Text fontWeight={600}>
+                {allUnavailable
                   ? "Couldn’t load your workspace"
-                  : "Some workspace content couldn’t load"
-              }
-              description={resourceError}
-              actionLabel="Try again"
-              onAction={() => {
+                  : "Some workspace content couldn’t load"}
+              </Text>
+              <Text fontSize="sm">{resourceError}</Text>
+            </Box>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
                 storiesResource.retry();
                 datasetsResource.retry();
               }}
-            />
-          </Box>
+            >
+              Try again
+            </Button>
+          </Flex>
         )}
 
         {loading ? (

--- a/frontend/src/pages/__tests__/DataPage.test.tsx
+++ b/frontend/src/pages/__tests__/DataPage.test.tsx
@@ -103,14 +103,14 @@ describe("DataPage creation action", () => {
 });
 
 describe("DataPage example copy rows", () => {
-  it("shows an Example badge on seeded example copies in the main table", async () => {
+  it("shows an Example badge on seeded example copies in the collection", async () => {
     renderDataPage();
 
     await waitFor(() => {
       expect(screen.getByText("Example Zarr")).toBeInTheDocument();
     });
 
-    const exampleRow = screen.getByText("Example Zarr").closest("tr");
+    const exampleRow = screen.getByText("Example Zarr").closest("article");
     expect(exampleRow).not.toBeNull();
     expect(
       within(exampleRow as HTMLElement).getByText("Example", { exact: true })
@@ -124,7 +124,7 @@ describe("DataPage example copy rows", () => {
       expect(screen.getByText("User Zarr")).toBeInTheDocument();
     });
 
-    const userRow = screen.getByText("User Zarr").closest("tr");
+    const userRow = screen.getByText("User Zarr").closest("article");
     expect(userRow).not.toBeNull();
     const deleteButton = userRow!.querySelector("button");
     expect(deleteButton?.textContent).toMatch(/delete/i);
@@ -141,7 +141,7 @@ describe("DataPage fetch failures", () => {
     renderDataPage();
 
     expect(
-      await screen.findByText(/couldn’t load your data library/i)
+      await screen.findByText(/some data couldn’t load/i)
     ).toBeInTheDocument();
     expect(
       screen.queryByText(/nothing in your data library yet/i)
@@ -170,7 +170,7 @@ describe("DataPage deletion failures", () => {
     );
     renderDataPage();
 
-    const userRow = (await screen.findByText("User Zarr")).closest("tr");
+    const userRow = (await screen.findByText("User Zarr")).closest("article");
     fireEvent.click(
       within(userRow as HTMLElement).getByRole("button", { name: /delete/i })
     );

--- a/frontend/src/pages/__tests__/StoriesPage.test.tsx
+++ b/frontend/src/pages/__tests__/StoriesPage.test.tsx
@@ -152,7 +152,7 @@ describe("StoriesPage deletion failures", () => {
     );
     renderStoriesPage();
 
-    const row = (await screen.findByText("Story to keep")).closest("tr");
+    const row = (await screen.findByText("Story to keep")).closest("article");
     fireEvent.click(
       within(row as HTMLElement).getByRole("button", { name: /delete/i })
     );

--- a/frontend/src/pages/__tests__/StoryEditorPage.overlay.test.tsx
+++ b/frontend/src/pages/__tests__/StoryEditorPage.overlay.test.tsx
@@ -61,6 +61,18 @@ vi.mock("../../hooks/useStoryEditor", () => ({
     mapContainerRef: { current: null },
     allDatasets: [],
     allConnections: [],
+    datasetsResource: {
+      status: "ready",
+      data: [],
+      error: null,
+      retry: vi.fn(),
+    },
+    connectionsResource: {
+      status: "ready",
+      data: [],
+      error: null,
+      retry: vi.fn(),
+    },
     uploadModalOpen: false,
     saveState: "idle",
     layers: [],

--- a/frontend/src/pages/__tests__/StoryReaderInner.test.tsx
+++ b/frontend/src/pages/__tests__/StoryReaderInner.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { describe, expect, it, vi } from "vitest";
+import { system } from "../../theme";
+import { StoryReaderInner } from "../StoryReaderInner";
+import { createStory } from "../../lib/story";
+
+vi.mock("../../components/StoryRenderer", () => ({
+  StoryRenderer: () => <div>Story content</div>,
+}));
+
+vi.mock("../../lib/chat/useChatConfig", () => ({
+  useChatConfig: () => ({ enabled: false }),
+}));
+
+describe("StoryReaderInner", () => {
+  it("marks a non-scrollable story complete after layout", () => {
+    render(
+      <ChakraProvider value={system}>
+        <StoryReaderInner
+          story={createStory(null, { id: "story-1" })}
+          datasetMap={new Map()}
+          connectionMap={new Map()}
+          embed
+        />
+      </ChakraProvider>
+    );
+
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "100"
+    );
+  });
+});

--- a/frontend/src/pages/__tests__/StorySetupPage.test.tsx
+++ b/frontend/src/pages/__tests__/StorySetupPage.test.tsx
@@ -7,6 +7,7 @@ import StorySetupPage from "../StorySetupPage";
 import { createStoryOnServer } from "../../lib/story";
 
 const navigate = vi.fn();
+const useWorkspaceDatasetsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("react-router-dom", async () => {
   const actual =
@@ -22,12 +23,7 @@ vi.mock("../../hooks/useWorkspace", () => ({
 }));
 
 vi.mock("../../hooks/useWorkspaceLibrary", () => ({
-  useWorkspaceDatasets: () => ({
-    status: "ready",
-    data: [],
-    error: null,
-    retry: vi.fn(),
-  }),
+  useWorkspaceDatasets: useWorkspaceDatasetsMock,
 }));
 
 vi.mock("../../lib/story", async () => {
@@ -41,10 +37,10 @@ vi.mock("../../lib/story", async () => {
   };
 });
 
-function renderPage() {
+function renderPage(entry = "/story/new") {
   return render(
     <ChakraProvider value={system}>
-      <MemoryRouter initialEntries={["/story/new"]}>
+      <MemoryRouter initialEntries={[entry]}>
         <StorySetupPage />
       </MemoryRouter>
     </ChakraProvider>
@@ -54,6 +50,12 @@ function renderPage() {
 describe("StorySetupPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useWorkspaceDatasetsMock.mockReturnValue({
+      status: "ready",
+      data: [],
+      error: null,
+      retry: vi.fn(),
+    });
   });
 
   it("does not persist a story before a template is chosen", () => {
@@ -83,5 +85,46 @@ describe("StorySetupPage", () => {
     await waitFor(() => expect(createStoryOnServer).toHaveBeenCalledOnce());
     const created = vi.mocked(createStoryOnServer).mock.calls[0][0];
     expect(created.chapters[0].type).toBe("map");
+  });
+
+  it("waits for a requested dataset before enabling map creation", () => {
+    useWorkspaceDatasetsMock.mockReturnValue({
+      status: "loading",
+      data: [],
+      error: null,
+      retry: vi.fn(),
+    });
+    renderPage("/story/new?dataset=dataset-1");
+
+    expect(
+      screen.getByRole("button", { name: "Loading selected dataset…" })
+    ).toBeDisabled();
+    expect(createStoryOnServer).not.toHaveBeenCalled();
+  });
+
+  it("offers retry when a requested dataset fails to load", () => {
+    const retry = vi.fn();
+    useWorkspaceDatasetsMock.mockReturnValue({
+      status: "error",
+      data: [],
+      error: "HTTP 503",
+      retry,
+    });
+    renderPage("/story/new?dataset=dataset-1");
+
+    expect(
+      screen.getByRole("button", { name: "Dataset couldn’t load" })
+    ).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(retry).toHaveBeenCalledOnce();
+    expect(createStoryOnServer).not.toHaveBeenCalled();
+  });
+
+  it("does not create a story for a settled missing dataset", () => {
+    renderPage("/story/new?dataset=missing");
+    expect(
+      screen.getByRole("button", { name: "Dataset unavailable" })
+    ).toBeDisabled();
+    expect(createStoryOnServer).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/__tests__/StorySetupPage.test.tsx
+++ b/frontend/src/pages/__tests__/StorySetupPage.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { system } from "../../theme";
+import StorySetupPage from "../StorySetupPage";
+import { createStoryOnServer } from "../../lib/story";
+
+const navigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom"
+    );
+  return { ...actual, useNavigate: () => navigate };
+});
+
+vi.mock("../../hooks/useWorkspace", () => ({
+  useWorkspace: () => ({ workspacePath: (path: string) => `/w/ws${path}` }),
+  useOptionalWorkspace: () => null,
+}));
+
+vi.mock("../../hooks/useWorkspaceLibrary", () => ({
+  useWorkspaceDatasets: () => ({
+    status: "ready",
+    data: [],
+    error: null,
+    retry: vi.fn(),
+  }),
+}));
+
+vi.mock("../../lib/story", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../lib/story")>("../../lib/story");
+  return {
+    ...actual,
+    createStoryOnServer: vi.fn((story) =>
+      Promise.resolve({ ...story, id: "story-created" })
+    ),
+  };
+});
+
+function renderPage() {
+  return render(
+    <ChakraProvider value={system}>
+      <MemoryRouter initialEntries={["/story/new"]}>
+        <StorySetupPage />
+      </MemoryRouter>
+    </ChakraProvider>
+  );
+}
+
+describe("StorySetupPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not persist a story before a template is chosen", () => {
+    renderPage();
+    expect(createStoryOnServer).not.toHaveBeenCalled();
+    expect(screen.getByText("Map-led story")).toBeInTheDocument();
+    expect(screen.getByText("Media story")).toBeInTheDocument();
+    expect(screen.getByText("Blank story")).toBeInTheDocument();
+  });
+
+  it("creates the selected template and opens its editor", async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: "Choose Blank story" }));
+
+    await waitFor(() => expect(createStoryOnServer).toHaveBeenCalledOnce());
+    expect(navigate).toHaveBeenCalledWith("/w/ws/story/story-created/edit", {
+      replace: true,
+    });
+  });
+
+  it("creates a map chapter even when no dataset was provided", async () => {
+    renderPage();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Choose Map-led story" })
+    );
+
+    await waitFor(() => expect(createStoryOnServer).toHaveBeenCalledOnce());
+    const created = vi.mocked(createStoryOnServer).mock.calls[0][0];
+    expect(created.chapters[0].type).toBe("map");
+  });
+});


### PR DESCRIPTION
## Summary

- introduce shared workspace resource hooks with explicit loading, empty, error, retry, stale-data, and partial-success states
- distinguish missing dataset references from active loading in map and story selectors
- replace desktop-only Stories and Data tables with responsive card/row collections and intentional preview placeholders
- add a local story-template setup route so visiting `/story/new` no longer creates abandoned drafts
- open map creation directly on upload/connect, centralize chapter-type metadata, and move specialized authoring controls behind progressive disclosure
- add reader progress and expand regression coverage

## Why

The previous UI inferred request state from empty arrays and missing active IDs. Request failures could therefore look like empty workspaces, and deleted or inaccessible datasets could remain labeled “Loading…” forever. Creation routes also persisted stories before an author made a meaningful choice, while collection pages were difficult to use on narrow screens.

This change establishes explicit resource-state contracts first, then builds the responsive and simplified authoring experience on top of them without changing the persisted chapter schema or rendering stack.

## User impact

- failures are visible and retryable without hiding resources that loaded successfully
- unavailable chapter data has a clear replacement path
- Stories and Data work as touch-friendly cards on mobile and aligned rows on desktop
- authors choose Map-led, Media, or Blank before a story is persisted
- common chapter controls stay prominent while specialized types, 3D, and styling remain available on demand
- published readers show accessible reading progress

## Validation

- `npx tsc --noEmit`
- `npx vitest run` — 186 files, 1,166 tests passed
- `yarn build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a story setup screen with map-led, media, and blank story templates.
  * Added responsive resource collections with thumbnails for stories and datasets.
  * Added expandable advanced settings and a reading-progress indicator.
  * Expanded chapter type selection with secondary types shown on demand.
* **Bug Fixes**
  * Improved loading, empty, partial-error, and retry states for workspace data.
  * Preserved available data during refreshes and identified unavailable selections.
  * Upload pages now open expanded by default.
* **Tests**
  * Added coverage for story creation, chapter selection, progress, and data-loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->