### PR TITLE
chore(compose): gate the frontend dev server behind a dev profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate compose config
-        run: cp .env.example .env && docker compose config --quiet
+        run: cp .env.example .env && docker compose --profile dev --profile prod config --quiet
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 

--- a/.github/workflows/full-stack-smoke.yml
+++ b/.github/workflows/full-stack-smoke.yml
@@ -32,15 +32,15 @@ jobs:
         run: cp .env.example .env
 
       - name: Build and start the stack
-        run: docker compose -p cng-smoke up -d --build
+        run: docker compose --profile dev -p cng-smoke up -d --build
 
       - name: Verify services and proxy routes
         run: scripts/full-stack-smoke.sh
 
       - name: Show service logs after failure
         if: failure()
-        run: docker compose -p cng-smoke logs --no-color --tail 200
+        run: docker compose --profile dev -p cng-smoke logs --no-color --tail 200
 
       - name: Stop the stack
         if: always()
-        run: docker compose -p cng-smoke down -v
+        run: docker compose --profile dev -p cng-smoke down -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,20 +53,29 @@ After pushing a branch and opening a PR for a significant feature or fix, write 
 
 ```bash
 # Start all services
-docker compose -f docker-compose.yml up -d --build
+docker compose -f docker-compose.yml --profile dev up -d --build
 
 # Verify all containers are healthy
-docker compose -f docker-compose.yml ps
+docker compose -f docker-compose.yml --profile dev ps
 ```
 
 The frontend is available at `http://localhost:5185`.
 
+`--profile dev` is required for the `frontend` service (the Vite dev server).
+It is profile-gated so it never starts on the prod host, where Caddy serves the
+built bundle out of `frontend_dist` instead. Omit the flag and the backend comes
+up fine but nothing listens on 5185.
+
 ### Stop the stack
 
 ```bash
-docker compose -f docker-compose.yml down        # Stop containers
-docker compose -f docker-compose.yml down -v     # Stop and delete volumes (wipes data)
+docker compose -f docker-compose.yml --profile dev down        # Stop containers
+docker compose -f docker-compose.yml --profile dev down -v     # Stop and delete volumes (wipes data)
 ```
+
+`down` needs `--profile dev` too. Without it Compose tears down the backend but
+silently leaves the `frontend` container running, and the network then fails to
+remove with "resource is still in use".
 
 ### Rebuild a single service
 
@@ -76,6 +85,9 @@ docker compose -f docker-compose.yml up -d <service>
 ```
 
 Service names: `database`, `stac-api`, `raster-tiler`, `vector-tiler`, `cog-tiler`, `ingestion`, `frontend`
+
+Naming a service on the command line enables its profiles automatically, so the
+`frontend` commands below need no `--profile dev`.
 
 Note that `build` alone is not enough — a running container keeps using the image
 it started with, so it must be recreated with `up -d` to pick up a new build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,23 @@ docker compose -f docker-compose.yml up -d <service>
 
 Service names: `database`, `stac-api`, `raster-tiler`, `vector-tiler`, `cog-tiler`, `ingestion`, `frontend`
 
+Note that `build` alone is not enough — a running container keeps using the image
+it started with, so it must be recreated with `up -d` to pick up a new build.
+
+**The `frontend` service is the exception.** It bind-mounts `./frontend` over `/app`,
+so source edits are live: Vite HMR picks them up with no rebuild and no restart.
+Two cases still need action:
+
+- **Dependency changes** (`package.json` / `yarn.lock`): the installed `node_modules`
+  lives in an anonymous volume that survives `up -d`, so it goes stale. Rebuild and
+  drop the volume:
+  ```bash
+  docker compose -f docker-compose.yml rm -sfv frontend
+  docker compose -f docker-compose.yml up -d --build frontend
+  ```
+- **Vite server config** (`vite.config.ts` proxy targets, compose `environment:`):
+  restart the container; the dev server reads these only at boot.
+
 ## Production Deployment
 
 Deployed to Hetzner via the `prod` Docker Compose profile, with Caddy providing HTTPS. The whole site is public (no basic-auth gate). Full deploy steps, CSP rules, and tile caching are in [docs/production-deployment.md](docs/production-deployment.md) — read before any prod change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,15 +84,20 @@ it started with, so it must be recreated with `up -d` to pick up a new build.
 so source edits are live: Vite HMR picks them up with no rebuild and no restart.
 Two cases still need action:
 
-- **Dependency changes** (`package.json` / `yarn.lock`): the installed `node_modules`
+- **Dependency changes** — `package.json`, `yarn.lock`, or `.yarnrc.yml`, i.e. any
+  input the Dockerfile copies before `yarn install`. The installed `node_modules`
   lives in an anonymous volume that survives `up -d`, so it goes stale. Rebuild and
   drop the volume:
   ```bash
   docker compose -f docker-compose.yml rm -sfv frontend
   docker compose -f docker-compose.yml up -d --build frontend
   ```
-- **Vite server config** (`vite.config.ts` proxy targets, compose `environment:`):
-  restart the container; the dev server reads these only at boot.
+- **Compose `environment:` changes** (`API_PROXY_TARGET`, `RASTER_TILER_PROXY_TARGET`, …):
+  `docker compose restart` does **not** pick these up — it restarts the same container
+  with the environment it was created with. Use `up -d frontend` instead; Compose sees
+  the changed config and recreates the container. `--force-recreate` is not needed.
+- **`vite.config.ts` changes**: restart the container — the dev server reads its own
+  config only at boot.
 
 ## Production Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,9 @@ scripts/worktree-stack.sh logs ingestion  # Tail a service's logs
 
 The worktree stack gets its own containers, network, and database volume (via the `-p` project name). Use `down` (not just `stop`) when done to free resources — it removes volumes too.
 
-For **frontend-only changes**, you can skip Docker entirely and just run `cd frontend && npx vite dev --port 5285` — this uses the prod backend services through the Vite proxy.
+The stack's `frontend` container bind-mounts `./frontend` relative to the compose file, and `worktree-stack.sh` points compose at the **worktree's** `docker-compose.yml`. So the running dev server serves the worktree's source, and edits hot-reload without a rebuild — see [Rebuild a single service](#rebuild-a-single-service) for the two cases that still need action.
+
+For **frontend-only changes**, you can also skip Docker entirely and just run `cd frontend && npx vite dev --port 5285` — this uses the prod backend services through the Vite proxy.
 
 ## Skill Feedback Loop
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,9 @@
    docker compose --profile dev up -d --build
    ```
 
