### PR TITLE
fix(frontend): bind-mount source into dev container so edits are live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,23 @@ docker compose -f docker-compose.yml up -d <service>
 
 Service names: `database`, `stac-api`, `raster-tiler`, `vector-tiler`, `cog-tiler`, `ingestion`, `frontend`
 
+Note that `build` alone is not enough — a running container keeps using the image
+it started with, so it must be recreated with `up -d` to pick up a new build.
+
+**The `frontend` service is the exception.** It bind-mounts `./frontend` over `/app`,
+so source edits are live: Vite HMR picks them up with no rebuild and no restart.
+Two cases still need action:
+
+- **Dependency changes** (`package.json` / `yarn.lock`): the installed `node_modules`
+  lives in an anonymous volume that survives `up -d`, so it goes stale. Rebuild and
+  drop the volume:
+  ```bash
+  docker compose -f docker-compose.yml rm -sfv frontend
+  docker compose -f docker-compose.yml up -d --build frontend
+  ```
+- **Vite server config** (`vite.config.ts` proxy targets, compose `environment:`):
+  restart the container; the dev server reads these only at boot.
+
 ## Production Deployment
 
 Deployed to Hetzner via the `prod` Docker Compose profile, with Caddy providing HTTPS. The whole site is public (no basic-auth gate). Full deploy steps, CSP rules, and tile caching are in [docs/production-deployment.md](docs/production-deployment.md) — read before any prod change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,15 +84,20 @@ it started with, so it must be recreated with `up -d` to pick up a new build.
 so source edits are live: Vite HMR picks them up with no rebuild and no restart.
 Two cases still need action:
 
-- **Dependency changes** (`package.json` / `yarn.lock`): the installed `node_modules`
+- **Dependency changes** — `package.json`, `yarn.lock`, or `.yarnrc.yml`, i.e. any
+  input the Dockerfile copies before `yarn install`. The installed `node_modules`
   lives in an anonymous volume that survives `up -d`, so it goes stale. Rebuild and
   drop the volume:
   ```bash
   docker compose -f docker-compose.yml rm -sfv frontend
   docker compose -f docker-compose.yml up -d --build frontend
   ```
-- **Vite server config** (`vite.config.ts` proxy targets, compose `environment:`):
-  restart the container; the dev server reads these only at boot.
+- **Compose `environment:` changes** (`API_PROXY_TARGET`, `RASTER_TILER_PROXY_TARGET`, …):
+  `docker compose restart` does **not** pick these up — it restarts the same container
+  with the environment it was created with. Use `up -d frontend` instead; Compose sees
+  the changed config and recreates the container. `--force-recreate` is not needed.
+- **`vite.config.ts` changes**: restart the container — the dev server reads its own
+  config only at boot.
 
 ## Production Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,9 @@ scripts/worktree-stack.sh logs ingestion  # Tail a service's logs
 
 The worktree stack gets its own containers, network, and database volume (via the `-p` project name). Use `down` (not just `stop`) when done to free resources — it removes volumes too.
 
-For **frontend-only changes**, you can skip Docker entirely and just run `cd frontend && npx vite dev --port 5285` — this uses the prod backend services through the Vite proxy.
+The stack's `frontend` container bind-mounts `./frontend` relative to the compose file, and `worktree-stack.sh` points compose at the **worktree's** `docker-compose.yml`. So the running dev server serves the worktree's source, and edits hot-reload without a rebuild — see [Rebuild a single service](#rebuild-a-single-service) for the two cases that still need action.
+
+For **frontend-only changes**, you can also skip Docker entirely and just run `cd frontend && npx vite dev --port 5285` — this uses the prod backend services through the Vite proxy.
 
 ## Skill Feedback Loop
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,9 @@ services:
           memory: 2G
     ports:
       - "${FRONTEND_PORT:-5185}:5185"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
     environment:
       VITE_API_BASE: ""
       VITE_RASTER_TILER_URL: ""

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -58,6 +58,7 @@ This is what the `release-please` workflow runs over SSH after a release PR is m
 ## Notes
 
 - `docker compose up` (without `--profile prod`) still runs local dev without Caddy
+- Caddy serves the static bundle from the `frontend_dist` volume, which the `prod`-profile `frontend-build` service populates from the released image. The Vite dev `frontend` service carries no profile, so `--profile prod up -d` starts it too — but nothing routes to it in prod. It bind-mounts the VM's `./frontend` checkout over `/app`, so its dev server reflects whatever is on disk, not the released bundle. Don't use it to sanity-check a deploy; verify against the public URL
 - Backend service ports (8081-8086) are accessible on localhost via SSH tunnel but blocked externally by the Hetzner firewall
 - The `caddy_data` volume persists TLS certificates — don't delete it or you'll hit Let's Encrypt rate limits
 - During the brief restart window when ingestion or the tilers cycle, Caddy's `handle_errors 502 503` block serves a small self-refreshing "Deploying…" page (meta-refresh every 15s) so users don't see a raw 502/503. The same handler is wired up for both the main host and the `viewer.<domain>` subdomain

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,11 @@ ARG VITE_VIEWER_ORIGIN
 ENV VITE_VIEWER_ORIGIN=$VITE_VIEWER_ORIGIN
 RUN yarn build
 
-# --- Dev: hot-reloading Vite dev server for local development ---
+# --- Dev: hot-reloading Vite dev server for local development.
+# The compose `frontend` service bind-mounts ./frontend over /app, so the COPY
+# steps below are a fallback that keeps this image runnable on its own. Source
+# edits reach the running container through the mount, not through a rebuild;
+# the installed node_modules is preserved by an anonymous volume. ---
 FROM node:20 AS dev
 WORKDIR /app
 RUN corepack enable


### PR DESCRIPTION
## Problem

The compose `frontend` service (the Vite dev server on :5185) had **no bind mount** — source came in via `COPY` at build time, so the running container could only ever serve the code present when its image was built.

Two failure modes compounded:

1. **No mount** → any source change needs an image rebuild.
2. **`docker compose build` does not recreate containers** → a running container keeps its original image until `up -d` swaps it.

Neither has a visible signal. Found in practice when the local dev frontend was serving a **2026-05-13 image** — roughly three months of drift — while prod (served from the `frontend-build` → `frontend_dist` → Caddy path) was current. A rebuild appeared to change nothing, because the container was still on the old image SHA.

The Dockerfile even labelled this target "hot-reloading Vite dev server," which it was not.

## Change

```yaml
 frontend:
   ports:
     - "${FRONTEND_PORT:-5185}:5185"
+  volumes:
+    - ./frontend:/app
+    - /app/node_modules
```

- `./frontend:/app` — source edits reach the container directly; Vite HMR handles the rest.
- `/app/node_modules` (anonymous volume) — shadows the bind so the image's `yarn install` survives. Required: the host `frontend/node_modules` would otherwise mask it, and in CI (no host `node_modules`) `/app/node_modules` would be empty.

The `COPY` steps in the `dev` target are kept deliberately — CI's `docker-build` job builds that target standalone, so the image must remain runnable without the mount. Dockerfile comment updated to say so.

`CLAUDE.md` gains a note that `build` alone never updates a running container, plus the two cases that still need action on the frontend: dependency changes (anonymous volume goes stale) and Vite server config (read only at boot).

## Verification

Ran the isolated worktree stack (`-p wt-fix-frontend-dev-hot-reload`, frontend only, `--no-deps`) — prod stack untouched.

- Rendered config resolves the bind to the worktree's `frontend/` and mounts the anonymous volume at `/app/node_modules` ✓
- Vite booted: `VITE v8.1.2 ready in 311 ms` ✓
- `node_modules` survived the mount: 551 entries in-container ✓
- Wrote a probe file on the host → visible via `docker exec` with no rebuild ✓
- Served through the dev server, then edited on the host and re-fetched — same container, no restart:
  ```
  serve #1 → MOUNT_PROOF_ee4a9dc
  serve #2 → EDITED_LIVE_NO_RESTART
  ```
- Probe removed; stack torn down with `down -v`.

CI impact checked: `frontend` job's prettier scope is `src/**/*.{ts,tsx,css}` (untouched), and `full-stack-smoke` runs `compose up -d --build` on a fresh checkout — the no-host-`node_modules` case verified above.

## Note

The `frontend` service carries no `profiles:` key, so it runs under the `prod` profile too. On the Hetzner host it will now bind-mount the deployed checkout's `frontend/`. Prod traffic is unaffected — Caddy serves `frontend_dist` from `frontend-build`, not this service — but worth a look if :5185 is exposed there for any reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Developer Experience**
  * Frontend source changes now appear live during development through a source-directory mount and hot reload.
  * Frontend dependencies remain managed inside the container for consistent development environments.
  * Added guidance for rebuilding or recreating Docker services after configuration or dependency changes.
  * Documented when frontend development tools are available and when restarts are required.

* **Documentation**
  * Clarified that the development frontend is not used for production deployment verification.
  * Documented deployment behavior and limitations for the development frontend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->