-   The `dev` profile adds the Vite dev server; production runs the same file
-   without it and serves the built bundle through Caddy instead.
+   The `dev` profile adds the Vite dev server. Production uses the same file with
+   `--profile prod` instead, which starts `frontend-build` and `caddy` to serve the
+   built bundle. The two profiles are separate — neither implies the other.
 
 4. Verify at [http://localhost:5185](http://localhost:5185).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,11 @@
 3. Start the stack:
 
    ```bash
-   docker compose up -d --build
+   docker compose --profile dev up -d --build
    ```
+
+   The `dev` profile adds the Vite dev server; production runs the same file
+   without it and serves the built bundle through Caddy instead.
 
 4. Verify at [http://localhost:5185](http://localhost:5185).
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ Currently can be found at [storytelling.developmentseed.org](https://storytellin
 You need [Docker](https://docs.docker.com/get-docker/) installed and a [Cloudflare R2](https://developers.cloudflare.com/r2/) bucket with API credentials.
 
 ```bash
-cp .env.example .env          # create local config — fill in R2 credentials
-docker compose up -d --build   # start all services
+cp .env.example .env                          # create local config — fill in R2 credentials
+docker compose --profile dev up -d --build    # start all services
 ```
+
+`--profile dev` is what brings up the frontend dev server; without it the backend
+services start but nothing listens on 5185.
 
 Open [http://localhost:5185](http://localhost:5185) in your browser.
 
@@ -42,8 +45,8 @@ Want to run your own instance and drive it from an AI client (Claude Desktop or 
 ## Stopping
 
 ```bash
-docker compose down       # stop containers (data is preserved)
-docker compose down -v    # stop and wipe all data
+docker compose --profile dev down       # stop containers (data is preserved)
+docker compose --profile dev down -v    # stop and wipe all data
 ```
 
 ## Architecture
@@ -132,7 +135,8 @@ All browser traffic goes through port 5185 — the frontend proxies API and tile
 
 | Problem | Solution |
 |---------|----------|
-| Containers won't start | `docker compose down -v && docker compose up -d --build` |
+| Containers won't start | `docker compose --profile dev down -v && docker compose --profile dev up -d --build` |
+| Nothing on port 5185 | The frontend is behind the `dev` profile — start with `--profile dev` |
 | Upload stuck at "Ingesting" | Check tiler logs: `docker compose logs raster-tiler` |
 | Vector tiles return 404 | tipg refreshes its catalog every 5 seconds — wait briefly after upload |
 | Map shows wrong location | Clear browser cache; old tile URLs may be cached |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,13 @@ services:
     build:
       context: frontend
       target: dev
+    # The Vite dev server is for local and worktree stacks only. Production
+    # serves the built bundle from frontend-build via the frontend_dist volume
+    # (see the caddy service), so this container must not start under --profile
+    # prod: it would bind-mount the deployed checkout and hold its memory limit
+    # while nothing routes to it.
+    profiles:
+      - dev
     restart: unless-stopped
     deploy:
       resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,9 @@ services:
           memory: 2G
     ports:
       - "${FRONTEND_PORT:-5185}:5185"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
     environment:
       VITE_API_BASE: ""
       VITE_RASTER_TILER_URL: ""

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -57,8 +57,8 @@ This is what the `release-please` workflow runs over SSH after a release PR is m
 
 ## Notes
 
-- `docker compose up` (without `--profile prod`) still runs local dev without Caddy
-- Caddy serves the static bundle from the `frontend_dist` volume, which the `prod`-profile `frontend-build` service populates from the released image. The Vite dev `frontend` service carries no profile, so `--profile prod up -d` starts it too — but nothing routes to it in prod. It bind-mounts the VM's `./frontend` checkout over `/app`, so its dev server reflects whatever is on disk, not the released bundle. Don't use it to sanity-check a deploy; verify against the public URL
+- `docker compose --profile dev up` (without `--profile prod`) still runs local dev without Caddy
+- Caddy serves the static bundle from the `frontend_dist` volume, which the `prod`-profile `frontend-build` service populates from the released image. The Vite dev `frontend` service sits behind the `dev` profile, so `--profile prod up -d` does not start it on the VM. That is deliberate: it bind-mounts `./frontend` over `/app`, so if it were running its dev server would reflect whatever is on the VM's disk rather than the released bundle. Verify a deploy against the public URL, never against port 5185
 - Backend service ports (8081-8086) are accessible on localhost via SSH tunnel but blocked externally by the Hetzner firewall
 - The `caddy_data` volume persists TLS certificates — don't delete it or you'll hit Let's Encrypt rate limits
 - During the brief restart window when ingestion or the tilers cycle, Caddy's `handle_errors 502 503` block serves a small self-refreshing "Deploying…" page (meta-refresh every 15s) so users don't see a raw 502/503. The same handler is wired up for both the main host and the `viewer.<domain>` subdomain

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -58,6 +58,7 @@ This is what the `release-please` workflow runs over SSH after a release PR is m
 ## Notes
 
 - `docker compose up` (without `--profile prod`) still runs local dev without Caddy
+- Caddy serves the static bundle from the `frontend_dist` volume, which the `prod`-profile `frontend-build` service populates from the released image. The Vite dev `frontend` service carries no profile, so `--profile prod up -d` starts it too — but nothing routes to it in prod. It bind-mounts the VM's `./frontend` checkout over `/app`, so its dev server reflects whatever is on disk, not the released bundle. Don't use it to sanity-check a deploy; verify against the public URL
 - Backend service ports (8081-8086) are accessible on localhost via SSH tunnel but blocked externally by the Hetzner firewall
 - The `caddy_data` volume persists TLS certificates — don't delete it or you'll hit Let's Encrypt rate limits
 - During the brief restart window when ingestion or the tilers cycle, Caddy's `handle_errors 502 503` block serves a small self-refreshing "Deploying…" page (meta-refresh every 15s) so users don't see a raw 502/503. The same handler is wired up for both the main host and the `viewer.<domain>` subdomain

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -48,6 +48,16 @@ docker compose --profile prod pull && docker compose --profile prod up -d
 
 This is what the `release-please` workflow runs over SSH after a release PR is merged. The `ingestion` and `frontend-build` images are published to `ghcr.io/aboydnw/cng-sandbox/*` by the `build-and-push` job before the deploy step runs. Caddy uses the upstream `caddy:2` image directly, so it's pulled from Docker Hub.
 
+### One-time migration: remove the legacy `frontend` container
+
+The `frontend` dev service used to run on the VM (it carried no profile). Now that it's gated behind `dev`, `--profile prod up -d` no longer manages that container — but it does not stop it either, and `restart: unless-stopped` brings it back after a daemon restart, holding port 5185 and up to 2G. `--remove-orphans` will not clean it up, because the service is still defined in the Compose file; only profile-less services count as orphans.
+
+Run once on the VM, before or after the first deploy that includes the profile change:
+
+```bash
+docker compose --profile dev rm -sfv frontend
+```
+
 ## Verify
 
 - Visit `https://storytelling.developmentseed.org/` in an incognito window — should load the landing page directly with no password prompt. Hard-refresh and verify favicon, fonts, and logo all load (no 401s in DevTools network tab)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -29,12 +29,19 @@ Set the R2 variables in `.env`: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`,
 ## 2. Start the stack
 
 ```bash
-docker compose -f docker-compose.yml up -d --build
-docker compose -f docker-compose.yml ps   # all services healthy
+docker compose -f docker-compose.yml --profile dev up -d --build
+docker compose -f docker-compose.yml --profile dev ps   # all services healthy
 ```
 
 The app is at <http://localhost:5185> and the ingestion API at
 <http://localhost:8086>.
+
+`--profile dev` is required: the `frontend` service (the Vite dev server that
+serves the app on 5185 and proxies `/api`, `/cog`, `/raster`, and `/vector`) is
+profile-gated so it never starts on a production host. Without the flag the
+backend comes up fine but nothing listens on 5185. Use it when stopping too —
+`docker compose -f docker-compose.yml --profile dev down` — otherwise the
+frontend container is left running and the network fails to remove.
 
 ## 3. Install the MCP server
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,11 @@ ARG VITE_VIEWER_ORIGIN
 ENV VITE_VIEWER_ORIGIN=$VITE_VIEWER_ORIGIN
 RUN yarn build
 
-# --- Dev: hot-reloading Vite dev server for local development ---
+# --- Dev: hot-reloading Vite dev server for local development.
+# The compose `frontend` service bind-mounts ./frontend over /app, so the COPY
+# steps below are a fallback that keeps this image runnable on its own. Source
+# edits reach the running container through the mount, not through a rebuild;
+# the installed node_modules is preserved by an anonymous volume. ---
 FROM node:20 AS dev
 WORKDIR /app
 RUN corepack enable

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -10,7 +10,7 @@ uv run pytest -v
 
 ## API docs
 
-OpenAPI docs are auto-generated at `/api/docs` when the stack is running — visit [http://localhost:5185/api/docs](http://localhost:5185/api/docs).
+OpenAPI docs are auto-generated at `/api/docs` when the stack is running — visit [http://localhost:5185/api/docs](http://localhost:5185/api/docs) if the frontend dev server is up (`docker compose --profile dev up -d`), or [http://localhost:8086/api/docs](http://localhost:8086/api/docs) to reach the ingestion container directly.
 
 ## Key directories
 

--- a/ingestion/tests/test_integration.py
+++ b/ingestion/tests/test_integration.py
@@ -1,6 +1,6 @@
 """Integration tests — require Docker Compose running (eoAPI + R2).
 
-Run with: cd sandbox && docker compose up -d
+Run with: docker compose --profile dev up -d   (from the repo root)
 Then: cd ingestion && python -m pytest tests/test_integration.py -v -s
 """
 
@@ -21,7 +21,7 @@ def _is_docker_running():
 
 pytestmark = pytest.mark.skipif(
     not _is_docker_running(),
-    reason="Docker Compose services not running (start with: cd sandbox && docker compose up -d)",
+    reason="Docker Compose services not running (start with: docker compose --profile dev up -d)",
 )
 
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -153,7 +153,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) and [ARCHITECTURE.md](ARCHITECTURE.md).
 ## Troubleshooting
 
 ### "Connection refused" on localhost:8086
-Verify sandbox stack is running: `docker compose ps`. If not, start it: `docker compose up -d`.
+Verify sandbox stack is running: `docker compose --profile dev ps`. If not, start it: `docker compose --profile dev up -d`.
 
 ### "Unknown colormap" validation error
 List valid colormaps via the `cng://colormaps` resource and pick one.

--- a/scripts/worktree-stack.sh
+++ b/scripts/worktree-stack.sh
@@ -73,7 +73,9 @@ export FRONTEND_PORT=5285
 # `latest` image on the shared Docker daemon.
 export IMAGE_TAG="wt-${SANITIZED}"
 
-COMPOSE_CMD=(docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$PROJECT")
+# The frontend dev server sits behind the `dev` profile so it never starts on
+# the prod host; worktree stacks always want it.
+COMPOSE_CMD=(docker compose -f "$REPO_ROOT/docker-compose.yml" -p "$PROJECT" --profile dev)
 
 case "$ACTION" in
     up)


### PR DESCRIPTION
Follow-up to #610. **Stacked on `fix/frontend-dev-hot-reload`** — base retargets to `main` automatically once #610 merges. Review that one first.

## Problem

The `frontend` service carries no `profiles:` key, so `docker compose --profile prod up -d` starts the Vite dev server on the Hetzner VM alongside Caddy. Nothing routes to it — Caddy serves `frontend_dist` from `frontend-build` — but it holds a 2G memory limit for no benefit.

#610 raised the stakes: the service now bind-mounts `./frontend`, so on the VM that container tracks the on-disk checkout rather than the released bundle. A container that looks like the site but can silently disagree with it is a bad thing to leave running next to the real one.

## Change

```yaml
 frontend:
   build:
     context: frontend
     target: dev
+  profiles:
+    - dev
```

`--profile dev` threaded through everything that wants the dev server:

| File | Why |
|---|---|
| `scripts/worktree-stack.sh` | added to `COMPOSE_CMD`, so `up`/`down`/`ps`/`logs` all inherit it |
| `.github/workflows/full-stack-smoke.yml` | `full-stack-smoke.sh` probes :5185 and asserts `frontend` in the expected service set |
| `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `mcp/README.md` | start/stop instructions |
| `docs/production-deployment.md` | the note added in #610 said the dev service runs in prod; now it doesn't |

`AGENTS.md` is a symlink to `CLAUDE.md`, so it follows automatically.

## Two Compose behaviors worth knowing (both verified, not assumed)

**Naming a service enables its profile.** `docker compose up -d frontend` still works with no flag, so the single-service rebuild commands in CLAUDE.md are unchanged. Verified by starting the profiled service by name with no `--profile`: container came up, `VITE v8.1.2 ready in 255 ms`, `HTTP 200` on :5285.

**`down` does *not* get the same treatment.** Without the flag it tears down the backend and silently leaves the frontend container running:

```
$ docker compose -p … down -v
 Network …_default Removing
 Network …_default Resource is still in use     ← frontend still attached
$ docker ps -a --filter name=…
wt-chore-frontend-dev-profile-frontend-1         ← orphaned
```

With `--profile dev` it removes cleanly. That's a fresh footgun this PR introduces, so it's called out explicitly in the CLAUDE.md stop-the-stack section rather than left for someone to trip over.

## Verification

- `--profile prod config --services` → **no** `frontend` ✓ (the actual goal)
- `--profile dev config --services` → `frontend` present ✓
- `docker compose config --quiet` passes ✓
- `bash -n scripts/worktree-stack.sh` passes ✓
- Named-service start and both `down` paths exercised on an isolated project (`-p wt-chore-frontend-dev-profile`, port 5285); prod stack untouched, torn down after.

## Deploy note

First deploy after this merges will leave the now-unprofiled `cng-sandbox-frontend-1` container running on the VM — `--profile prod up -d` won't start it again, but it also won't stop what's already up. One-time manual `docker rm -f cng-sandbox-frontend-1` on the host to reclaim the memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Addendum — follow-up audit

A docs sweep after the initial push turned up one **real CI coverage regression** caused by this PR, plus three stale-instruction fixes.

**`.github/workflows/ci.yml` — the compose-validation gate stopped seeing the frontend.** `docker compose config --quiet` only renders services in active profiles, so once `frontend` was gated it dropped out of the only compose validation in CI. A syntax or reference error in that block would have sailed through. Now `--profile dev --profile prod`:

```
config --services, no profile          → 6 services
config --services, --profile dev+prod  → 9 services (all of them)
```

Verified against `.env.example`; `--quiet` passes.

**Stale start-the-stack instructions** that would now leave someone with a healthy backend and nothing on :5185:

- `docs/self-hosting.md` — the last user-facing start/stop pair without a profile, immediately followed by "the app is at localhost:5185"
- `ingestion/README.md` — pointed at `:5185/api/docs` as the only route to OpenAPI; now also gives the direct `:8086/api/docs`
- `ingestion/tests/test_integration.py` — docstring and `skipif` reason (also fixes a stale `cd sandbox` path that predates the repo layout)

**Checked and deliberately not changed:** `scripts/full-stack-smoke.sh` asserts `frontend` appears in `ps` output without passing `--profile dev`. That is correct — `docker compose ps` does not filter by profile, so running containers of gated services are listed either way. Confirmed in an isolated throwaway project rather than assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development stack commands now include the frontend development server through the `dev` profile.
  * Production deployments exclude the development frontend and serve the released frontend bundle instead.

* **Documentation**
  * Updated setup, troubleshooting, self-hosting, deployment, and testing instructions for profile-specific workflows.
  * Clarified development frontend access on port 5185 and ingestion API access on port 8086.

* **Tests**
  * CI and smoke tests now validate and run against the appropriate development and production profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->